### PR TITLE
v3: per-tab model, Add Element, naming

### DIFF
--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -317,13 +317,18 @@ before starting the next.
 3. **Toolbar + table shell** (SPEC §3, §6). ✅ **Done** — `ui/AppToolbar.vue`, `ui/ModelTable.vue`,
    `src/frameworks.ts`. Enablement rules wired; buttons acknowledge and do nothing. Awaiting hand-test.
 
-4. **Model lifetime** (SPEC §5). One model per tab, held in memory, swapping on tab change. Small, and
-   everything after it assumes it.
+4. **Model lifetime** (SPEC §5). ✅ **Done** — `src/model.ts`, one model per tab in memory.
 
-5. **Add Element** (SPEC §4). One-shot pick of any single element → a row. Exercises the whole path:
-   pick → engine → naming → table.
+5. **Add Element** (SPEC §4). ✅ **Done** — one-shot pick → row, plus row delete and Delete Model with
+   their confirms. Awaiting hand-test.
 
-6. **Naming** (SPEC §13). Accessible name first, the word-boundary fix, drop the Angular rules.
+6. **Naming** (SPEC §13). ✅ **Done** — `src/engine/naming.ts`, split so `baseName` runs in the page and
+   `uniqueName` in the panel.
+
+   **Gap: the engine only generates Playwright strategies.** No `id`, `name`, `linkText`,
+   `partialLinkText`, `className` or `tagName`, so selecting a Selenium target today yields `css:` for
+   everything. Needs a superset generator with per-framework filtering, as v2.5.1 had. Do this before
+   step 10.
 
 7. **View Matched Elements** (SPEC §8). The eye: highlight all, scroll to first, three-state snackbar.
    Verifies the engine against real pages, so it comes before scan.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -333,6 +333,13 @@ Four agreed changes: **[settled]**
 Keep v2.5.1's **plain names** — `About`, not `AboutLink`. No role suffix; the user can rename before
 exporting.
 
+**Build-generated identifiers are skipped**, in both the class-name and `id` rules. `Xtvsq51` is not a
+name anyone would choose, and it changes on the next build of the site under test. Detected by known
+CSS-in-JS shapes (emotion, styled-components, CSS Modules, leading-underscore hashes, React `useId`) and
+by a run of four or more consonants, which real words and abbreviations — `btn`, `nav`, `col` — stay
+under. Deliberately conservative in the cheap direction: a false positive only falls through to the next
+rule, while a false negative ships a name that rots. **[settled]**
+
 De-dupe by counter: a second `About` becomes `About2`.
 
 Name churn versus v2.5.1 is acceptable — no stored model survives the upgrade, so nothing breaks.

--- a/v3/README.md
+++ b/v3/README.md
@@ -66,12 +66,14 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    Generate Code visibly disabled while the model is empty (SPEC §3).
 4. **Add Element** → hover highlights → click adds one row, then picking *stops* (SPEC §4). Clicking
    again without pressing Add must not add a second row.
-5. The row's name and locator look right; a second element with the same name becomes `About2`.
-6. Row trash and Delete Model both confirm before deleting.
-7. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
+5. **Escape** cancels Add Element — both with focus in the panel and with focus in the page.
+6. The row's name and locator look right, **on one line** — Name, Locator and Actions across, not
+   stacked; a second element with the same name becomes `About2`.
+7. Row trash and Delete Model both confirm, and the dialog follows the light/dark theme.
+8. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
    switch to B, add something different, switch back — A must be intact.
-8. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
-9. Table headers stay visible at the narrowest side-panel width.
+9. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
+10. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the
 engine was validated on — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a

--- a/v3/README.md
+++ b/v3/README.md
@@ -13,6 +13,9 @@ the stack validated in the feasibility study (WXT + Vue 3 + Quasar + TypeScript,
 - **Panel UI** (`ui/`) — Quasar: `AppToolbar` (SPEC §3) over `ModelTable` (SPEC §6). One app, three
   surfaces. Shell only so far — capture, generation and the dialogs are the next increments.
 - **Frameworks** (`src/frameworks.ts`) — the targets and the locator types each can express (SPEC §7).
+- **Session model** (`src/model.ts`) — one model per tab, in memory (SPEC §5).
+- **Naming** (`src/engine/naming.ts`) — split across the message boundary: `baseName` runs in the page,
+  where the DOM rules apply; `uniqueName` runs in the panel, which owns the model (SPEC §13).
 - **Host adapter** (`host/`) — the only thing that differs per surface: which tab the panel drives.
   Side panel / sidebar follow the active tab (`tabs.query`); a DevTools panel is pinned to the tab it
   was opened on (`devtools.inspectedWindow.tabId`).
@@ -28,7 +31,7 @@ the stack validated in the feasibility study (WXT + Vue 3 + Quasar + TypeScript,
 | `npm run typecheck` | Strict TS check of the pure core |
 | `npm run test:unit` | Vitest — pure core |
 | `npm run check:manifests` | Assert both builds emit the expected surfaces |
-| `npm test` | Unit + engine fidelity (real Playwright) + both builds + manifests + extension E2E |
+| `npm test` | Unit + engine fidelity (real Playwright) + both builds + manifests + extension & capture E2E |
 
 ## Surfaces
 
@@ -61,10 +64,14 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    surface you're on.
 3. Toolbar reads Scan · Delete Model · framework · Add Element · Generate Code, with Delete Model and
    Generate Code visibly disabled while the model is empty (SPEC §3).
-4. The framework selector opens and lists all six targets; picking one updates the label.
-5. Table shows Name · Locator · Actions and the empty state, with all three headers visible at the
-   narrowest side-panel width.
-6. Tooltips appear on every toolbar button.
+4. **Add Element** → hover highlights → click adds one row, then picking *stops* (SPEC §4). Clicking
+   again without pressing Add must not add a second row.
+5. The row's name and locator look right; a second element with the same name becomes `About2`.
+6. Row trash and Delete Model both confirm before deleting.
+7. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
+   switch to B, add something different, switch back — A must be intact.
+8. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
+9. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the
 engine was validated on — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -72,6 +72,9 @@ export default defineContentScript({
       e.stopPropagation();
       const el = e.target as Element;
       const result = generate(el);
+      // Both modes are one-shot (SPEC §4) — stop before reporting, so the
+      // overlay is gone by the time the panel re-renders.
+      stop({ notify: false });
       // Rejects when no panel is open; that's fine, drop it.
       browser.runtime.sendMessage({ type: 'ELEMENT_PICKED', result }).catch(() => {});
     };
@@ -88,14 +91,18 @@ export default defineContentScript({
       document.addEventListener('keydown', onKey, true);
     }
 
-    function stop() {
+    /**
+     * `notify: false` when a pick is what stopped us — ELEMENT_PICKED already
+     * tells the panel picking is over, and a second message would race it.
+     */
+    function stop({ notify = true }: { notify?: boolean } = {}) {
       if (!active) return;
       active = false;
       document.removeEventListener('mousemove', onMove, true);
       document.removeEventListener('click', onClick, true);
       document.removeEventListener('keydown', onKey, true);
       removeOverlay();
-      browser.runtime.sendMessage({ type: 'PICKING_STOPPED' }).catch(() => {});
+      if (notify) browser.runtime.sendMessage({ type: 'PICKING_STOPPED' }).catch(() => {});
     }
 
     browser.runtime.onMessage.addListener((msg: unknown) => {

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -19,6 +19,7 @@
         "@quasar/vite-plugin": "^2.0.2",
         "@vitejs/plugin-vue": "^6.0.8",
         "esbuild": "^0.28.2",
+        "jsdom": "^30.0.1",
         "sass-embedded": "^1.83.0",
         "typescript": "^5.7.0",
         "vite": "^8.2.2",
@@ -85,6 +86,39 @@
       "integrity": "sha512-07a596Bd1QO0bi3tIyt2xruq6vKk7hCUt9enHBwggvipB0iiycoJ9/CqzN6UFawaKbOi6NBfMlUxUXzIOZ7Dsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -161,12 +195,165 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.1.tgz",
       "integrity": "sha512-agRJn3+EJDUe8AvxTx/LnHA/GErvLE62pSaSk7+MwFOtOv8eWBu/qCq2qoZjBjVZ3C2aiFJCveuSs17KMkYGOw==",
       "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@devicefarmer/adbkit": {
       "version": "3.3.9",
@@ -910,6 +1097,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fluent/syntax": {
@@ -2504,6 +2709,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.1.0.tgz",
+      "integrity": "sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3336,6 +3551,45 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -3380,6 +3634,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -4408,6 +4669,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -4873,6 +5147,93 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+      "integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/json-buffer": {
@@ -5470,6 +5831,16 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -6917,6 +7288,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scule": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
@@ -7228,6 +7612,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sync-child-process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
@@ -7339,6 +7730,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.12.tgz",
+      "integrity": "sha512-WylhSDKVeYnWXL3a+vKTaOxjnOeEGw938hImY8zoRWJjRRK/Jp1K+IihBzIONpUmW4e3WmXT6q5FW6vlESVZCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.12"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.12.tgz",
+      "integrity": "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
@@ -7347,6 +7758,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -7871,6 +8308,19 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
@@ -7989,6 +8439,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -8018,6 +8478,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/when-exit": {
@@ -8277,6 +8752,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -8300,6 +8785,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/v3/package.json
+++ b/v3/package.json
@@ -30,6 +30,7 @@
     "@quasar/vite-plugin": "^2.0.2",
     "@vitejs/plugin-vue": "^6.0.8",
     "esbuild": "^0.28.2",
+    "jsdom": "^30.0.1",
     "sass-embedded": "^1.83.0",
     "typescript": "^5.7.0",
     "vite": "^8.2.2",

--- a/v3/src/engine/candidates.ts
+++ b/v3/src/engine/candidates.ts
@@ -1,5 +1,6 @@
 import { computeAccessibleName, getRole } from 'dom-accessibility-api';
 import type { LocatorCandidate, ElementResult, RankedCandidate } from './types';
+import { baseName } from './naming';
 
 const norm = (s: string | null | undefined): string => (s ?? '').replace(/\s+/g, ' ').trim();
 
@@ -175,5 +176,5 @@ export function generate(el: Element): ElementResult {
 
   const preferredIndex = candidates.findIndex((c) => c.predictedCount === 1);
 
-  return { tag, role, accessibleName: name || null, candidates, preferredIndex };
+  return { tag, role, accessibleName: name || null, suggestedName: baseName(el), candidates, preferredIndex };
 }

--- a/v3/src/engine/naming.ts
+++ b/v3/src/engine/naming.ts
@@ -33,8 +33,31 @@ function accessibleName(el: Element): string {
   }
 }
 
+/**
+ * Build-generated identifiers make terrible names: they are meaningless to read
+ * and they change on the next build of the site under test. `Xtvsq51` is not a
+ * name anyone would choose.
+ *
+ * Two signals, both deliberately conservative — a false positive only falls
+ * through to the next naming rule, while a false negative ships a name that
+ * will rot.
+ */
+function looksGenerated(value: string): boolean {
+  // Known CSS-in-JS shapes: emotion (css-1q2w3e), styled-components (sc-bdVaJa),
+  // CSS Modules (Button_root__2xK9f), and leading-underscore hashes (_2xK9f).
+  if (/^(css|sc|emotion)-[a-z0-9]+$/i.test(value)) return true;
+  if (/__[A-Za-z0-9]{4,}$/.test(value)) return true;
+  if (/^_+[A-Za-z0-9]{4,}$/.test(value)) return true;
+  // React's useId: ":r1:", "«r1»".
+  if (/^[:«][a-z0-9]+[:»]$/i.test(value)) return true;
+  // No pronounceable structure: a run of 4+ letters without a vowel. Real
+  // words and abbreviations ("btn", "nav", "col") stay under that bar.
+  return /[^aeiouy\W\d]{4,}/i.test(value);
+}
+
 function uniqueClassName(el: Element): string {
   for (const cls of Array.from(el.classList)) {
+    if (looksGenerated(cls)) continue;
     if (el.ownerDocument.getElementsByClassName(cls).length === 1) return cls;
   }
   return '';
@@ -53,7 +76,7 @@ const rules: Array<(el: Element) => string> = [
   (el) => attr(el, 'placeholder'),
   (el) => (el.tagName === 'BUTTON' || ['submit', 'reset'].includes((el as HTMLInputElement).type) ? attr(el, 'value') : ''),
   (el) => attr(el, 'name'),
-  (el) => attr(el, 'id'),
+  (el) => (looksGenerated(attr(el, 'id')) ? '' : attr(el, 'id')),
   uniqueClassName,
   (el) => (el.tagName === 'INPUT' && SELF_DESCRIBING.has((el as HTMLInputElement).type) ? `${(el as HTMLInputElement).type}Element` : ''),
   tagIndexName,

--- a/v3/src/engine/naming.ts
+++ b/v3/src/engine/naming.ts
@@ -1,0 +1,126 @@
+// Derive a readable, unique name for a picked element (SPEC §13).
+//
+// Ported from v2.5.1's ordered rule list — first rule to yield a usable name
+// wins — with the four agreed changes:
+//
+//   1. camelCase runs BEFORE whitespace is stripped. v2.5.1 stripped first,
+//      destroying word boundaries, which is why it produced TableofContents
+//      and DocumentUploadandQuery.
+//   2. The computed accessible name replaces the hand-rolled label /
+//      aria-label / textContent rules, which were a partial reimplementation
+//      of accname.
+//   3. The accessible name outranks the `name` and `id` attributes. v2.5.1
+//      named a button with id="btn-1" and the text "Submit" `Btn1`.
+//   4. The ng-model and ng-binding rules are gone.
+//
+// Names stay plain — `About`, not `AboutLink`. No role suffix.
+import { computeAccessibleName } from 'dom-accessibility-api';
+
+const MAX_NAME_LENGTH = 25;
+
+/** Input types that describe themselves when nothing else names them. */
+const SELF_DESCRIBING = new Set(['password', 'email', 'tel', 'url', 'search', 'color', 'date', 'month', 'week', 'time']);
+
+function attr(el: Element, name: string): string {
+  return (el.getAttribute(name) ?? '').trim();
+}
+
+function accessibleName(el: Element): string {
+  try {
+    return computeAccessibleName(el).replace(/\s+/g, ' ').trim();
+  } catch {
+    return '';
+  }
+}
+
+function uniqueClassName(el: Element): string {
+  for (const cls of Array.from(el.classList)) {
+    if (el.ownerDocument.getElementsByClassName(cls).length === 1) return cls;
+  }
+  return '';
+}
+
+function tagIndexName(el: Element): string {
+  const tag = el.tagName.toLowerCase();
+  const all = el.ownerDocument.getElementsByTagName(el.tagName);
+  const index = Array.prototype.indexOf.call(all, el) + 1;
+  return `${tag}${index}`;
+}
+
+/** Ordered; the first to return a non-empty string wins. */
+const rules: Array<(el: Element) => string> = [
+  accessibleName,
+  (el) => attr(el, 'placeholder'),
+  (el) => (el.tagName === 'BUTTON' || ['submit', 'reset'].includes((el as HTMLInputElement).type) ? attr(el, 'value') : ''),
+  (el) => attr(el, 'name'),
+  (el) => attr(el, 'id'),
+  uniqueClassName,
+  (el) => (el.tagName === 'INPUT' && SELF_DESCRIBING.has((el as HTMLInputElement).type) ? `${(el as HTMLInputElement).type}Element` : ''),
+  tagIndexName,
+];
+
+const DIGIT_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'];
+
+/**
+ * `Table of Contents` → `TableOfContents`. Word boundaries come from
+ * whitespace, punctuation and existing camelCase, so they must be read before
+ * anything is stripped.
+ */
+function toPascalCase(raw: string): string {
+  const words = raw
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter(Boolean);
+  return words.map((w) => w[0].toUpperCase() + w.slice(1)).join('');
+}
+
+/** Truncate at a word boundary rather than mid-word (SPEC §13). */
+function truncate(name: string): string {
+  if (name.length <= MAX_NAME_LENGTH) return name;
+  const boundaries = [...name.matchAll(/[A-Z][^A-Z]*/g)];
+  let out = '';
+  for (const m of boundaries) {
+    if (out.length + m[0].length > MAX_NAME_LENGTH) break;
+    out += m[0];
+  }
+  // A single word longer than the limit has no boundary to cut on.
+  return out || name.slice(0, MAX_NAME_LENGTH);
+}
+
+function clean(raw: string): string {
+  // Defensive: accname already normalises whitespace, so this only bites on a
+  // raw attribute (placeholder, name, id) that contains a newline.
+  const firstLine = raw.split(/\r\n|\r|\n/)[0];
+  let name = toPascalCase(firstLine);
+  if (!name) return '';
+  // Identifiers cannot start with a digit.
+  if (/^\d/.test(name)) {
+    name = name.length === 1 ? DIGIT_WORDS[Number(name)] : `Element${name}`;
+    name = name[0].toUpperCase() + name.slice(1);
+  }
+  return truncate(name);
+}
+
+/**
+ * The name this element suggests for itself. Runs in the page, since every rule
+ * after the accessible name reads the DOM.
+ */
+export function baseName(el: Element): string {
+  for (const rule of rules) {
+    const name = clean(rule(el));
+    if (name) return name;
+  }
+  return 'Element';
+}
+
+/**
+ * Make `base` unique within `used`, which is mutated to reserve the result.
+ * Runs in the panel, which owns the model — a second `About` becomes `About2`.
+ */
+export function uniqueName(base: string, used: Set<string>): string {
+  let name = base || 'Element';
+  let n = 2;
+  while (used.has(name)) name = `${base}${n++}`;
+  used.add(name);
+  return name;
+}

--- a/v3/src/engine/types.ts
+++ b/v3/src/engine/types.ts
@@ -24,6 +24,8 @@ export interface ElementResult {
   tag: string;
   role: string | null;
   accessibleName: string | null;
+  /** Name derived in the page, before de-duplication (see naming.ts). */
+  suggestedName: string;
   candidates: RankedCandidate[];
   /** Index of the first predicted-unique candidate, or -1 if none. */
   preferredIndex: number;

--- a/v3/src/locators/display.ts
+++ b/v3/src/locators/display.ts
@@ -1,0 +1,55 @@
+// How a locator reads in the model table.
+//
+// Selenium and Puppeteer show `type: value` (SPEC §6). Playwright shows the
+// framework expression instead (SPEC §12) — `getByRole` takes a role AND a
+// name, so there is no single value to put after a colon.
+import type { LocatorCandidate } from '../engine/types';
+
+const q = (s: string) => `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+
+/** The Playwright call this candidate becomes. */
+export function playwrightExpr(c: LocatorCandidate): string {
+  switch (c.kind) {
+    case 'testId':
+      return `getByTestId(${q(c.value)})`;
+    case 'role':
+      // exact: true always — see SPEC §12 name matching.
+      return c.name === undefined ? `getByRole(${q(c.role)})` : `getByRole(${q(c.role)}, { name: ${q(c.name)}, exact: true })`;
+    case 'label':
+      return `getByLabel(${q(c.text)}, { exact: true })`;
+    case 'placeholder':
+      return `getByPlaceholder(${q(c.text)})`;
+    case 'text':
+      return `getByText(${q(c.text)}, { exact: true })`;
+    case 'altText':
+      return `getByAltText(${q(c.text)})`;
+    case 'title':
+      return `getByTitle(${q(c.text)})`;
+    case 'css':
+    case 'xpath':
+      return `locator(${q(c.value)})`;
+  }
+}
+
+/** `type: value`, for frameworks whose locators are a flat pair. */
+export function typeValue(c: LocatorCandidate): string {
+  switch (c.kind) {
+    case 'testId':
+      return `testId: ${c.value}`;
+    case 'role':
+      return c.name === undefined ? `role: ${c.role}` : `role: ${c.role} — ${c.name}`;
+    case 'label':
+    case 'placeholder':
+    case 'text':
+    case 'altText':
+    case 'title':
+      return `${c.kind}: ${c.text}`;
+    case 'css':
+    case 'xpath':
+      return `${c.kind}: ${c.value}`;
+  }
+}
+
+export function displayLocator(c: LocatorCandidate, frameworkId: string): string {
+  return frameworkId.startsWith('playwright') ? playwrightExpr(c) : typeValue(c);
+}

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -1,7 +1,12 @@
 import type { ElementResult } from './engine/types';
 
 // Messages panel → content (sent via browser.tabs.sendMessage to the active tab).
-export type PanelToContent = { type: 'START_PICKING' } | { type: 'STOP_PICKING' };
+//
+// Picking is one-shot in both modes (SPEC §4): the content script stops itself
+// as soon as an element is chosen. 'add' takes any single element anywhere;
+// 'scan' takes a container and is not wired up yet.
+export type PickMode = 'add' | 'scan';
+export type PanelToContent = { type: 'START_PICKING'; mode: PickMode } | { type: 'STOP_PICKING' };
 
 // Messages content → panel/background (sent via browser.runtime.sendMessage).
 export type ContentToPanel =

--- a/v3/src/model.ts
+++ b/v3/src/model.ts
@@ -1,0 +1,57 @@
+// The session model (SPEC §5, §7).
+//
+// One model per tab, held in memory. Switching tabs swaps the table; closing
+// the tab or the panel discards it. Nothing is persisted — a model is session
+// work, not a saved artifact, and this way a model can never be shown against
+// a page it was not built from.
+import type { ElementResult, LocatorCandidate } from './engine/types';
+
+export interface ModelElement extends ElementResult {
+  id: string;
+  name: string;
+  /** Index into `candidates`, or -1 when the user typed a locator by hand. */
+  selectedIndex: number;
+  /** Set only when the user overrides the generated locator (SPEC §7). */
+  override?: LocatorCandidate;
+}
+
+export interface TabModel {
+  elements: ModelElement[];
+  /** Reserves derived names so a second `About` becomes `About2`. */
+  usedNames: Set<string>;
+  /** The URL the model was built against, for the stale check (SPEC §5). */
+  url: string | null;
+}
+
+export function emptyModel(): TabModel {
+  return { elements: [], usedNames: new Set(), url: null };
+}
+
+/** The locator currently in effect for an element: an override, or the pick. */
+export function activeCandidate(el: ModelElement): LocatorCandidate {
+  return el.override ?? el.candidates[el.selectedIndex]?.candidate ?? el.candidates[0].candidate;
+}
+
+/** Per-tab store. Keyed by tab id; entries live only as long as the panel. */
+export class ModelStore {
+  private byTab = new Map<number, TabModel>();
+
+  get(tabId: number): TabModel {
+    let m = this.byTab.get(tabId);
+    if (!m) {
+      m = emptyModel();
+      this.byTab.set(tabId, m);
+    }
+    return m;
+  }
+
+  clear(tabId: number): void {
+    this.byTab.delete(tabId);
+  }
+
+  /** Drop models for tabs that have gone away, so closing a tab frees it. */
+  retain(liveTabIds: Iterable<number>): void {
+    const live = new Set(liveTabIds);
+    for (const id of [...this.byTab.keys()]) if (!live.has(id)) this.byTab.delete(id);
+  }
+}

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, chromium, type BrowserContext } from '@playwright/test';
+import { resolve } from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+// Capture E2E: drives the content script the way the panel does, from the
+// service worker. Playwright cannot open a real side panel, so this is the only
+// automated cover the inspector overlay gets — the panel→row half stays a
+// manual check.
+//
+// Fixtures are served over http because content scripts do not run on file://.
+const EXT_PATH = resolve('.output/chrome-mv3');
+const PORT = 5211;
+
+let server: ChildProcess;
+let context: BrowserContext;
+
+test.beforeAll(async () => {
+  server = spawn('node', ['scripts/serve-fixtures.mjs'], { env: { ...process.env, FIXTURES_PORT: String(PORT) }, stdio: 'ignore' });
+  context = await chromium.launchPersistentContext('', {
+    headless: false,
+    args: ['--headless=new', `--disable-extensions-except=${EXT_PATH}`, `--load-extension=${EXT_PATH}`],
+  });
+});
+
+test.afterAll(async () => {
+  await context?.close();
+  server?.kill();
+});
+
+test('picking is one-shot and reports a named element', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const page = await context.newPage();
+  await page.goto(`http://localhost:${PORT}/login.html`);
+
+  const tabId: number = await sw.evaluate(
+    async (url) => (await chrome.tabs.query({ url }))[0].id!,
+    `http://localhost:${PORT}/login.html`
+  );
+
+  // Collect every ELEMENT_PICKED / PICKING_STOPPED the content script emits.
+  await sw.evaluate(() => {
+    (globalThis as unknown as { __picks: unknown[] }).__picks = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (globalThis as unknown as { __picks: unknown[] }).__picks.push(m);
+    });
+  });
+
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
+
+  // Hovering draws the overlay; clicking picks.
+  await page.getByRole('button', { name: 'Sign in' }).hover();
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect
+    .poll(async () => (await sw.evaluate(() => (globalThis as unknown as { __picks: { type: string }[] }).__picks)).length)
+    .toBe(1);
+
+  const picks = await sw.evaluate(() => (globalThis as unknown as { __picks: Record<string, unknown>[] }).__picks);
+  expect(picks[0].type).toBe('ELEMENT_PICKED');
+
+  const result = picks[0].result as { role: string; suggestedName: string; preferredIndex: number };
+  expect(result.role).toBe('button');
+  expect(result.suggestedName).toBe('SignIn');
+  expect(result.preferredIndex, 'engine found a unique locator').toBeGreaterThanOrEqual(0);
+
+  // One-shot (SPEC §4): a second click must NOT produce another pick, and the
+  // overlay must be gone.
+  await page.getByRole('link', { name: 'Home' }).click();
+  await page.waitForTimeout(500);
+  const after = await sw.evaluate(() => (globalThis as unknown as { __picks: unknown[] }).__picks.length);
+  expect(after, 'picking stopped itself after one element').toBe(1);
+});

--- a/v3/tests/unit/css-collisions.test.ts
+++ b/v3/tests/unit/css-collisions.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Quasar ships single-word utility classes that are easy to collide with by
+// accident. `class="row"` on a <tr> silently turned every table row into a flex
+// container (`.row, .column, .flex { display: flex; flex-wrap: wrap }`), which
+// stacked each cell onto its own line. Scoped styles do not protect against
+// this — the collision is on the class name, not the CSS.
+const RESERVED = ['row', 'column', 'flex', 'items-center', 'justify-between', 'absolute', 'relative', 'fixed', 'hidden'];
+
+const UI_DIR = join(import.meta.dirname, '../../ui');
+
+function classAttrs(source: string): string[] {
+  return [...source.matchAll(/\bclass="([^"{}]+)"/g)].flatMap((m) => m[1].split(/\s+/)).filter(Boolean);
+}
+
+describe('our templates do not collide with Quasar utility classes', () => {
+  const files = readdirSync(UI_DIR).filter((f) => f.endsWith('.vue'));
+
+  it('finds the components to check', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const file of files) {
+    it(file, () => {
+      const used = classAttrs(readFileSync(join(UI_DIR, file), 'utf8'));
+      // Quasar's own q-* classes are fine; these bare words are not, unless we
+      // actually want Quasar's utility behaviour.
+      const collisions = used.filter((c) => RESERVED.includes(c));
+      expect(collisions, `namespace these (e.g. pm-row) — they are Quasar utilities`).toEqual([]);
+    });
+  }
+});

--- a/v3/tests/unit/display.test.ts
+++ b/v3/tests/unit/display.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { displayLocator, playwrightExpr } from '../../src/locators/display';
+
+describe('displayLocator', () => {
+  it('renders Playwright as the framework expression', () => {
+    expect(displayLocator({ kind: 'role', role: 'button', name: 'Sign in', exact: true }, 'playwright-ts')).toBe(
+      "getByRole('button', { name: 'Sign in', exact: true })"
+    );
+    expect(displayLocator({ kind: 'testId', value: 'submit' }, 'playwright-python')).toBe("getByTestId('submit')");
+  });
+
+  it('always emits exact: true for a named role (SPEC §12)', () => {
+    expect(playwrightExpr({ kind: 'role', role: 'link', name: 'About' })).toContain('exact: true');
+  });
+
+  it('renders other frameworks as type: value', () => {
+    expect(displayLocator({ kind: 'css', value: 'button.pay' }, 'selenium-java')).toBe('css: button.pay');
+    expect(displayLocator({ kind: 'xpath', value: '//a[1]' }, 'puppeteer')).toBe('xpath: //a[1]');
+  });
+
+  it('escapes quotes so the expression stays valid', () => {
+    expect(playwrightExpr({ kind: 'text', text: "It's here", exact: true })).toBe("getByText('It\\'s here', { exact: true })");
+  });
+
+  it('omits the name option when the role has no accessible name', () => {
+    expect(playwrightExpr({ kind: 'role', role: 'navigation' })).toBe("getByRole('navigation')");
+  });
+});

--- a/v3/tests/unit/naming.test.ts
+++ b/v3/tests/unit/naming.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { baseName, uniqueName } from '../../src/engine/naming';
+
+let used: Set<string>;
+beforeEach(() => {
+  used = new Set();
+});
+
+/** Derive then reserve — the split the message boundary forces: baseName runs
+ *  in the page, uniqueName in the panel, which owns the model. */
+const name = (e: Element) => uniqueName(baseName(e), used);
+
+function el(html: string, sel = '[data-t]'): Element {
+  const dom = new JSDOM(`<!doctype html><body>${html}</body>`);
+  const found = dom.window.document.querySelector(sel);
+  if (!found) throw new Error(`no match for ${sel}`);
+  return found;
+}
+
+describe('baseName', () => {
+  it('fixes the word-boundary bug', () => {
+    // v2.5.1 stripped whitespace before camelCase and produced TableofContents.
+    expect(name(el('<button data-t>Table of Contents</button>'))).toBe('TableOfContents');
+    expect(name(el('<a href="#" data-t>Document Upload and Query</a>'))).toBe('DocumentUploadAndQuery');
+  });
+
+  it('keeps plain names — no role suffix', () => {
+    expect(name(el('<a href="#" data-t>About</a>'))).toBe('About');
+  });
+
+  it('ranks the accessible name above name and id', () => {
+    // v2.5.1 named this Btn1, because id outranked text content.
+    expect(name(el('<button id="btn-1" name="go" data-t>Submit</button>'))).toBe('Submit');
+  });
+
+  it('uses a label association for the accessible name', () => {
+    expect(name(el('<label for="e">Email address</label><input id="e" data-t />', 'input'))).toBe('EmailAddress');
+  });
+
+  it('falls back through placeholder, name, then id', () => {
+    expect(name(el('<input data-t placeholder="Your password" />'))).toBe('YourPassword');
+    expect(name(el('<input data-t name="firstName" />'))).toBe('FirstName');
+    expect(name(el('<input data-t id="last-name" />'))).toBe('LastName');
+  });
+
+  it('describes self-describing inputs when nothing else names them', () => {
+    expect(name(el('<input type="password" data-t />'))).toBe('PasswordElement');
+  });
+
+  it('falls back to tag and index', () => {
+    expect(name(el('<div data-t></div>'))).toBe('Div1');
+  });
+
+  it('does not start a name with a digit', () => {
+    expect(name(el('<button data-t>2 items</button>'))).toBe('Element2Items');
+  });
+
+  it('truncates on a word boundary', () => {
+    const n = name(el('<button data-t>Download the quarterly revenue report</button>'));
+    expect(n.length).toBeLessThanOrEqual(25);
+    // Mid-word truncation, as in v2.5.1, would give "DownloadTheQuarterlyReve".
+    expect(n).toBe('DownloadTheQuarterly');
+  });
+
+  it('folds multi-line text into one name', () => {
+    // v2.5.1 read raw textContent and cut at the first newline, giving
+    // "Feedback". accname normalises whitespace, so the accessible name really
+    // is "Feedback and support" — the better name anyway.
+    expect(name(el('<a href="#" data-t>Feedback\nand support</a>'))).toBe('FeedbackAndSupport');
+  });
+});
+
+describe('uniqueName', () => {
+  it('de-dupes by counter', () => {
+    const mk = () => name(el('<a href="#" data-t>About</a>'));
+    expect([mk(), mk(), mk()]).toEqual(['About', 'About2', 'About3']);
+  });
+
+  it('reserves the name it returns', () => {
+    uniqueName('About', used);
+    expect(used.has('About')).toBe(true);
+  });
+});

--- a/v3/tests/unit/naming.test.ts
+++ b/v3/tests/unit/naming.test.ts
@@ -71,6 +71,40 @@ describe('baseName', () => {
   });
 });
 
+describe('build-generated identifiers', () => {
+  // These change on the next build of the site under test, so a name derived
+  // from one rots. Falling through to the next rule is always better.
+  const rejected = [
+    ['emotion', '<div data-t class="css-1q2w3e"></div>'],
+    ['styled-components', '<div data-t class="sc-bdVaJa"></div>'],
+    ['CSS Modules', '<div data-t class="Button_root__2xK9f"></div>'],
+    ['leading underscore', '<div data-t class="_2xK9f"></div>'],
+    ['no vowels', '<div data-t class="Xtvsq51"></div>'],
+    ['hashed id', '<div data-t id="Xtvsq51"></div>'],
+  ] as const;
+
+  for (const [label, html] of rejected) {
+    it(`skips ${label}`, () => {
+      // Falls through to the tag+index rule.
+      expect(name(el(html))).toBe('Div1');
+    });
+  }
+
+  const kept = [
+    ['btn', '<div data-t class="btn"></div>', 'Btn'],
+    ['nav', '<div data-t class="nav"></div>', 'Nav'],
+    ['hyphenated', '<div data-t class="col-md-6"></div>', 'ColMd6'],
+    ['real word', '<div data-t class="site-header"></div>', 'SiteHeader'],
+    ['readable id', '<div data-t id="login-form"></div>', 'LoginForm'],
+  ] as const;
+
+  for (const [label, html, expected] of kept) {
+    it(`keeps ${label}`, () => {
+      expect(name(el(html))).toBe(expected);
+    });
+  }
+});
+
 describe('uniqueName', () => {
   it('de-dupes by counter', () => {
     const mk = () => name(el('<a href="#" data-t>About</a>'));

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -7,52 +7,154 @@
         :is-scanning="isScanning"
         :is-adding="isAdding"
         @scan="notYet('Scan')"
-        @add="notYet('Add Element')"
-        @delete-model="notYet('Delete Model')"
+        @add="toggleAdd"
+        @delete-model="deleteModel"
         @generate="notYet('Generate Code')"
       />
     </q-header>
 
     <q-page-container>
       <q-page>
-        <ModelTable
-          :elements="elements"
-          @highlight="notYet('View Matched Elements')"
-          @edit="notYet('Edit')"
-          @remove="notYet('Delete')"
-        />
+        <ModelTable :elements="rows" @highlight="notYet('View Matched Elements')" @edit="notYet('Edit')" @remove="removeElement" />
       </q-page>
     </q-page-container>
   </q-layout>
 </template>
 
 <script setup lang="ts">
-import { ref, inject } from 'vue';
+import { ref, computed, inject, onMounted } from 'vue';
 import { useQuasar } from 'quasar';
+import { browser } from 'wxt/browser';
 import AppToolbar from './AppToolbar.vue';
 import ModelTable, { type ModelRow } from './ModelTable.vue';
 import { defaultFrameworkId } from '@/src/frameworks';
+import { displayLocator } from '@/src/locators/display';
+import { ModelStore, activeCandidate, type ModelElement } from '@/src/model';
+import { uniqueName } from '@/src/engine/naming';
+import { isMessage, type ContentToPanel, type PickMode } from '@/src/messaging';
 import { hostKey } from '@/host/types';
 
-// Shell only (REWRITE-PLAN §12 step 3): toolbar and table, no capture yet. The
-// per-tab session model (SPEC §5) and Add Element (SPEC §4) come next, and
-// `elements` becomes that model.
 const $q = useQuasar();
 const host = inject(hostKey)!;
 
 const frameworkId = ref(defaultFrameworkId);
-const elements = ref<ModelRow[]>([]);
+const tabId = ref<number | undefined>();
 const isScanning = ref(false);
 const isAdding = ref(false);
+
+// One model per tab (SPEC §5). `elements` is a shallow copy of the active tab's
+// list so Vue tracks it; the store owns the real thing.
+const store = new ModelStore();
+const elements = ref<ModelElement[]>([]);
+
+function syncFromStore() {
+  elements.value = tabId.value == null ? [] : [...store.get(tabId.value).elements];
+}
+
+const rows = computed<ModelRow[]>(() =>
+  elements.value.map((el) => ({
+    id: el.id,
+    name: el.name,
+    locator: displayLocator(activeCandidate(el), frameworkId.value),
+  }))
+);
+
+onMounted(async () => {
+  tabId.value = await host.getTabId();
+  syncFromStore();
+});
+
+host.onTabChanged(async (next) => {
+  if (isPicking() && tabId.value != null) void send(tabId.value, { type: 'STOP_PICKING' });
+  isScanning.value = isAdding.value = false;
+  tabId.value = next;
+  syncFromStore();
+});
+
+const isPicking = () => isScanning.value || isAdding.value;
+
+async function send(target: number, msg: { type: 'START_PICKING'; mode: PickMode } | { type: 'STOP_PICKING' }): Promise<boolean> {
+  try {
+    await browser.tabs.sendMessage(target, msg);
+    return true;
+  } catch {
+    // No content script: a browser-internal page, the web store, or a tab that
+    // was already open when the extension loaded.
+    $q.notify({
+      message: 'Page Modeller can’t reach this page. Reload the tab, or try a normal http(s) page.',
+      icon: 'block',
+      color: 'negative',
+      timeout: 3000,
+      position: 'bottom',
+    });
+    return false;
+  }
+}
+
+async function toggleAdd() {
+  const target = tabId.value ?? (await host.getTabId());
+  tabId.value = target;
+  if (target == null) return;
+  const next = !isAdding.value;
+  const ok = await send(target, next ? { type: 'START_PICKING', mode: 'add' } : { type: 'STOP_PICKING' });
+  if (ok) isAdding.value = next;
+}
+
+let idSeq = 0;
+
+browser.runtime.onMessage.addListener((msg: unknown, sender: { tab?: { id?: number } }) => {
+  if (!isMessage(msg)) return;
+  // Only this panel's tab. Without it, a DevTools panel would absorb every
+  // other tab's picks.
+  if (sender.tab?.id !== tabId.value || tabId.value == null) return;
+  const m = msg as ContentToPanel;
+
+  if (m.type === 'ELEMENT_PICKED') {
+    const model = store.get(tabId.value);
+    model.elements.push({
+      ...m.result,
+      id: `el-${idSeq++}`,
+      name: uniqueName(m.result.suggestedName, model.usedNames),
+      selectedIndex: m.result.preferredIndex >= 0 ? m.result.preferredIndex : 0,
+    });
+    // Picking is one-shot (SPEC §4); the content script has already stopped.
+    isAdding.value = isScanning.value = false;
+    syncFromStore();
+  } else if (m.type === 'PICKING_STOPPED') {
+    isAdding.value = isScanning.value = false;
+  }
+});
+
+function removeElement(id: string) {
+  const el = elements.value.find((e) => e.id === id);
+  if (!el || tabId.value == null) return;
+  $q.dialog({
+    title: 'Delete Element',
+    message: `Really delete ${el.name}?`,
+    cancel: true,
+    ok: { label: 'Yes', flat: true },
+  }).onOk(() => {
+    const model = store.get(tabId.value!);
+    model.elements = model.elements.filter((e) => e.id !== id);
+    model.usedNames.delete(el.name);
+    syncFromStore();
+  });
+}
+
+function deleteModel() {
+  if (tabId.value == null) return;
+  $q.dialog({
+    title: 'Delete Model',
+    message: 'Really delete the model?',
+    cancel: true,
+    ok: { label: 'Yes', flat: true },
+  }).onOk(() => {
+    store.clear(tabId.value!);
+    syncFromStore();
+  });
+}
 
 function notYet(what: string) {
   $q.notify({ message: `${what} — not built yet`, icon: 'construction', timeout: 1500, position: 'bottom' });
 }
-
-// Keeps the host adapter live so tab switching is exercised while hand-testing;
-// the model it will swap arrives with SPEC §5.
-host.onTabChanged(() => {
-  isScanning.value = false;
-  isAdding.value = false;
-});
 </script>

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue';
+import { ref, computed, inject, onMounted, onBeforeUnmount } from 'vue';
 import { useQuasar } from 'quasar';
 import { browser } from 'wxt/browser';
 import AppToolbar from './AppToolbar.vue';
@@ -62,9 +62,20 @@ const rows = computed<ModelRow[]>(() =>
 onMounted(async () => {
   tabId.value = await host.getTabId();
   syncFromStore();
+  // The content script listens for Escape too, but after clicking Add Element
+  // focus is in the panel, so the page never sees the keydown. Cover both.
+  window.addEventListener('keydown', onPanelKey, true);
 });
 
-host.onTabChanged(async (next) => {
+onBeforeUnmount(() => window.removeEventListener('keydown', onPanelKey, true));
+
+function onPanelKey(e: KeyboardEvent) {
+  if (e.key !== 'Escape' || !isPicking()) return;
+  e.preventDefault();
+  void stopPicking();
+}
+
+host.onTabChanged((next) => {
   if (isPicking() && tabId.value != null) void send(tabId.value, { type: 'STOP_PICKING' });
   isScanning.value = isAdding.value = false;
   tabId.value = next;
@@ -72,6 +83,11 @@ host.onTabChanged(async (next) => {
 });
 
 const isPicking = () => isScanning.value || isAdding.value;
+
+async function stopPicking() {
+  if (tabId.value != null) await send(tabId.value, { type: 'STOP_PICKING' });
+  isAdding.value = isScanning.value = false;
+}
 
 async function send(target: number, msg: { type: 'START_PICKING'; mode: PickMode } | { type: 'STOP_PICKING' }): Promise<boolean> {
   try {
@@ -92,12 +108,11 @@ async function send(target: number, msg: { type: 'START_PICKING'; mode: PickMode
 }
 
 async function toggleAdd() {
+  if (isAdding.value) return stopPicking();
   const target = tabId.value ?? (await host.getTabId());
   tabId.value = target;
   if (target == null) return;
-  const next = !isAdding.value;
-  const ok = await send(target, next ? { type: 'START_PICKING', mode: 'add' } : { type: 'STOP_PICKING' });
-  if (ok) isAdding.value = next;
+  if (await send(target, { type: 'START_PICKING', mode: 'add' })) isAdding.value = true;
 }
 
 let idSeq = 0;

--- a/v3/ui/ModelTable.vue
+++ b/v3/ui/ModelTable.vue
@@ -15,7 +15,7 @@
         <tr
           v-for="el in elements"
           :key="el.id"
-          class="row"
+          class="pm-row"
           @click="$emit('highlight', el.id)"
           @dblclick="$emit('edit', el.id)"
         >
@@ -109,12 +109,14 @@ td {
   font-size: 12px;
 }
 
-.row {
+/* Namespaced: a bare `.row` is Quasar's flex grid utility (display: flex;
+   flex-wrap: wrap), which stacks the cells of every row. */
+.pm-row {
   cursor: default;
   user-select: none;
 }
 
-.row:hover {
+.pm-row:hover {
   background: var(--pm-row-hover);
 }
 

--- a/v3/ui/mount.ts
+++ b/v3/ui/mount.ts
@@ -8,5 +8,5 @@ import { hostKey, type PanelHost } from '@/host/types';
 
 /** Mount the one panel app onto whichever surface is hosting it. */
 export function mountPanel(host: PanelHost) {
-  createApp(App).use(Quasar, { plugins: { Notify, Dialog } }).provide(hostKey, host).mount('#app');
+  createApp(App).use(Quasar, { plugins: { Notify, Dialog }, config: { dark: 'auto' } }).provide(hostKey, host).mount('#app');
 }

--- a/v3/ui/mount.ts
+++ b/v3/ui/mount.ts
@@ -1,5 +1,5 @@
 import { createApp } from 'vue';
-import { Quasar, Notify } from 'quasar';
+import { Quasar, Notify, Dialog } from 'quasar';
 import 'quasar/src/css/index.sass';
 import '@quasar/extras/material-icons/material-icons.css';
 import './theme.css';
@@ -8,5 +8,5 @@ import { hostKey, type PanelHost } from '@/host/types';
 
 /** Mount the one panel app onto whichever surface is hosting it. */
 export function mountPanel(host: PanelHost) {
-  createApp(App).use(Quasar, { plugins: { Notify } }).provide(hostKey, host).mount('#app');
+  createApp(App).use(Quasar, { plugins: { Notify, Dialog } }).provide(hostKey, host).mount('#app');
 }

--- a/v3/ui/theme.css
+++ b/v3/ui/theme.css
@@ -29,6 +29,9 @@
     --pm-text-muted: #9aa0a6;
     --pm-rule: #3c4043;
     --pm-row-hover: rgba(138, 180, 248, 0.12);
+    /* Quasar themes its own overlays (dialog, notify) from these. */
+    --q-dark-page: #1e1f22;
+    --q-dark: #2b2d31;
   }
 }
 
@@ -40,6 +43,8 @@
   --pm-text-muted: #9aa0a6;
   --pm-rule: #3c4043;
   --pm-row-hover: rgba(138, 180, 248, 0.12);
+  --q-dark-page: #1e1f22;
+  --q-dark: #2b2d31;
 }
 
 body {


### PR DESCRIPTION
`REWRITE-PLAN.md` §12 steps 4–6. Together, because model lifetime and naming are both untestable on their own — and because the table has had nothing to show since the strip.

## Model lifetime (SPEC §5)

One model per tab, held in memory. Switching tabs swaps the table; closing the tab or the panel discards it; nothing is persisted. So a model can never be shown against a page it wasn't built from.

v2.5.1 never had to decide this — a DevTools panel is inherently per-tab. The side panel is per-*window* and outlives navigation, which is why it needed specifying.

## Add Element (SPEC §4)

**One-shot.** The content script stops itself the moment an element is chosen, rather than picking continuously as the spike did. Two details worth noting: it stops *before* reporting, so the overlay is gone by the time the panel re-renders; and it suppresses the `PICKING_STOPPED` it would otherwise race against `ELEMENT_PICKED`.

Row delete and Delete Model come along with their confirm dialogs — without them a model can't be reset while hand-testing.

## Naming (SPEC §13)

Ported from v2.5.1's ordered rule list with the four agreed changes:

| | |
|---|---|
| camelCase runs **before** whitespace is stripped | v2.5.1 stripped first, destroying word boundaries — hence `TableofContents` |
| computed accessible name | replaces the hand-rolled label / `aria-label` / textContent rules |
| accessible name outranks `name` and `id` | v2.5.1 named a button with `id="btn-1"` and the text "Submit" `Btn1` |
| Angular rules gone | |

**Naming is split across the message boundary.** The panel never holds the `Element` — the engine runs in the page — so `baseName` runs there, where the DOM fallbacks apply, and travels as `ElementResult.suggestedName`; `uniqueName` runs in the panel, which owns the model. My first attempt did it all panel-side by fabricating a stub element, which silently discarded every rule after the accessible name.

## Tests

23 unit assertions over jsdom for naming and locator display, including the truncation and word-boundary behaviours that differ from v2.5.1.

**New capture E2E** drives the content script from the service worker against a served fixture. Playwright can't open a real side panel, so this is the first automated cover the inspector overlay has had — and it pins the one-shot rule: a second click produces no second pick. It also confirms the naming pipeline end-to-end in a real browser (`role: button`, `suggestedName: SignIn`).

## Known gap

**The engine only generates Playwright strategies** — no `id`, `name`, `linkText`, `partialLinkText`, `className`, `tagName`. So selecting a Selenium target today yields `css:` for everything. This needs a superset generator with per-framework filtering, as v2.5.1 had; it's recorded in §12 step 6 as a prerequisite for the Selenium generator. **Hand-test on the default Playwright target.**

## Still not built

Scan, the eye, the Edit dialog and Generate Code all still acknowledge and do nothing.

The panel→row half of capture can't be automated, so the README checklist covers it — in particular tab switching (build a model in tab A, switch to B, add something else, switch back; A must be intact) and that clicking again after a pick does *not* add a second row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)