### PR TITLE
Adds new Protractor Typescript Template profile

### DIFF
--- a/src/profiles/ProtractorTypescriptTemplate.js
+++ b/src/profiles/ProtractorTypescriptTemplate.js
@@ -1,0 +1,109 @@
+import { isClickable, isInteractive } from './templates-helpers';
+
+const renderEntityComment = entity => `
+/*
+ * ${entity.name}
+ * ***************************************************************
+ */
+`;
+const getSelectedLocator = entity => entity.locators.find(l => l.selected);
+const renderGetElement = entity => {
+  const locator = getSelectedLocator(entity);
+  return `
+ get${entity.name}Element() {
+   return element(by.${locator.name}(\`${locator.locator}\`));
+ }
+`;
+};
+
+const renderClickMethod = entity => {
+  if (!isClickable(entity)) {
+    return '';
+  }
+  return `
+ click${entity.name}() {
+   this.get${entity.name}Element().click();
+ }
+`;
+};
+
+const renderGetAndSetCheckboxRadio = entity => `
+ get${entity.name}() {
+   this.get${entity.name}Element().isSelected();
+ }
+ 
+ set${entity.name}(onOrOff: boolean) {
+   var val = this.get${entity.name}();
+   if( (onOrOff && !val) || (!onOrOff && val)) {
+     const elmt = this.get${entity.name}Element();
+     elmt.click(); 
+   }
+ }
+`;
+
+const renderGetAndSetSelect = entity => `
+ get${entity.name}Text() {
+   const elmt = this.get${entity.name}Element();
+   return elmt.all(by.css('option[selected="selected"]')).getText();
+ }
+ 
+ get${entity.name}Value() {
+   const elmt = this.get${entity.name}Element();
+   return elmt.all(by.css('option[selected="selected"]')).getAttribute('value');
+ }
+ 
+ set${entity.name}ByValue(value: string) {
+   const elmt = this.get${entity.name}Element();  
+   elmt.all(by.css('option[value="' + value + '"]')).click();
+ }
+ 
+ set${entity.name}ByText(text: string) {
+   const elmt = this.get${entity.name}Element();  
+   elmt.all(by.xpath('option[.="' + text + '"]')).click(); 
+ }
+`;
+
+const renderGetAndSetMethods = entity => {
+  if (isClickable(entity)) {
+    return '';
+  }
+
+  if (['INPUT', 'TEXTAREA'].includes(entity.tagName)) {
+    if (['checkbox', 'radio'].includes(entity.type)) {
+      return renderGetAndSetCheckboxRadio(entity);
+    }
+    // regular input
+    return `
+ get${entity.name}() {
+   const elmt = this.get${entity.name}Element();
+   return elmt.getAttribute('value');
+ }
+ 
+ set${entity.name}(value: string) {
+   const elmt = this.get${entity.name}Element();
+   elmt.sendKeys(value);
+ }
+ `;
+  }
+  if (entity.tagName === 'SELECT') {
+    return renderGetAndSetSelect(entity);
+  }
+  return '';
+};
+const renderGetTextMethod = entity => {
+  if (isInteractive(entity)) {
+    return '';
+  }
+
+  return `
+ get${entity.name}() {
+   const elmt = this.get${entity.name}Element();
+   return elmt.getText();
+ }
+`;
+};
+
+export default model =>
+  model.entities
+    .map(entity => `${renderEntityComment(entity)}${renderGetElement(entity)}${renderClickMethod(entity)}${renderGetAndSetMethods(entity)}${renderGetTextMethod(entity)}`)
+    .join('');

--- a/src/profiles/profiles.js
+++ b/src/profiles/profiles.js
@@ -3,6 +3,7 @@ import SeleniumWebDriverCSharpTemplate from './SeleniumWebDriverCSharpTemplate';
 import RobotFrameworkTemplate from './RobotFrameworkTemplate';
 import PuppeteerTemplate from './PuppeteerTemplate';
 import ProtractorTemplate from './ProtractorTemplate';
+import ProtractorTypescriptTemplate from './ProtractorTypescriptTemplate';
 
 export default [
   {
@@ -30,4 +31,9 @@ export default [
     template: ProtractorTemplate,
     locators: ['id', 'linkText', 'partialLinkText', 'name', 'model', 'binding', 'css', 'xpath', 'className', 'tagName'],
   },
+  {
+    name: 'Protractor (Typescript)',
+    template: ProtractorTypescriptTemplate,
+    locators: ['id', 'linkText', 'partialLinkText', 'name', 'model', 'binding', 'css', 'xpath', 'className', 'tagName'],
+  }
 ];


### PR DESCRIPTION
Adds new protractor typescript profile. 

### Rationale
Angular projects, by default, use typescript for page object classes. Whilst this plugin is excellent and has saved our team time, there is still the manual process of _typescriptifying_ the generated protractor model.

This PR adds a new profile named `Protractor (Typescript)` which generates tslint happy code.

### Changes
- adds new profile template `./src/profiles/ProtractorTypescriptTemplate.js`
- adds new profile entry in `./src/profiles/profiles.js`

Profile is based on the javascript implementation, with the following differences
- replaces use of `this.methodName = function() { ... }` in favour of `methodName() { ... }`
- adds type hints to method parameters
- replaces `var` in favour of `const` [tslint](https://palantir.github.io/tslint/rules/no-var-keyword/)
- replaces `const element` with `const elmt` to prevent [shadowed variable naming](https://palantir.github.io/tslint/rules/no-shadowed-variable/)

