### PR TITLE
v3: View Matched Elements, and make the resolver match Playwright

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,11 @@ exploited.
 - Build output is gitignored (`/v3/.output`, `/v3/.wxt`, `/v3/.test-dist`, `/v3/test-results`).
 - `v3/` output sizes are small by design; WXT 0.21 emits little runtime boilerplate.
 
+- **Never send Vue reactive state through `tabs.sendMessage`.** Anything read out of a `ref` is a Proxy,
+  and Firefox serialises messages with structured clone, which throws `DataCloneError` on a Proxy —
+  Chrome's path tolerates it, so this fails on Firefox only and presents as an unreachable tab. `send()`
+  in `ui/App.vue` JSON round-trips for this reason; anything bypassing it must do the same.
+
 ## Verification — manual testing is the completion gate
 
 **Automated tests are a net, not the criterion for done.** Nothing is complete until it has been

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,9 @@ exploited.
   `devtools.*`, `runtime.*` and a few others. Chrome tolerates the direct call, so a regression is
   invisible on Chrome and in every test we can run — Playwright cannot load a Firefox extension. The
   panel goes through the background relay (`RELAY_TO_TAB`); a unit test scans `ui/` to keep it that way.
+- **`sender.tab` is not reliable in a Firefox DevTools page.** A content script's `runtime.sendMessage`
+  arrives without it, so a `sender.tab.id === myTab` filter silently drops every message. The background
+  always sees the sender, so it stamps the tab and re-broadcasts as `FROM_TAB`; panels filter on that.
 - **Never send Vue reactive state through `tabs.sendMessage`.** Anything read out of a `ref` is a Proxy,
   and Firefox serialises messages with structured clone, which throws `DataCloneError` on a Proxy —
   Chrome's path tolerates it, so this fails on Firefox only and presents as an unreachable tab. `send()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,10 @@ exploited.
 - Build output is gitignored (`/v3/.output`, `/v3/.wxt`, `/v3/.test-dist`, `/v3/test-results`).
 - `v3/` output sizes are small by design; WXT 0.21 emits little runtime boilerplate.
 
+- **`browser.tabs` is undefined in a Firefox DevTools panel.** A devtools page is granted only
+  `devtools.*`, `runtime.*` and a few others. Chrome tolerates the direct call, so a regression is
+  invisible on Chrome and in every test we can run — Playwright cannot load a Firefox extension. The
+  panel goes through the background relay (`RELAY_TO_TAB`); a unit test scans `ui/` to keep it that way.
 - **Never send Vue reactive state through `tabs.sendMessage`.** Anything read out of a `ref` is a Proxy,
   and Firefox serialises messages with structured clone, which throws `DataCloneError` on a Proxy —
   Chrome's path tolerates it, so this fails on Firefox only and presents as an unreachable tab. `send()`

--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -330,8 +330,13 @@ before starting the next.
    everything. Needs a superset generator with per-framework filtering, as v2.5.1 had. Do this before
    step 10.
 
-7. **View Matched Elements** (SPEC §8). The eye: highlight all, scroll to first, three-state snackbar.
-   Verifies the engine against real pages, so it comes before scan.
+7. **View Matched Elements** (SPEC §8). ✅ **Done** — the eye: highlight all, scroll to first,
+   three-state snackbar. Awaiting hand-test.
+
+   Building it forced the in-page resolver to actually match Playwright rather than approximate it:
+   `exact` is honoured, role candidates exclude a11y-hidden elements, and text candidates match the
+   innermost element only. The fidelity spec now asserts **every** candidate's predicted count against
+   real Playwright, not just the preferred one — which is how those three were found.
 
 8. **Edit dialog** (SPEC §9) and **Delete Model** (SPEC §10).
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -341,7 +341,10 @@ Four agreed changes: **[settled]**
    boundaries — hence `TableofContents` and `DocumentUploadandQuery`. Case first, then strip:
    `TableOfContents`, `DocumentUploadAndQuery`.
 2. **Use the computed accessible name** (`dom-accessibility-api`) in place of the hand-rolled label /
-   `aria-label` / text-content rules, which are a partial reimplementation of accname.
+   `aria-label` rules, which are a partial reimplementation of accname. **The text-content rule stays**,
+   ranked just below it: accname derives a name from content only for roles that support it, so a plain
+   `<span>` or `<div>` computes to nothing — and those are exactly what Add Element captures (§4).
+   Capped at 80 characters, since a container's `textContent` can be most of the page.
 3. **Rank the accessible name above `name` and `id`.** Today a button with `id="btn-1"` and text
    "Submit" is named `Btn1`; what a human calls the element should win.
 4. **Drop the ng-model and ng-binding rules.**

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -133,9 +133,10 @@ Adding Playwright changes the per-framework type list, not the model's shape.
 ## 8. View Matched Elements (the eye)
 
 Runs the locator live against the page: highlights **every** match (yellow fill, red outline), scrolls
-the **first** match into view, and reports the count in a snackbar. Highlight clears after ~3s.
-Available from the table row *and* from inside the Edit dialog, so a locator can be tested before
-saving. **[settled]**
+the **first** match into view, and reports the count in a snackbar. Highlight clears after ~3s, or
+immediately on **Close** — dismissing the count takes the highlight with it, so the page is never left
+marked up with no explanation. Available from the table row *and* from inside the Edit dialog, so a
+locator can be tested before saving. **[settled]**
 
 | Matches | Icon | Message |
 |---|---|---|

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -97,6 +97,7 @@ assumptions: it is per *window*, it follows the active tab, and it outlives navi
 | Navigate within a tab | model kept — may be stale |
 | Close the tab | that model is gone |
 | Close a panel | model survives; the other surface still has it |
+| Close the **last** panel | session over — every model is dropped |
 | Both surfaces open | **the same model**, and a pick in one appears in the other |
 
 A model can therefore never be displayed against a page it was not built from. Nothing is persisted to
@@ -110,6 +111,13 @@ sidebar should not lose the work.
 
 The framework selection lives in the model for the same reason: two surfaces rendering one model in
 different frameworks would show different locators for the same row.
+
+**A model with no panel attached is abandoned work**, so closing the last panel ends the session and
+drops everything. Panels hold a `runtime.connect` port for their lifetime and the background counts
+them; `onDisconnect` covers closing the sidebar, closing DevTools, and the tab hosting them going away.
+The count is deliberately global rather than per tab — a side panel follows the active tab, so a per-tab
+port would drop tab A's model the moment you looked at tab B, and switching away and back must not lose
+work.
 
 Because scan is once-per-model (§4), a model kept across a navigation blocks scanning the new page until
 it is deleted, so the panel needs to say the model has gone stale.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -89,17 +89,27 @@ v2.5.1 never had to decide this — a DevTools panel is inherently per-tab, its 
 memory, survived navigation within that tab, and died with the panel. The side panel breaks all three
 assumptions: it is per *window*, it follows the active tab, and it outlives navigation.
 
-**One model per tab, held in memory.** **[settled]**
+**One model per tab, owned by the background.** **[settled]**
 
 | Event | Effect |
 |---|---|
 | Switch tab | table swaps to that tab's model |
 | Navigate within a tab | model kept — may be stale |
 | Close the tab | that model is gone |
-| Close the panel | all models gone |
+| Close a panel | model survives; the other surface still has it |
+| Both surfaces open | **the same model**, and a pick in one appears in the other |
 
 A model can therefore never be displayed against a page it was not built from. Nothing is persisted to
 storage; a model is session work, not a saved artifact.
+
+**The background owns it, and panels are views** — they render what it broadcasts and mutate it by
+sending commands. Held in a panel it was one model per *panel*: a sidebar and a DevTools panel on the
+same tab showed different rows, and a pick landed in whichever happened to be listening. This is also
+why closing a panel no longer discards the model, which is the better behaviour anyway — closing the
+sidebar should not lose the work.
+
+The framework selection lives in the model for the same reason: two surfaces rendering one model in
+different frameworks would show different locators for the same row.
 
 Because scan is once-per-model (§4), a model kept across a navigation blocks scanning the new page until
 it is deleted, so the panel needs to say the model has gone stale.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -143,6 +143,21 @@ saving. **[settled]**
 | 0 | red error | *0 elements match that locator* |
 | >1 | amber warning | *N elements match that locator* |
 
+**The count has to be the count the generated test will get.** The in-page resolver is our own
+approximation of Playwright's matching, and the eye reports from it, so any drift means showing the user
+a number their test will not reproduce. Three behaviours this forces, all found by asserting every
+candidate against real Playwright rather than reasoning about it:
+
+- **`exact` is honoured.** `exact: true` is case-sensitive whole-string; the default is case-insensitive
+  substring. Whitespace is normalised either way — exact match still trims, and matching by text collapses
+  runs and turns line breaks into spaces. Generated candidates always set `exact: true` (§12), but a
+  hand-edited locator may not, and the resolver must follow the locator rather than the convention.
+- **Role candidates exclude elements hidden from the accessibility tree**, since `getByRole` defaults to
+  `includeHidden: false`. The same ARIA tree exclusion as §4.
+- **Text candidates match the innermost element only.** Playwright matches the smallest element
+  containing the text, so an ancestor whose text comes entirely from a matching descendant does not
+  count — otherwise a `<fieldset>` matches alongside its `<legend>`.
+
 ## 9. Edit dialog
 
 Title **Edit Element**. Fields: **Name** · locator **type** dropdown · editable locator **value** · eye.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -96,8 +96,8 @@ assumptions: it is per *window*, it follows the active tab, and it outlives navi
 | Switch tab | table swaps to that tab's model |
 | Navigate within a tab | model kept — may be stale |
 | Close the tab | that model is gone |
-| Close a panel | model survives; the other surface still has it |
-| Close the **last** panel | session over — every model is dropped |
+| Close a panel | model survives if another panel is still on that tab |
+| Close the **last panel watching a tab** | that tab's model is dropped |
 | Both surfaces open | **the same model**, and a pick in one appears in the other |
 
 A model can therefore never be displayed against a page it was not built from. Nothing is persisted to
@@ -112,12 +112,18 @@ sidebar should not lose the work.
 The framework selection lives in the model for the same reason: two surfaces rendering one model in
 different frameworks would show different locators for the same row.
 
-**A model with no panel attached is abandoned work**, so closing the last panel ends the session and
-drops everything. Panels hold a `runtime.connect` port for their lifetime and the background counts
-them; `onDisconnect` covers closing the sidebar, closing DevTools, and the tab hosting them going away.
-The count is deliberately global rather than per tab — a side panel follows the active tab, so a per-tab
-port would drop tab A's model the moment you looked at tab B, and switching away and back must not lose
-work.
+**A model with no panel watching it is abandoned work.** Panels hold a `runtime.connect` port for their
+lifetime and report which tab they are showing; when a panel closes, that tab's model goes unless another
+panel is still on it. `onDisconnect` covers closing the sidebar, closing DevTools, and the tab hosting
+them going away.
+
+Two things this gets right that simpler rules do not:
+
+- **Evaluated on disconnect, never on a tab change.** A side panel follows the active tab, so dropping
+  whenever no panel is watching would lose tab A's model the moment you looked at tab B. Switching away
+  and back must not lose work; closing the panel is what ends it.
+- **Scoped to the tab the closing panel was on, not to a global count.** A global count meant a panel
+  open on tab 1 kept tab 2's model alive after both of tab 2's panels had been closed.
 
 Because scan is once-per-model (§4), a model kept across a navigation blocks scanning the new page until
 it is deleted, so the panel needs to say the model has gone stale.

--- a/v3/README.md
+++ b/v3/README.md
@@ -85,7 +85,8 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    still opens the editor.
 10. **Both surfaces at once**: open the sidebar and the DevTools panel on one tab — they show the same
     rows, and a pick in either appears in both. Close one; the model survives in the other. Close them
-    all and reopen; the model is gone, because the session ended.
+    all and reopen; that tab's model is gone. Check this with a second tab modelled too — closing one
+    tab's panels must not touch the other's.
 11. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
    switch to B, add something different, switch back — A must be intact.
 12. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).

--- a/v3/README.md
+++ b/v3/README.md
@@ -84,7 +84,8 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
 9. **Clicking a row** does nothing — that is setting-gated and off by default (SPEC §6). Double-click
    still opens the editor.
 10. **Both surfaces at once**: open the sidebar and the DevTools panel on one tab — they show the same
-    rows, and a pick in either appears in both. Close one; the model survives in the other.
+    rows, and a pick in either appears in both. Close one; the model survives in the other. Close them
+    all and reopen; the model is gone, because the session ended.
 11. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
    switch to B, add something different, switch back — A must be intact.
 12. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).

--- a/v3/README.md
+++ b/v3/README.md
@@ -29,7 +29,7 @@ the stack validated in the feasibility study (WXT + Vue 3 + Quasar + TypeScript,
 | `npm run build` / `build:firefox` | Production build (`.output/`) |
 | `npm run zip` | Store-ready zips (incl. Firefox sources zip) |
 | `npm run typecheck` | Strict TS check of the pure core |
-| `npm run test:unit` | Vitest — pure core |
+| `npm run test:unit` | Vitest — pure core, plus Vue component tests |
 | `npm run check:manifests` | Assert both builds emit the expected surfaces |
 | `npm test` | Unit + engine fidelity (real Playwright) + both builds + manifests + extension & capture E2E |
 
@@ -71,11 +71,14 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    stacked; a second element with the same name becomes `About2`.
 7. Row trash and Delete Model both confirm, and the dialog follows the light/dark theme.
 8. **Eye** highlights every match in yellow with a red outline, scrolls the first into view, and reports
-   the count — green for 1, red for 0, amber for more. Highlight clears after ~3s.
-9. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
+   the count — green for 1, red for 0, amber for more. Highlight clears after ~3s. Clicking it repeatedly
+   replaces the message rather than stacking a counter badge.
+9. **Clicking a row** does nothing — that is setting-gated and off by default (SPEC §6). Double-click
+   still opens the editor.
+10. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
    switch to B, add something different, switch back — A must be intact.
-10. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
-11. Table headers stay visible at the narrowest side-panel width.
+11. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
+12. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the
 engine was validated on — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a

--- a/v3/README.md
+++ b/v3/README.md
@@ -71,8 +71,9 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    stacked; a second element with the same name becomes `About2`.
 7. Row trash and Delete Model both confirm, and the dialog follows the light/dark theme.
 8. **Eye** highlights every match in yellow with a red outline, scrolls the first into view, and reports
-   the count — green for 1, red for 0, amber for more. Highlight clears after ~3s. Clicking it repeatedly
-   replaces the message rather than stacking a counter badge.
+   the count — green for 1, red for 0, amber for more. Highlight clears after ~3s, or at once on
+   **Close**. Clicking it repeatedly replaces the message rather than stacking a counter badge, and the
+   new highlight survives the replacement.
 9. **Clicking a row** does nothing — that is setting-gated and off by default (SPEC §6). Double-click
    still opens the editor.
 10. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,

--- a/v3/README.md
+++ b/v3/README.md
@@ -70,10 +70,12 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
 6. The row's name and locator look right, **on one line** — Name, Locator and Actions across, not
    stacked; a second element with the same name becomes `About2`.
 7. Row trash and Delete Model both confirm, and the dialog follows the light/dark theme.
-8. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
+8. **Eye** highlights every match in yellow with a red outline, scrolls the first into view, and reports
+   the count — green for 1, red for 0, amber for more. Highlight clears after ~3s.
+9. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
    switch to B, add something different, switch back — A must be intact.
-9. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
-10. Table headers stay visible at the narrowest side-panel width.
+10. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
+11. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the
 engine was validated on — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a

--- a/v3/README.md
+++ b/v3/README.md
@@ -13,7 +13,8 @@ the stack validated in the feasibility study (WXT + Vue 3 + Quasar + TypeScript,
 - **Panel UI** (`ui/`) — Quasar: `AppToolbar` (SPEC §3) over `ModelTable` (SPEC §6). One app, three
   surfaces. Shell only so far — capture, generation and the dialogs are the next increments.
 - **Frameworks** (`src/frameworks.ts`) — the targets and the locator types each can express (SPEC §7).
-- **Session model** (`src/model.ts`) — one model per tab, in memory (SPEC §5).
+- **Session model** (`src/model.ts`) — one model per tab, owned by the background; panels are views
+  (SPEC §5).
 - **Naming** (`src/engine/naming.ts`) — split across the message boundary: `baseName` runs in the page,
   where the DOM rules apply; `uniqueName` runs in the panel, which owns the model (SPEC §13).
 - **Host adapter** (`host/`) — the only thing that differs per surface: which tab the panel drives.
@@ -57,7 +58,13 @@ Manually, from a production build:
 
 ## Manual verification
 
-Automated tests are a net; this is the gate. Per increment, on **both** browsers:
+Automated tests are a net; this is the gate. Per increment, on **both** browsers.
+
+> **Reload the page tab after any change to the engine, content script or naming.** WXT re-registers the
+> content script on rebuild, but re-registration only affects pages loaded afterwards — a tab open across
+> a rebuild keeps the old script and the old behaviour. Panel-only changes are hot-reloaded, which is
+> what makes the mixed behaviour confusing.
+
 
 1. Extension loads with no console errors (check the background/service-worker console too).
 2. Open the side panel / sidebar **and** the DevTools panel. Both render, and the header chip names the
@@ -76,10 +83,12 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    new highlight survives the replacement.
 9. **Clicking a row** does nothing — that is setting-gated and off by default (SPEC §6). Double-click
    still opens the editor.
-10. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
+10. **Both surfaces at once**: open the sidebar and the DevTools panel on one tab — they show the same
+    rows, and a pick in either appears in both. Close one; the model survives in the other.
+11. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
    switch to B, add something different, switch back — A must be intact.
-11. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
-12. Table headers stay visible at the narrowest side-panel width.
+12. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
+13. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the
 engine was validated on — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -1,42 +1,95 @@
 import { browser } from 'wxt/browser';
 import { isMessage, type Message } from '@/src/messaging';
+import { ModelStore, usedNames, type TabModel } from '@/src/model';
+import { uniqueName } from '@/src/engine/naming';
+import { defaultFrameworkId } from '@/src/frameworks';
 
 // Background service worker / event page.
 //
-// Two jobs: opening the panel from the toolbar, and relaying panel → page
-// messages. The relay exists because a DevTools page is not granted the `tabs`
-// API — only devtools.*, runtime.* and a few others — so it cannot talk to a
-// content script directly. Every surface goes through here, so there is one
-// path rather than one per host.
+// Owns the model — one per tab (SPEC §5) — and relays messages in both
+// directions. Both exist because the panel cannot do them itself:
+//
+//   * A DevTools page is granted only devtools.*, runtime.* and a few others.
+//     `browser.tabs` is undefined there, so a panel cannot talk to a content
+//     script; it sends RELAY_TO_TAB instead.
+//   * Firefox does not populate `sender.tab` for a message delivered to a
+//     DevTools page, so a panel cannot tell which tab a pick came from. The
+//     background always sees the sender, and stamps it.
+//   * A model held in a panel is one model per *panel*: a sidebar and a
+//     DevTools panel on the same tab showed different rows.
 export default defineBackground(() => {
-  // Printed on startup so it is obvious which build is actually running. Both
-  // browsers show background output in their browser console, unlike a DevTools
-  // panel page, whose logs do not reliably surface anywhere convenient.
   console.log('[Page Modeller] background ready', import.meta.env.MODE, import.meta.env.BROWSER);
+
+  const store = new ModelStore(defaultFrameworkId);
+  let idSeq = 0;
+
+  /** Every panel gets the model; each ignores tabs that are not its own. */
+  function publish(tabId: number, model: TabModel) {
+    browser.runtime.sendMessage({ type: 'MODEL', tabId, model }).catch(() => {});
+  }
+
+  browser.tabs.onRemoved.addListener((tabId) => store.clear(tabId));
 
   browser.runtime.onMessage.addListener((msg: unknown, sender: { tab?: { id?: number } }) => {
     if (!isMessage(msg)) return;
     const m = msg as Message;
 
-    // Content → panel. Re-broadcast with the tab stamped on it, because only
-    // the background reliably sees sender.tab — a DevTools page does not.
-    if (m.type === 'ELEMENT_PICKED' || m.type === 'PICKING_STOPPED' || m.type === 'HIGHLIGHT_RESULT') {
-      const tabId = sender.tab?.id;
-      if (tabId == null) return;
-      browser.runtime.sendMessage({ type: 'FROM_TAB', tabId, message: m }).catch(() => {});
-      return;
+    switch (m.type) {
+      // ---- from a content script ----
+      case 'ELEMENT_PICKED': {
+        const tabId = sender.tab?.id;
+        if (tabId == null) return;
+        const model = store.get(tabId);
+        model.elements.push({
+          ...m.result,
+          id: `el-${idSeq++}`,
+          name: uniqueName(m.result.suggestedName, usedNames(model)),
+          selectedIndex: m.result.preferredIndex >= 0 ? m.result.preferredIndex : 0,
+        });
+        publish(tabId, model);
+        // Picking is one-shot (SPEC §4); tell the panels so they can un-arm.
+        browser.runtime.sendMessage({ type: 'FROM_TAB', tabId, message: { type: 'PICKING_STOPPED' } }).catch(() => {});
+        return;
+      }
+      case 'PICKING_STOPPED':
+      case 'HIGHLIGHT_RESULT': {
+        const tabId = sender.tab?.id;
+        if (tabId == null) return;
+        browser.runtime.sendMessage({ type: 'FROM_TAB', tabId, message: m }).catch(() => {});
+        return;
+      }
+
+      // ---- from a panel ----
+      case 'RELAY_TO_TAB': {
+        if (import.meta.env.DEV) console.log('[Page Modeller] relay', m.message.type, '→ tab', m.tabId);
+        browser.tabs.sendMessage(m.tabId, m.message).catch((err) => {
+          // No content script: a browser-internal page, the add-on store, or a
+          // tab open before the extension loaded.
+          console.error('[Page Modeller] relay failed', m.message.type, err);
+          browser.runtime.sendMessage({ type: 'TAB_UNREACHABLE', tabId: m.tabId }).catch(() => {});
+        });
+        return;
+      }
+      case 'GET_MODEL':
+        publish(m.tabId, store.get(m.tabId));
+        return;
+      case 'DELETE_ELEMENT': {
+        const model = store.get(m.tabId);
+        model.elements = model.elements.filter((e) => e.id !== m.id);
+        publish(m.tabId, model);
+        return;
+      }
+      case 'DELETE_MODEL':
+        store.clear(m.tabId);
+        publish(m.tabId, store.get(m.tabId));
+        return;
+      case 'SET_FRAMEWORK': {
+        const model = store.get(m.tabId);
+        model.frameworkId = m.frameworkId;
+        publish(m.tabId, model);
+        return;
+      }
     }
-
-    if (m.type !== 'RELAY_TO_TAB') return;
-
-    if (import.meta.env.DEV) console.log('[Page Modeller] relay', m.message.type, '→ tab', m.tabId);
-
-    browser.tabs.sendMessage(m.tabId, m.message).catch((err) => {
-      // No content script: a browser-internal page, the add-on store, or a tab
-      // open before the extension loaded.
-      console.error('[Page Modeller] relay failed', m.message.type, err);
-      browser.runtime.sendMessage({ type: 'TAB_UNREACHABLE', tabId: m.tabId }).catch(() => {});
-    });
   });
 
   if (import.meta.env.FIREFOX) {

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -46,15 +46,19 @@ export default defineBackground(() => {
     viewing.set(port, undefined);
 
     port.onMessage.addListener((msg: unknown) => {
-      viewing.set(port, (msg as PanelViewing)?.tabId);
+      const tabId = (msg as PanelViewing)?.tabId;
+      if (import.meta.env.DEV) console.log('[Page Modeller] panel now watching tab', tabId);
+      viewing.set(port, tabId);
     });
 
     port.onDisconnect.addListener(() => {
       const wasOn = viewing.get(port);
       viewing.delete(port);
-      if (wasOn == null) return;
-      const stillWatched = [...viewing.values()].includes(wasOn);
-      if (stillWatched) return;
+      const stillWatched = wasOn != null && [...viewing.values()].includes(wasOn);
+      if (import.meta.env.DEV) {
+        console.log('[Page Modeller] panel closed; was watching tab', wasOn, stillWatched ? '— still watched' : '— dropping model');
+      }
+      if (wasOn == null || stillWatched) return;
       store.clear(wasOn);
       // Any panel still listening shows an empty table rather than stale rows.
       publish(wasOn, store.get(wasOn));

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -9,10 +9,17 @@ import { isMessage, type Message } from '@/src/messaging';
 // content script directly. Every surface goes through here, so there is one
 // path rather than one per host.
 export default defineBackground(() => {
+  // Printed on startup so it is obvious which build is actually running. Both
+  // browsers show background output in their browser console, unlike a DevTools
+  // panel page, whose logs do not reliably surface anywhere convenient.
+  console.log('[Page Modeller] background ready', import.meta.env.MODE, import.meta.env.BROWSER);
+
   browser.runtime.onMessage.addListener((msg: unknown) => {
     if (!isMessage(msg)) return;
     const m = msg as Message;
     if (m.type !== 'RELAY_TO_TAB') return;
+
+    if (import.meta.env.DEV) console.log('[Page Modeller] relay', m.message.type, '→ tab', m.tabId);
 
     browser.tabs.sendMessage(m.tabId, m.message).catch((err) => {
       // No content script: a browser-internal page, the add-on store, or a tab

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -14,9 +14,19 @@ export default defineBackground(() => {
   // panel page, whose logs do not reliably surface anywhere convenient.
   console.log('[Page Modeller] background ready', import.meta.env.MODE, import.meta.env.BROWSER);
 
-  browser.runtime.onMessage.addListener((msg: unknown) => {
+  browser.runtime.onMessage.addListener((msg: unknown, sender: { tab?: { id?: number } }) => {
     if (!isMessage(msg)) return;
     const m = msg as Message;
+
+    // Content → panel. Re-broadcast with the tab stamped on it, because only
+    // the background reliably sees sender.tab — a DevTools page does not.
+    if (m.type === 'ELEMENT_PICKED' || m.type === 'PICKING_STOPPED' || m.type === 'HIGHLIGHT_RESULT') {
+      const tabId = sender.tab?.id;
+      if (tabId == null) return;
+      browser.runtime.sendMessage({ type: 'FROM_TAB', tabId, message: m }).catch(() => {});
+      return;
+    }
+
     if (m.type !== 'RELAY_TO_TAB') return;
 
     if (import.meta.env.DEV) console.log('[Page Modeller] relay', m.message.type, '→ tab', m.tabId);

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -1,5 +1,5 @@
 import { browser } from 'wxt/browser';
-import { isMessage, type Message } from '@/src/messaging';
+import { isMessage, PANEL_PORT, type Message } from '@/src/messaging';
 import { ModelStore, usedNames, type TabModel } from '@/src/model';
 import { uniqueName } from '@/src/engine/naming';
 import { defaultFrameworkId } from '@/src/frameworks';
@@ -29,6 +29,30 @@ export default defineBackground(() => {
   }
 
   browser.tabs.onRemoved.addListener((tabId) => store.clear(tabId));
+
+  // A model with no panel attached is abandoned work, so the last panel closing
+  // ends the session and drops everything. Ports are how the background can
+  // tell: onDisconnect fires when the page goes away, which covers closing the
+  // sidebar, closing DevTools, and the tab hosting them being closed.
+  //
+  // Deliberately not per-tab. A side panel follows the active tab, so a
+  // per-tab port would drop tab A's model the moment you looked at tab B —
+  // switching away and back must not lose work (SPEC §5).
+  const panels = new Set<{ onDisconnect: { addListener(cb: () => void): void } }>();
+
+  browser.runtime.onConnect.addListener((port) => {
+    if (port.name !== PANEL_PORT) return;
+    panels.add(port);
+    port.onDisconnect.addListener(() => {
+      panels.delete(port);
+      if (panels.size > 0) return;
+      const dropped = store.tabIds();
+      store.clearAll();
+      // Anything still listening should show an empty table rather than stale
+      // rows, in the window before it too goes away.
+      for (const tabId of dropped) publish(tabId, store.get(tabId));
+    });
+  });
 
   browser.runtime.onMessage.addListener((msg: unknown, sender: { tab?: { id?: number } }) => {
     if (!isMessage(msg)) return;

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -1,10 +1,27 @@
 import { browser } from 'wxt/browser';
+import { isMessage, type Message } from '@/src/messaging';
 
-// Background service worker / event page. The toolbar click is the only way in
-// to the side panel on Chrome and the quickest one to the sidebar on Firefox,
-// so it lives here; the DevTools panel registers itself via devtools.html.
-// Content ↔ panel messaging goes direct over runtime/tabs, so nothing else does.
+// Background service worker / event page.
+//
+// Two jobs: opening the panel from the toolbar, and relaying panel → page
+// messages. The relay exists because a DevTools page is not granted the `tabs`
+// API — only devtools.*, runtime.* and a few others — so it cannot talk to a
+// content script directly. Every surface goes through here, so there is one
+// path rather than one per host.
 export default defineBackground(() => {
+  browser.runtime.onMessage.addListener((msg: unknown) => {
+    if (!isMessage(msg)) return;
+    const m = msg as Message;
+    if (m.type !== 'RELAY_TO_TAB') return;
+
+    browser.tabs.sendMessage(m.tabId, m.message).catch((err) => {
+      // No content script: a browser-internal page, the add-on store, or a tab
+      // open before the extension loaded.
+      console.error('[Page Modeller] relay failed', m.message.type, err);
+      browser.runtime.sendMessage({ type: 'TAB_UNREACHABLE', tabId: m.tabId }).catch(() => {});
+    });
+  });
+
   if (import.meta.env.FIREFOX) {
     // sidebarAction.toggle() needs a user gesture — the action click is one.
     browser.action.onClicked.addListener(() => browser.sidebarAction.toggle());

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -1,5 +1,5 @@
 import { browser } from 'wxt/browser';
-import { isMessage, PANEL_PORT, type Message } from '@/src/messaging';
+import { isMessage, PANEL_PORT, type Message, type PanelViewing } from '@/src/messaging';
 import { ModelStore, usedNames, type TabModel } from '@/src/model';
 import { uniqueName } from '@/src/engine/naming';
 import { defaultFrameworkId } from '@/src/frameworks';
@@ -30,27 +30,34 @@ export default defineBackground(() => {
 
   browser.tabs.onRemoved.addListener((tabId) => store.clear(tabId));
 
-  // A model with no panel attached is abandoned work, so the last panel closing
-  // ends the session and drops everything. Ports are how the background can
-  // tell: onDisconnect fires when the page goes away, which covers closing the
-  // sidebar, closing DevTools, and the tab hosting them being closed.
+  // A model with no panel watching it is abandoned work (SPEC §5). Each panel
+  // holds a port and reports which tab it is showing; when a panel closes, the
+  // tab it was on loses its model unless another panel is still on that tab.
   //
-  // Deliberately not per-tab. A side panel follows the active tab, so a
-  // per-tab port would drop tab A's model the moment you looked at tab B —
-  // switching away and back must not lose work (SPEC §5).
-  const panels = new Set<{ onDisconnect: { addListener(cb: () => void): void } }>();
+  // Evaluated on DISCONNECT, never on a tab change. A side panel follows the
+  // active tab, so dropping whenever no panel is watching would lose tab A's
+  // model the moment you looked at tab B. Switching away and back must not
+  // lose work; closing the panel is what ends it.
+  type PanelPort = { onDisconnect: { addListener(cb: () => void): void } };
+  const viewing = new Map<PanelPort, number | undefined>();
 
   browser.runtime.onConnect.addListener((port) => {
     if (port.name !== PANEL_PORT) return;
-    panels.add(port);
+    viewing.set(port, undefined);
+
+    port.onMessage.addListener((msg: unknown) => {
+      viewing.set(port, (msg as PanelViewing)?.tabId);
+    });
+
     port.onDisconnect.addListener(() => {
-      panels.delete(port);
-      if (panels.size > 0) return;
-      const dropped = store.tabIds();
-      store.clearAll();
-      // Anything still listening should show an empty table rather than stale
-      // rows, in the window before it too goes away.
-      for (const tabId of dropped) publish(tabId, store.get(tabId));
+      const wasOn = viewing.get(port);
+      viewing.delete(port);
+      if (wasOn == null) return;
+      const stillWatched = [...viewing.values()].includes(wasOn);
+      if (stillWatched) return;
+      store.clear(wasOn);
+      // Any panel still listening shows an empty table rather than stale rows.
+      publish(wasOn, store.get(wasOn));
     });
   });
 

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -1,4 +1,4 @@
-import { generate } from '@/src/engine/candidates';
+import { generate, resolveCandidate } from '@/src/engine/candidates';
 import { isMessage, type Message } from '@/src/messaging';
 
 // Inspector overlay: highlight the element under the cursor (like DevTools) and,
@@ -58,6 +58,51 @@ export default defineContentScript({
       label!.style.top = `${Math.max(0, r.top - 18)}px`;
     }
 
+    // ---- View Matched Elements (SPEC §8) ----
+    //
+    // Yellow fill, red outline, on every match. Boxes are position:fixed against
+    // the viewport, so they go stale if the page scrolls — acceptable for a
+    // 3s lifetime, and the same trade v2.5.1 made.
+    let marks: HTMLDivElement[] = [];
+    let markTimer: ReturnType<typeof setTimeout> | undefined;
+    const HIGHLIGHT_MS = 3000;
+
+    function clearMarks() {
+      for (const m of marks) m.remove();
+      marks = [];
+      if (markTimer) clearTimeout(markTimer);
+      markTimer = undefined;
+    }
+
+    function highlightAll(targets: Element[]) {
+      clearMarks();
+      if (targets.length === 0) return;
+
+      // Scroll the FIRST match into view before measuring, or every box after
+      // it would be positioned against the pre-scroll viewport.
+      targets[0].scrollIntoView({ block: 'center', inline: 'nearest' });
+
+      for (const t of targets) {
+        const r = t.getBoundingClientRect();
+        const mark = document.createElement('div');
+        Object.assign(mark.style, {
+          position: 'fixed',
+          pointerEvents: 'none',
+          zIndex: Z,
+          left: `${r.left}px`,
+          top: `${r.top}px`,
+          width: `${r.width}px`,
+          height: `${r.height}px`,
+          background: 'rgba(255, 235, 59, 0.45)',
+          outline: '2px solid #d32f2f',
+          outlineOffset: '-1px',
+        } as CSSStyleDeclaration);
+        document.documentElement.appendChild(mark);
+        marks.push(mark);
+      }
+      markTimer = setTimeout(clearMarks, HIGHLIGHT_MS);
+    }
+
     const onMove = (e: MouseEvent) => {
       if (!active) return;
       const el = e.target as Element | null;
@@ -105,11 +150,21 @@ export default defineContentScript({
       if (notify) browser.runtime.sendMessage({ type: 'PICKING_STOPPED' }).catch(() => {});
     }
 
-    browser.runtime.onMessage.addListener((msg: unknown) => {
+    browser.runtime.onMessage.addListener((msg: unknown, _sender: unknown, sendResponse: (r: unknown) => void) => {
       if (!isMessage(msg)) return;
       const m = msg as Message;
       if (m.type === 'START_PICKING') start();
       else if (m.type === 'STOP_PICKING') stop();
+      else if (m.type === 'HIGHLIGHT') {
+        // The panel sends this to the main frame only (frameId: 0). This script
+        // runs in every frame, and tabs.sendMessage delivers just the first
+        // reply — so a frame with no matches could answer for one that has
+        // them. Cross-frame highlighting arrives with frame support (SPEC §16).
+        const targets = resolveCandidate(document, m.candidate);
+        highlightAll(targets);
+        sendResponse({ count: targets.length });
+        return true;
+      }
     });
   },
 });

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -155,6 +155,7 @@ export default defineContentScript({
       const m = msg as Message;
       if (m.type === 'START_PICKING') start();
       else if (m.type === 'STOP_PICKING') stop();
+      else if (m.type === 'CLEAR_HIGHLIGHT') clearMarks();
       else if (m.type === 'HIGHLIGHT') {
         // The panel sends this to the main frame only (frameId: 0). This script
         // runs in every frame, and tabs.sendMessage delivers just the first

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -1,4 +1,4 @@
-import { generate, resolveCandidate } from '@/src/engine/candidates';
+import { generate, resolveCandidate, safeRole } from '@/src/engine/candidates';
 import { isMessage, type Message } from '@/src/messaging';
 
 // Inspector overlay: highlight the element under the cursor (like DevTools) and,
@@ -48,12 +48,22 @@ export default defineContentScript({
       current = null;
     }
 
+    /**
+     * What the tool will classify this element as (SPEC §11), not its raw role
+     * attribute. `role="none"` and `presentation` remove an element from the
+     * accessibility tree, so they say nothing useful about what you are picking
+     * — fall back to the tag, as for anything with no computed role.
+     */
+    function overlayLabel(el: Element): string {
+      const role = safeRole(el);
+      return role && role !== 'none' && role !== 'presentation' ? role : el.tagName.toLowerCase();
+    }
+
     function highlight(el: Element) {
       ensureOverlay();
       const r = el.getBoundingClientRect();
       Object.assign(box!.style, { left: `${r.left}px`, top: `${r.top}px`, width: `${r.width}px`, height: `${r.height}px` });
-      const role = (el as HTMLElement).getAttribute('role') ?? el.tagName.toLowerCase();
-      label!.textContent = role;
+      label!.textContent = overlayLabel(el);
       label!.style.left = `${r.left}px`;
       label!.style.top = `${Math.max(0, r.top - 18)}px`;
     }
@@ -85,6 +95,8 @@ export default defineContentScript({
       for (const t of targets) {
         const r = t.getBoundingClientRect();
         const mark = document.createElement('div');
+        // Identifies our overlay to tests and to anyone inspecting the page.
+        mark.dataset.pageModeller = 'highlight';
         Object.assign(mark.style, {
           position: 'fixed',
           pointerEvents: 'none',
@@ -150,21 +162,23 @@ export default defineContentScript({
       if (notify) browser.runtime.sendMessage({ type: 'PICKING_STOPPED' }).catch(() => {});
     }
 
-    browser.runtime.onMessage.addListener((msg: unknown, _sender: unknown, sendResponse: (r: unknown) => void) => {
+    browser.runtime.onMessage.addListener((msg: unknown) => {
       if (!isMessage(msg)) return;
       const m = msg as Message;
       if (m.type === 'START_PICKING') start();
       else if (m.type === 'STOP_PICKING') stop();
       else if (m.type === 'CLEAR_HIGHLIGHT') clearMarks();
       else if (m.type === 'HIGHLIGHT') {
-        // The panel sends this to the main frame only (frameId: 0). This script
-        // runs in every frame, and tabs.sendMessage delivers just the first
-        // reply — so a frame with no matches could answer for one that has
-        // them. Cross-frame highlighting arrives with frame support (SPEC §16).
+        // This script runs in every frame, but only the top one answers — a
+        // sub-frame with no matches would otherwise report 0 over the top
+        // frame's real count. Decided here rather than by the panel passing
+        // frameId, so the send is shaped exactly like the ones that work on
+        // both browsers. Cross-frame highlighting arrives with SPEC §16.
+        if (window.top !== window) return;
         const targets = resolveCandidate(document, m.candidate);
         highlightAll(targets);
-        sendResponse({ count: targets.length });
-        return true;
+        // Answered as a message, not a reply — sendResponse is not portable.
+        browser.runtime.sendMessage({ type: 'HIGHLIGHT_RESULT', count: targets.length }).catch(() => {});
       }
     });
   },

--- a/v3/package-lock.json
+++ b/v3/package-lock.json
@@ -18,6 +18,7 @@
         "@playwright/test": "^1.49.0",
         "@quasar/vite-plugin": "^2.0.2",
         "@vitejs/plugin-vue": "^6.0.8",
+        "@vue/test-utils": "^2.5.0",
         "esbuild": "^0.28.2",
         "jsdom": "^30.0.1",
         "sass-embedded": "^1.83.0",
@@ -1260,6 +1261,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.2.1.tgz",
+      "integrity": "sha512-TUqERXGNTifZ9y2g3wPxQrw3HpHv/02DsW3D90T9x0hhonrL1ZqpSmNrU2XkoIq0fP1N6gZfVQzy2Fw1ZvGBNg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.148.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
@@ -2349,6 +2357,27 @@
       "integrity": "sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.5.0.tgz",
+      "integrity": "sha512-6Clu5EKR/r6cDPYrKsu+8wenciWJJ3rhS9OEGsfDlZeZIhlJeEPGIZQHxE4lHRJCzPSq3EWMsFxQUqCvrbHQuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^2.0.0",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@webext-core/fake-browser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@webext-core/fake-browser/-/fake-browser-2.0.1.tgz",
@@ -2409,6 +2438,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/wxt-dev"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-5.0.0.tgz",
+      "integrity": "sha512-/XrFJgzQQQHpti1raDJC6m4ws6aNktmjBlhk8Fdlk7LwCEuDoieEJJY9OFHjfiFJFFRM2tK+Ky/IsfbbmlMu1w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/acorn": {
@@ -3891,6 +3930,74 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/editorconfig": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-3.0.2.tgz",
+      "integrity": "sha512-T0ix8GhtxyKVfUFEcvdNDt3YGqlwkFHbD4/5bgFUDgFmxhI/cSRAeJ87/Sz//Cq8Eam6JX/e23RkoFO71P7aAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.2.1",
+        "commander": "^14.0.3",
+        "minimatch": "~10.2.4",
+        "semver": "^7.7.4"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/editorconfig/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4583,6 +4690,24 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4594,6 +4719,45 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-directory": {
@@ -5118,6 +5282,35 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-beautify": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-2.0.3.tgz",
+      "integrity": "sha512-cyFbh3tkPhknnTD/0bLf0T0yy2ZIbqL05mttzbt4y1Zfr7NxqXQZ62dkBLKs3oHH/lpjmDRAnciJiSUyOy8XwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^3.0.2",
+        "glob": "^13.0.6",
+        "js-cookie": "^3.0.8",
+        "nopt": "^10.0.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "10.0.0",
@@ -5923,6 +6116,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -6053,6 +6256,22 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-10.0.1.tgz",
+      "integrity": "sha512-df3sBr/6ax9hSGuC3CspvLlbnX8cP5L5nZwXF8cGN8l0zSWR6BvzmQ6jPUKjvo6+/xdpkNvEcucBNUdBeeV13g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^5.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/nth-check": {
@@ -6353,6 +6572,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -8290,6 +8526,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.11.tgz",
+      "integrity": "sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-tsc": {
       "version": "2.2.12",

--- a/v3/package.json
+++ b/v3/package.json
@@ -29,6 +29,7 @@
     "@playwright/test": "^1.49.0",
     "@quasar/vite-plugin": "^2.0.2",
     "@vitejs/plugin-vue": "^6.0.8",
+    "@vue/test-utils": "^2.5.0",
     "esbuild": "^0.28.2",
     "jsdom": "^30.0.1",
     "sass-embedded": "^1.83.0",

--- a/v3/src/engine/candidates.ts
+++ b/v3/src/engine/candidates.ts
@@ -41,7 +41,7 @@ function safeName(el: Element): string {
   }
 }
 
-function safeRole(el: Element): string | null {
+export function safeRole(el: Element): string | null {
   try {
     return getRole(el) || null;
   } catch {

--- a/v3/src/engine/candidates.ts
+++ b/v3/src/engine/candidates.ts
@@ -93,36 +93,97 @@ function xpathFor(el: Element): string {
   return '/' + parts.join('/');
 }
 
-// ---- predicted uniqueness (OUR best-effort, mirrors Playwright semantics) ----
+// ---- resolution ----
+//
+// One implementation, two callers: predicted uniqueness while ranking
+// candidates, and View Matched Elements (SPEC §8), which needs the elements
+// themselves so it can highlight them. They must agree, or the count the engine
+// ranked on would differ from the count the eye reports.
 
-function predictedCount(doc: Document, c: LocatorCandidate): number {
+/**
+ * Playwright's text matching, which the eye must reproduce or its count will
+ * disagree with the test that later runs the locator.
+ *
+ *   exact: true   case-sensitive, whole-string
+ *   exact: false  case-insensitive, substring   (Playwright's default)
+ *
+ * Whitespace is normalised either way — "exact match still trims whitespace",
+ * and matching by text collapses runs and turns line breaks into spaces.
+ */
+export function matchesText(actual: string, expected: string, exact: boolean | undefined): boolean {
+  const a = norm(actual);
+  const b = norm(expected);
+  return exact ? a === b : a.toLowerCase().includes(b.toLowerCase());
+}
+
+/**
+ * Excluded from the accessibility tree, per ARIA tree exclusion. `getByRole`
+ * applies this by default (`includeHidden: false`) and we must too, or the eye
+ * counts hidden elements the test will never see.
+ */
+function ariaHidden(el: Element): boolean {
+  for (let cur: Element | null = el; cur; cur = cur.parentElement) {
+    if (cur.getAttribute('aria-hidden') === 'true') return true;
+    if ((cur as HTMLElement).hidden) return true;
+    try {
+      const st = cur.ownerDocument.defaultView?.getComputedStyle(cur);
+      if (st && (st.display === 'none' || st.visibility === 'hidden' || st.visibility === 'collapse')) return true;
+    } catch {
+      /* detached or cross-document; treat as visible */
+    }
+  }
+  return false;
+}
+
+/** Every element the candidate matches, in document order. */
+export function resolveCandidate(doc: Document, c: LocatorCandidate): Element[] {
   const all = () => Array.from(doc.querySelectorAll('*'));
   switch (c.kind) {
     case 'testId':
-      return doc.querySelectorAll(`[data-testid="${CSS.escape(c.value)}"]`).length;
+      return Array.from(doc.querySelectorAll(`[data-testid="${CSS.escape(c.value)}"]`));
     case 'role':
-      return all().filter((e) => safeRole(e) === c.role && (c.name === undefined || safeName(e) === c.name)).length;
+      return all()
+        .filter((e) => safeRole(e) === c.role && (c.name === undefined || matchesText(safeName(e), c.name, c.exact)))
+        .filter((e) => !ariaHidden(e));
     case 'label':
-      return all().filter((e) => LABEL_TARGETS.has(e.tagName) && safeName(e) === c.text).length;
+      return all().filter((e) => LABEL_TARGETS.has(e.tagName) && matchesText(safeName(e), c.text, c.exact));
     case 'placeholder':
-      return Array.from(doc.querySelectorAll('[placeholder]')).filter(
-        (e) => norm(e.getAttribute('placeholder')) === c.text
-      ).length;
-    case 'text':
-      return all().filter((e) => norm((e as HTMLElement).textContent) === c.text).length;
+      return Array.from(doc.querySelectorAll('[placeholder]')).filter((e) =>
+        matchesText(e.getAttribute('placeholder') ?? '', c.text, c.exact)
+      );
+    case 'text': {
+      // Playwright matches the *smallest* element containing the text, so an
+      // ancestor whose text comes entirely from a matching descendant does not
+      // count. Without this a <fieldset> matches alongside its <legend>.
+      const hits = all().filter((e) => matchesText((e as HTMLElement).textContent ?? '', c.text, c.exact));
+      return hits.filter((e) => !hits.some((other) => other !== e && e.contains(other)));
+    }
     case 'altText':
-      return Array.from(doc.querySelectorAll('img[alt], input[alt], area[alt]')).filter(
-        (e) => norm(e.getAttribute('alt')) === c.text
-      ).length;
+      return Array.from(doc.querySelectorAll('img[alt], input[alt], area[alt]')).filter((e) =>
+        matchesText(e.getAttribute('alt') ?? '', c.text, c.exact)
+      );
     case 'title':
-      return Array.from(doc.querySelectorAll('[title]')).filter((e) => norm(e.getAttribute('title')) === c.text).length;
+      return Array.from(doc.querySelectorAll('[title]')).filter((e) => matchesText(e.getAttribute('title') ?? '', c.text, c.exact));
     case 'css':
-      return doc.querySelectorAll(c.value).length;
+      // A hand-typed selector can be invalid; that is a miss, not a crash.
+      try {
+        return Array.from(doc.querySelectorAll(c.value));
+      } catch {
+        return [];
+      }
     case 'xpath': {
-      const r = doc.evaluate(c.value, doc, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
-      return r.snapshotLength;
+      try {
+        const r = doc.evaluate(c.value, doc, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+        return Array.from({ length: r.snapshotLength }, (_, i) => r.snapshotItem(i) as Element);
+      } catch {
+        return [];
+      }
     }
   }
+}
+
+function predictedCount(doc: Document, c: LocatorCandidate): number {
+  return resolveCandidate(doc, c).length;
 }
 
 // ---- candidate generation (ranked, mirrors Playwright's priority) ----
@@ -151,15 +212,15 @@ export function generate(el: Element): ElementResult {
   }
 
   const placeholder = el.getAttribute('placeholder');
-  if (placeholder) out.push({ kind: 'placeholder', text: norm(placeholder) });
+  if (placeholder) out.push({ kind: 'placeholder', text: norm(placeholder), exact: true });
 
   if (tag === 'img') {
     const alt = el.getAttribute('alt');
-    if (alt) out.push({ kind: 'altText', text: norm(alt) });
+    if (alt) out.push({ kind: 'altText', text: norm(alt), exact: true });
   }
 
   const title = el.getAttribute('title');
-  if (title) out.push({ kind: 'title', text: norm(title) });
+  if (title) out.push({ kind: 'title', text: norm(title), exact: true });
 
   if (!NON_TEXT.has(el.tagName)) {
     const text = norm(el.textContent);

--- a/v3/src/engine/naming.ts
+++ b/v3/src/engine/naming.ts
@@ -70,9 +70,26 @@ function tagIndexName(el: Element): string {
   return `${tag}${index}`;
 }
 
+/**
+ * Visible text, for elements the accessible name cannot describe.
+ *
+ * accname only derives a name from content for roles that support it, so a
+ * plain <span> or <div> — exactly what Add Element is for (SPEC §4) — computes
+ * to nothing and would fall through to `Span97`. Capped, because a container's
+ * textContent can be most of the page, and truncating that produces a name as
+ * useless as the tag index it replaced.
+ */
+const MAX_TEXT_SOURCE = 80;
+
+function textContent(el: Element): string {
+  const text = (el.textContent ?? '').replace(/\s+/g, ' ').trim();
+  return text.length > 0 && text.length <= MAX_TEXT_SOURCE ? text : '';
+}
+
 /** Ordered; the first to return a non-empty string wins. */
 const rules: Array<(el: Element) => string> = [
   accessibleName,
+  textContent,
   (el) => attr(el, 'placeholder'),
   (el) => (el.tagName === 'BUTTON' || ['submit', 'reset'].includes((el as HTMLInputElement).type) ? attr(el, 'value') : ''),
   (el) => attr(el, 'name'),

--- a/v3/src/engine/types.ts
+++ b/v3/src/engine/types.ts
@@ -6,10 +6,10 @@ export type LocatorCandidate =
   | { kind: 'testId'; value: string }
   | { kind: 'role'; role: string; name?: string; exact?: boolean }
   | { kind: 'label'; text: string; exact?: boolean }
-  | { kind: 'placeholder'; text: string }
+  | { kind: 'placeholder'; text: string; exact?: boolean }
   | { kind: 'text'; text: string; exact?: boolean }
-  | { kind: 'altText'; text: string }
-  | { kind: 'title'; text: string }
+  | { kind: 'altText'; text: string; exact?: boolean }
+  | { kind: 'title'; text: string; exact?: boolean }
   | { kind: 'css'; value: string }
   | { kind: 'xpath'; value: string };
 

--- a/v3/src/locators/display.ts
+++ b/v3/src/locators/display.ts
@@ -14,17 +14,18 @@ export function playwrightExpr(c: LocatorCandidate): string {
       return `getByTestId(${q(c.value)})`;
     case 'role':
       // exact: true always — see SPEC §12 name matching.
-      return c.name === undefined ? `getByRole(${q(c.role)})` : `getByRole(${q(c.role)}, { name: ${q(c.name)}, exact: true })`;
+      if (c.name === undefined) return `getByRole(${q(c.role)})`;
+      return `getByRole(${q(c.role)}, { name: ${q(c.name)}${c.exact ? ', exact: true' : ''} })`;
     case 'label':
-      return `getByLabel(${q(c.text)}, { exact: true })`;
+      return `getByLabel(${q(c.text)}${c.exact ? ', { exact: true }' : ''})`;
     case 'placeholder':
-      return `getByPlaceholder(${q(c.text)})`;
+      return `getByPlaceholder(${q(c.text)}${c.exact ? ', { exact: true }' : ''})`;
     case 'text':
-      return `getByText(${q(c.text)}, { exact: true })`;
+      return `getByText(${q(c.text)}${c.exact ? ', { exact: true }' : ''})`;
     case 'altText':
-      return `getByAltText(${q(c.text)})`;
+      return `getByAltText(${q(c.text)}${c.exact ? ', { exact: true }' : ''})`;
     case 'title':
-      return `getByTitle(${q(c.text)})`;
+      return `getByTitle(${q(c.text)}${c.exact ? ', { exact: true }' : ''})`;
     case 'css':
     case 'xpath':
       return `locator(${q(c.value)})`;

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -38,6 +38,12 @@ export type ContentToPanel =
 // panel could not reach the page at all. Relaying through the background is the
 // documented route, and using it everywhere keeps one code path instead of a
 // per-surface branch.
+/**
+ * Port name every panel connects on. The background counts these to know when
+ * the last panel has closed and the session is over (SPEC §5).
+ */
+export const PANEL_PORT = 'page-modeller-panel';
+
 export type PanelToBackground =
   | { type: 'RELAY_TO_TAB'; tabId: number; message: PanelToContent }
   // Model commands. The background owns the model (SPEC §5), so panels ask for

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -28,7 +28,22 @@ export type ContentToPanel =
   | { type: 'PICKING_STOPPED' }
   | { type: 'HIGHLIGHT_RESULT'; count: number };
 
-export type Message = PanelToContent | ContentToPanel;
+// Messages panel → background.
+//
+// The panel never calls tabs.sendMessage itself. A DevTools page gets only a
+// subset of the extension APIs — devtools.*, runtime.*, and little else — and
+// `tabs` is not in it, which is documented for both browsers. Chrome happens to
+// tolerate the direct call from a panel page; Firefox does not, so the DevTools
+// panel could not reach the page at all. Relaying through the background is the
+// documented route, and using it everywhere keeps one code path instead of a
+// per-surface branch.
+export type PanelToBackground = { type: 'RELAY_TO_TAB'; tabId: number; message: PanelToContent };
+
+// Messages background → panel. Delivery is reported back rather than returned,
+// for the same portability reason as HIGHLIGHT_RESULT.
+export type BackgroundToPanel = { type: 'TAB_UNREACHABLE'; tabId: number };
+
+export type Message = PanelToContent | ContentToPanel | PanelToBackground | BackgroundToPanel;
 
 export function isMessage(x: unknown): x is Message {
   return typeof x === 'object' && x !== null && typeof (x as { type?: unknown }).type === 'string';

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -44,6 +44,15 @@ export type ContentToPanel =
  */
 export const PANEL_PORT = 'page-modeller-panel';
 
+/**
+ * Sent over the port whenever a panel changes which tab it is showing. The
+ * background needs it to decide, when a panel closes, whether any panel is
+ * still watching the tab it was on.
+ */
+export interface PanelViewing {
+  tabId: number | undefined;
+}
+
 export type PanelToBackground =
   | { type: 'RELAY_TO_TAB'; tabId: number; message: PanelToContent }
   // Model commands. The background owns the model (SPEC §5), so panels ask for

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -1,4 +1,5 @@
 import type { ElementResult, LocatorCandidate } from './engine/types';
+import type { TabModel } from './model';
 
 // Messages panel → content (sent via browser.tabs.sendMessage to the active tab).
 //
@@ -37,7 +38,14 @@ export type ContentToPanel =
 // panel could not reach the page at all. Relaying through the background is the
 // documented route, and using it everywhere keeps one code path instead of a
 // per-surface branch.
-export type PanelToBackground = { type: 'RELAY_TO_TAB'; tabId: number; message: PanelToContent };
+export type PanelToBackground =
+  | { type: 'RELAY_TO_TAB'; tabId: number; message: PanelToContent }
+  // Model commands. The background owns the model (SPEC §5), so panels ask for
+  // changes rather than making them, and every panel on the tab sees the result.
+  | { type: 'GET_MODEL'; tabId: number }
+  | { type: 'DELETE_ELEMENT'; tabId: number; id: string }
+  | { type: 'DELETE_MODEL'; tabId: number }
+  | { type: 'SET_FRAMEWORK'; tabId: number; frameworkId: string };
 
 // Messages background → panel.
 //
@@ -49,7 +57,10 @@ export type PanelToBackground = { type: 'RELAY_TO_TAB'; tabId: number; message: 
 // which tab a message came from.
 export type BackgroundToPanel =
   | { type: 'TAB_UNREACHABLE'; tabId: number }
-  | { type: 'FROM_TAB'; tabId: number; message: ContentToPanel };
+  | { type: 'FROM_TAB'; tabId: number; message: ContentToPanel }
+  // The whole model, after every change. Small enough that diffing would cost
+  // more in complexity than it saves, and it keeps panels stateless.
+  | { type: 'MODEL'; tabId: number; model: TabModel };
 
 export type Message = PanelToContent | ContentToPanel | PanelToBackground | BackgroundToPanel;
 

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -1,4 +1,4 @@
-import type { ElementResult } from './engine/types';
+import type { ElementResult, LocatorCandidate } from './engine/types';
 
 // Messages panel → content (sent via browser.tabs.sendMessage to the active tab).
 //
@@ -6,7 +6,16 @@ import type { ElementResult } from './engine/types';
 // as soon as an element is chosen. 'add' takes any single element anywhere;
 // 'scan' takes a container and is not wired up yet.
 export type PickMode = 'add' | 'scan';
-export type PanelToContent = { type: 'START_PICKING'; mode: PickMode } | { type: 'STOP_PICKING' };
+export type PanelToContent =
+  | { type: 'START_PICKING'; mode: PickMode }
+  | { type: 'STOP_PICKING' }
+  // View Matched Elements (SPEC §8). Replies with HighlightResult.
+  | { type: 'HIGHLIGHT'; candidate: LocatorCandidate };
+
+/** Reply to HIGHLIGHT: how many elements the locator actually matched. */
+export interface HighlightResult {
+  count: number;
+}
 
 // Messages content → panel/background (sent via browser.runtime.sendMessage).
 export type ContentToPanel =

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -10,7 +10,9 @@ export type PanelToContent =
   | { type: 'START_PICKING'; mode: PickMode }
   | { type: 'STOP_PICKING' }
   // View Matched Elements (SPEC §8). Replies with HighlightResult.
-  | { type: 'HIGHLIGHT'; candidate: LocatorCandidate };
+  | { type: 'HIGHLIGHT'; candidate: LocatorCandidate }
+  // Clear the highlight early — the user dismissed the match count.
+  | { type: 'CLEAR_HIGHLIGHT' };
 
 /** Reply to HIGHLIGHT: how many elements the locator actually matched. */
 export interface HighlightResult {

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -39,9 +39,17 @@ export type ContentToPanel =
 // per-surface branch.
 export type PanelToBackground = { type: 'RELAY_TO_TAB'; tabId: number; message: PanelToContent };
 
-// Messages background → panel. Delivery is reported back rather than returned,
-// for the same portability reason as HIGHLIGHT_RESULT.
-export type BackgroundToPanel = { type: 'TAB_UNREACHABLE'; tabId: number };
+// Messages background → panel.
+//
+// Content traffic is re-broadcast from the background with the tab stamped on
+// it. The panel cannot do that filtering itself: Firefox does not reliably
+// populate `sender.tab` for a message delivered to a DevTools page, so a
+// `sender.tab.id === myTab` check drops every pick without a trace. The
+// background always sees the sender, so it is the one context that can say
+// which tab a message came from.
+export type BackgroundToPanel =
+  | { type: 'TAB_UNREACHABLE'; tabId: number }
+  | { type: 'FROM_TAB'; tabId: number; message: ContentToPanel };
 
 export type Message = PanelToContent | ContentToPanel | PanelToBackground | BackgroundToPanel;
 

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -9,20 +9,24 @@ export type PickMode = 'add' | 'scan';
 export type PanelToContent =
   | { type: 'START_PICKING'; mode: PickMode }
   | { type: 'STOP_PICKING' }
-  // View Matched Elements (SPEC §8). Replies with HighlightResult.
+  // View Matched Elements (SPEC §8). Answered by HIGHLIGHT_RESULT, not by a
+  // reply — see the note on ContentToPanel below.
   | { type: 'HIGHLIGHT'; candidate: LocatorCandidate }
   // Clear the highlight early — the user dismissed the match count.
   | { type: 'CLEAR_HIGHLIGHT' };
 
-/** Reply to HIGHLIGHT: how many elements the locator actually matched. */
-export interface HighlightResult {
-  count: number;
-}
-
 // Messages content → panel/background (sent via browser.runtime.sendMessage).
+//
+// Everything the content script has to say travels this way, including answers
+// to panel requests. Request/response via sendResponse is not portable: Chrome
+// wants `return true` for an async reply, Firefox's native browser.* wants a
+// returned Promise, and doing both leaves the caller's promise unsettled on
+// Firefox — which surfaced as "can't reach this page" for a tab that was
+// plainly reachable.
 export type ContentToPanel =
   | { type: 'ELEMENT_PICKED'; result: ElementResult }
-  | { type: 'PICKING_STOPPED' };
+  | { type: 'PICKING_STOPPED' }
+  | { type: 'HIGHLIGHT_RESULT'; count: number };
 
 export type Message = PanelToContent | ContentToPanel;
 

--- a/v3/src/model.ts
+++ b/v3/src/model.ts
@@ -1,9 +1,12 @@
 // The session model (SPEC §5, §7).
 //
-// One model per tab, held in memory. Switching tabs swaps the table; closing
-// the tab or the panel discards it. Nothing is persisted — a model is session
-// work, not a saved artifact, and this way a model can never be shown against
-// a page it was not built from.
+// One model per TAB, owned by the background. Panels are views: they render
+// what the background broadcasts and mutate it by sending messages. Holding it
+// in a panel made it one model per *panel*, so a sidebar and a DevTools panel
+// on the same tab showed different rows and a pick landed in whichever happened
+// to be listening.
+//
+// Nothing is persisted. A model lives as long as its tab.
 import type { ElementResult, LocatorCandidate } from './engine/types';
 
 export interface ModelElement extends ElementResult {
@@ -15,16 +18,17 @@ export interface ModelElement extends ElementResult {
   override?: LocatorCandidate;
 }
 
+/** Serialisable: it crosses the message boundary on every change. */
 export interface TabModel {
   elements: ModelElement[];
-  /** Reserves derived names so a second `About` becomes `About2`. */
-  usedNames: Set<string>;
+  /** Chosen up front and locked once the model has anything in it (SPEC §3). */
+  frameworkId: string;
   /** The URL the model was built against, for the stale check (SPEC §5). */
   url: string | null;
 }
 
-export function emptyModel(): TabModel {
-  return { elements: [], usedNames: new Set(), url: null };
+export function emptyModel(frameworkId: string): TabModel {
+  return { elements: [], frameworkId, url: null };
 }
 
 /** The locator currently in effect for an element: an override, or the pick. */
@@ -32,14 +36,25 @@ export function activeCandidate(el: ModelElement): LocatorCandidate {
   return el.override ?? el.candidates[el.selectedIndex]?.candidate ?? el.candidates[0].candidate;
 }
 
-/** Per-tab store. Keyed by tab id; entries live only as long as the panel. */
+/**
+ * Names in use, derived rather than tracked. A stored set would have to be kept
+ * in step with deletions; deriving it means a freed name is reusable with no
+ * bookkeeping.
+ */
+export function usedNames(model: TabModel): Set<string> {
+  return new Set(model.elements.map((e) => e.name));
+}
+
+/** Per-tab store. Lives in the background; entries die with their tab. */
 export class ModelStore {
   private byTab = new Map<number, TabModel>();
+
+  constructor(private defaultFrameworkId: string) {}
 
   get(tabId: number): TabModel {
     let m = this.byTab.get(tabId);
     if (!m) {
-      m = emptyModel();
+      m = emptyModel(this.defaultFrameworkId);
       this.byTab.set(tabId, m);
     }
     return m;
@@ -47,11 +62,5 @@ export class ModelStore {
 
   clear(tabId: number): void {
     this.byTab.delete(tabId);
-  }
-
-  /** Drop models for tabs that have gone away, so closing a tab frees it. */
-  retain(liveTabIds: Iterable<number>): void {
-    const live = new Set(liveTabIds);
-    for (const id of [...this.byTab.keys()]) if (!live.has(id)) this.byTab.delete(id);
   }
 }

--- a/v3/src/model.ts
+++ b/v3/src/model.ts
@@ -63,4 +63,13 @@ export class ModelStore {
   clear(tabId: number): void {
     this.byTab.delete(tabId);
   }
+
+  /** Every model. Used when the last panel closes — the session is over. */
+  clearAll(): void {
+    this.byTab.clear();
+  }
+
+  tabIds(): number[] {
+    return [...this.byTab.keys()];
+  }
 }

--- a/v3/src/model.ts
+++ b/v3/src/model.ts
@@ -64,12 +64,4 @@ export class ModelStore {
     this.byTab.delete(tabId);
   }
 
-  /** Every model. Used when the last panel closes — the session is over. */
-  clearAll(): void {
-    this.byTab.clear();
-  }
-
-  tabIds(): number[] {
-    return [...this.byTab.keys()];
-  }
 }

--- a/v3/src/settings.ts
+++ b/v3/src/settings.ts
@@ -1,0 +1,24 @@
+// User settings (SPEC §14).
+//
+// Stored in chrome.storage.sync under the key `options`, preserving v2.5.1's
+// keys so an in-place upgrade keeps the user's choices. Storage and the options
+// page land with REWRITE-PLAN §12 step 13; until then these defaults are what
+// the panel runs on.
+export type ThemePreference = 'system' | 'light' | 'dark';
+
+export interface Settings {
+  showTooltips: boolean;
+  /** v2.5.1's boolean darkMode becomes three-way, defaulting to the host. */
+  theme: ThemePreference;
+  /** Scan includes elements not exposed to the accessibility tree (SPEC §4). */
+  modelHiddenElements: boolean;
+  /** Single-click a row runs View Matched Elements (SPEC §6). */
+  clickTableRowsToViewMatchedElements: boolean;
+}
+
+export const defaultSettings: Settings = {
+  showTooltips: true,
+  theme: 'system',
+  modelHiddenElements: false,
+  clickTableRowsToViewMatchedElements: false,
+};

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -286,62 +286,75 @@ test('both panels on a tab see the same model (SPEC §5)', async () => {
     .toEqual(['SignIn']);
 });
 
-test('closing the last panel ends the session and drops the models', async () => {
+test('a model dies when the last panel watching its tab closes', async () => {
   let [sw] = context.serviceWorkers();
   if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
   const extId = new URL(sw.url()).host;
 
   // Earlier tests leave panel pages open, and the real app connects a port on
-  // mount — so the background would never see the count reach zero.
+  // mount — each is a panel as far as the background is concerned.
   for (const open of context.pages()) {
     if (open.url().startsWith('chrome-extension://')) await open.close();
   }
 
-  const { page, tabId } = await openFixture(sw as never, 'session');
+  const a = await openFixture(sw as never, 'session-a');
+  const b = await openFixture(sw as never, 'session-b');
 
-  /** A panel page holding a port, as the real panels do. */
-  async function openPanel() {
+  /** A panel page holding a port and watching `tab`, as the real panels do. */
+  async function openPanel(tab: number) {
     const p = await context.newPage();
     await p.goto(`chrome-extension://${extId}/devtools-panel.html`);
-    await p.evaluate((name) => {
-      (window as unknown as { __port: unknown }).__port = chrome.runtime.connect({ name });
-      (window as unknown as { __msgs: unknown[] }).__msgs = [];
-      chrome.runtime.onMessage.addListener((m) => {
-        (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
-      });
-    }, 'page-modeller-panel');
+    await p.evaluate(
+      ([name, id]) => {
+        const port = chrome.runtime.connect({ name: name as string });
+        port.postMessage({ tabId: id as number });
+        (window as unknown as { __port: unknown }).__port = port;
+        (window as unknown as { __msgs: unknown[] }).__msgs = [];
+        chrome.runtime.onMessage.addListener((m) => {
+          (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+        });
+      },
+      ['page-modeller-panel', tab] as [string, number]
+    );
     return p;
   }
 
-  const first = await openPanel();
-  const second = await openPanel();
+  async function pick(fixture: { page: import('@playwright/test').Page; tabId: number }, panel: import('@playwright/test').Page) {
+    await panel.evaluate(
+      (id) => chrome.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: id, message: { type: 'START_PICKING', mode: 'add' } }),
+      fixture.tabId
+    );
+    await fixture.page.getByRole('button', { name: 'Sign in' }).click();
+  }
 
-  await first.evaluate(
-    (id) => chrome.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: id, message: { type: 'START_PICKING', mode: 'add' } }),
-    tabId
-  );
-  await page.getByRole('button', { name: 'Sign in' }).click();
-
-  const namesIn = async (p: typeof first) =>
+  const namesIn = async (p: import('@playwright/test').Page) =>
     (await p.evaluate(() => (window as unknown as { __msgs: { type: string; model?: { elements: { name: string }[] } }[] }).__msgs))
       .filter((m) => m.type === 'MODEL')
       .at(-1)
       ?.model?.elements.map((e) => e.name);
 
-  await expect.poll(() => namesIn(second)).toEqual(['SignIn']);
+  // Two panels on tab A, one on tab B; a model built on each.
+  const a1 = await openPanel(a.tabId);
+  const a2 = await openPanel(a.tabId);
+  const b1 = await openPanel(b.tabId);
+  await pick(a, a1);
+  await pick(b, b1);
+  await expect.poll(() => namesIn(a2)).toEqual(['SignIn']);
 
-  // Closing ONE panel must not end the session — that was the whole point of
-  // moving the model out of the panel.
-  await first.close();
-  const survivor = await openPanel();
-  await survivor.evaluate((id) => chrome.runtime.sendMessage({ type: 'GET_MODEL', tabId: id }), tabId);
-  await expect.poll(() => namesIn(survivor)).toEqual(['SignIn']);
+  // Closing one of tab A's two panels leaves its model alone.
+  await a1.close();
+  const a3 = await openPanel(a.tabId);
+  await a3.evaluate((id) => chrome.runtime.sendMessage({ type: 'GET_MODEL', tabId: id }), a.tabId);
+  await expect.poll(() => namesIn(a3)).toEqual(['SignIn']);
 
-  // Closing them all does: a model with no panel attached is abandoned work.
-  await second.close();
-  await survivor.close();
+  // Closing tab B's only panel drops B — and must NOT depend on whether any
+  // panel happens to be open on another tab, which a global count got wrong.
+  await b1.close();
+  const b2 = await openPanel(b.tabId);
+  await b2.evaluate((id) => chrome.runtime.sendMessage({ type: 'GET_MODEL', tabId: id }), b.tabId);
+  await expect.poll(() => namesIn(b2)).toEqual([]);
 
-  const reopened = await openPanel();
-  await reopened.evaluate((id) => chrome.runtime.sendMessage({ type: 'GET_MODEL', tabId: id }), tabId);
-  await expect.poll(() => namesIn(reopened)).toEqual([]);
+  // Tab A is untouched by any of that.
+  await a3.evaluate((id) => chrome.runtime.sendMessage({ type: 'GET_MODEL', tabId: id }), a.tabId);
+  await expect.poll(() => namesIn(a3)).toEqual(['SignIn']);
 });

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -358,3 +358,63 @@ test('a model dies when the last panel watching its tab closes', async () => {
   await a3.evaluate((id) => chrome.runtime.sendMessage({ type: 'GET_MODEL', tabId: id }), a.tabId);
   await expect.poll(() => namesIn(a3)).toEqual(['SignIn']);
 });
+
+test('a roaming sidebar closing on one tab leaves the other tab\'s model', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  for (const open of context.pages()) {
+    if (open.url().startsWith('chrome-extension://')) await open.close();
+  }
+
+  const a = await openFixture(sw as never, 'roam-a');
+  const b = await openFixture(sw as never, 'roam-b');
+
+  // ONE panel, standing in for a side panel that follows the active tab.
+  const panel = await context.newPage();
+  await panel.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await panel.evaluate((name) => {
+    const port = chrome.runtime.connect({ name: name as string });
+    (window as unknown as { __port: chrome.runtime.Port }).__port = port;
+    (window as unknown as { __msgs: unknown[] }).__msgs = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+    });
+  }, 'page-modeller-panel');
+
+  const watch = (id: number) =>
+    panel.evaluate((t) => (window as unknown as { __port: chrome.runtime.Port }).__port.postMessage({ tabId: t }), id);
+
+  // Build a model on tab A.
+  await watch(a.tabId);
+  await panel.evaluate(
+    (id) => chrome.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: id, message: { type: 'START_PICKING', mode: 'add' } }),
+    a.tabId
+  );
+  await a.page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Roam to tab B, then close the panel there.
+  await watch(b.tabId);
+  await panel.close();
+
+  // Tab A's model must survive: the panel was not watching it when it closed,
+  // and roaming away is not the same as finishing.
+  const probe = await context.newPage();
+  await probe.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await probe.evaluate(() => {
+    (window as unknown as { __msgs: unknown[] }).__msgs = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+    });
+  });
+  await probe.evaluate((id) => chrome.runtime.sendMessage({ type: 'GET_MODEL', tabId: id }), a.tabId);
+  await expect
+    .poll(async () =>
+      (await probe.evaluate(() => (window as unknown as { __msgs: { type: string; model?: { elements: { name: string }[] } }[] }).__msgs))
+        .filter((m) => m.type === 'MODEL')
+        .at(-1)
+        ?.model?.elements.map((e) => e.name)
+    )
+    .toEqual(['SignIn']);
+});

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -27,6 +27,21 @@ test.afterAll(async () => {
   server?.kill();
 });
 
+/**
+ * The panel's runtime.onMessage, stood up in the service worker. The worker
+ * outlives each test, so the listener is installed once — registering it per
+ * test records every message as many times as there are listeners.
+ */
+async function collectMessages(sw: { evaluate: (fn: never, arg?: unknown) => Promise<unknown> }) {
+  await (sw as unknown as { evaluate: (f: () => void) => Promise<void> }).evaluate(() => {
+    const g = globalThis as unknown as { __picks: unknown[]; __collecting?: boolean };
+    g.__picks = [];
+    if (g.__collecting) return;
+    g.__collecting = true;
+    chrome.runtime.onMessage.addListener((m) => g.__picks.push(m));
+  });
+}
+
 test('picking is one-shot and reports a named element', async () => {
   let [sw] = context.serviceWorkers();
   if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
@@ -39,13 +54,7 @@ test('picking is one-shot and reports a named element', async () => {
     `http://localhost:${PORT}/login.html`
   );
 
-  // Collect every ELEMENT_PICKED / PICKING_STOPPED the content script emits.
-  await sw.evaluate(() => {
-    (globalThis as unknown as { __picks: unknown[] }).__picks = [];
-    chrome.runtime.onMessage.addListener((m) => {
-      (globalThis as unknown as { __picks: unknown[] }).__picks.push(m);
-    });
-  });
+  await collectMessages(sw as never);
 
   await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
 
@@ -70,4 +79,43 @@ test('picking is one-shot and reports a named element', async () => {
   await page.waitForTimeout(500);
   const after = await sw.evaluate(() => (globalThis as unknown as { __picks: unknown[] }).__picks.length);
   expect(after, 'picking stopped itself after one element').toBe(1);
+});
+
+test('highlighting reports its count as a message, and Close clears it', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const page = await context.newPage();
+  await page.goto(`http://localhost:${PORT}/login.html`);
+  const tabId: number = await sw.evaluate(
+    async (url) => (await chrome.tabs.query({ url }))[0].id!,
+    `http://localhost:${PORT}/login.html`
+  );
+
+  await collectMessages(sw as never);
+
+  const marks = page.locator('[data-page-modeller="highlight"]');
+
+  // The count comes back as HIGHLIGHT_RESULT, not as a reply. sendResponse is
+  // not portable — Chrome wants `return true`, Firefox's native browser.* wants
+  // a returned Promise, and doing both left the caller's promise unsettled on
+  // Firefox, reported as "can't reach this page".
+  await sw.evaluate(
+    (id) => chrome.tabs.sendMessage(id, { type: 'HIGHLIGHT', candidate: { kind: 'role', role: 'link', name: 'Home', exact: true } }),
+    tabId
+  );
+  await expect(marks).toHaveCount(1);
+  await expect
+    .poll(async () => (await sw.evaluate(() => (globalThis as unknown as { __picks: { type: string; count?: number }[] }).__picks))
+      .filter((m) => m.type === 'HIGHLIGHT_RESULT')
+      .map((m) => m.count))
+    .toEqual([1]);
+
+  // A locator matching several elements highlights all of them.
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'HIGHLIGHT', candidate: { kind: 'css', value: 'a' } }), tabId);
+  await expect(marks).toHaveCount(3);
+
+  // Close dismisses the highlight, not just the message.
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'CLEAR_HIGHLIGHT' }), tabId);
+  await expect(marks).toHaveCount(0);
 });

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -28,6 +28,22 @@ test.afterAll(async () => {
 });
 
 /**
+ * Open a fixture and return its tab id. Each test gets a distinct URL: pages
+ * accumulate across tests in one persistent context, and tabs.query({url})
+ * would otherwise return an earlier test's tab.
+ */
+async function openFixture(sw: { evaluate: (fn: never, arg?: unknown) => Promise<unknown> }, caseName: string) {
+  const url = `http://localhost:${PORT}/login.html?case=${caseName}`;
+  const page = await context.newPage();
+  await page.goto(url);
+  const tabId = (await (sw as unknown as { evaluate: (f: (u: string) => Promise<number>, a: string) => Promise<number> }).evaluate(
+    async (u) => (await chrome.tabs.query({ url: u }))[0].id!,
+    url
+  )) as number;
+  return { page, tabId };
+}
+
+/**
  * The panel's runtime.onMessage, stood up in the service worker. The worker
  * outlives each test, so the listener is installed once — registering it per
  * test records every message as many times as there are listeners.
@@ -46,14 +62,7 @@ test('picking is one-shot and reports a named element', async () => {
   let [sw] = context.serviceWorkers();
   if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
 
-  const page = await context.newPage();
-  await page.goto(`http://localhost:${PORT}/login.html`);
-
-  const tabId: number = await sw.evaluate(
-    async (url) => (await chrome.tabs.query({ url }))[0].id!,
-    `http://localhost:${PORT}/login.html`
-  );
-
+  const { page, tabId } = await openFixture(sw as never, 'oneshot');
   await collectMessages(sw as never);
 
   await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
@@ -85,13 +94,7 @@ test('highlighting reports its count as a message, and Close clears it', async (
   let [sw] = context.serviceWorkers();
   if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
 
-  const page = await context.newPage();
-  await page.goto(`http://localhost:${PORT}/login.html`);
-  const tabId: number = await sw.evaluate(
-    async (url) => (await chrome.tabs.query({ url }))[0].id!,
-    `http://localhost:${PORT}/login.html`
-  );
-
+  const { page, tabId } = await openFixture(sw as never, 'highlight');
   await collectMessages(sw as never);
 
   const marks = page.locator('[data-page-modeller="highlight"]');
@@ -118,4 +121,56 @@ test('highlighting reports its count as a message, and Close clears it', async (
   // Close dismisses the highlight, not just the message.
   await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'CLEAR_HIGHLIGHT' }), tabId);
   await expect(marks).toHaveCount(0);
+});
+
+test('the background relays panel messages, and reports an unreachable tab', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  const { page, tabId } = await openFixture(sw as never, 'relay');
+  await collectMessages(sw as never);
+
+  // The panel never calls tabs.sendMessage — a DevTools page is not granted
+  // that API — so everything goes through the background. Drive the relay from
+  // a real extension page, which is what the panel is.
+  const panel = await context.newPage();
+  await panel.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await panel.evaluate(
+    (id) =>
+      chrome.runtime.sendMessage({
+        type: 'RELAY_TO_TAB',
+        tabId: id,
+        message: { type: 'HIGHLIGHT', candidate: { kind: 'role', role: 'link', name: 'Home', exact: true } },
+      }),
+    tabId
+  );
+  await expect(page.locator('[data-page-modeller="highlight"]')).toHaveCount(1);
+
+  // A tab that does not exist. An extension page would not do: tabs.sendMessage
+  // reaches extension pages hosted in a tab, so the panel's own listener
+  // answers and nothing rejects. The failure has to come back as a message,
+  // since the panel cannot see the background's rejection.
+  const missingTabId = 987654321;
+  // Collected in the panel page, not the service worker: runtime.sendMessage
+  // does not fire the sender's own listener, so the background cannot observe
+  // the failure it reports. The panel is the intended audience anyway.
+  await panel.evaluate(() => {
+    (window as unknown as { __msgs: { type: string; tabId?: number }[] }).__msgs = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+    });
+  });
+
+  await panel.evaluate(
+    (id) => chrome.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: id, message: { type: 'STOP_PICKING' } }),
+    missingTabId
+  );
+  await expect
+    .poll(async () =>
+      (await panel.evaluate(() => (window as unknown as { __msgs: { type: string; tabId?: number }[] }).__msgs))
+        .filter((m) => m.type === 'TAB_UNREACHABLE')
+        .map((m) => m.tabId)
+    )
+    .toEqual([missingTabId]);
 });

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -214,8 +214,74 @@ test('a pick reaches a panel page stamped with its tab', async () => {
           () => (window as unknown as { __msgs: { type: string; tabId?: number; message?: { type: string } }[] }).__msgs
         )
       )
-        .filter((m) => m.type === 'FROM_TAB' && m.message?.type === 'ELEMENT_PICKED')
+        .filter((m) => m.type === 'MODEL')
         .map((m) => m.tabId)
     )
     .toEqual([tabId]);
+
+  // The model the panel receives is the background's, with the element named.
+  const published = (await panel.evaluate(
+    () => (window as unknown as { __msgs: { type: string; model?: { elements: { name: string }[] } }[] }).__msgs
+  )).filter((m) => m.type === 'MODEL');
+  expect(published.at(-1)!.model!.elements.map((e) => e.name)).toEqual(['SignIn']);
+});
+
+test('both panels on a tab see the same model (SPEC §5)', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  const { page, tabId } = await openFixture(sw as never, 'shared');
+
+  // Two panel pages, standing in for the sidebar and the DevTools panel.
+  const panels = [];
+  for (let i = 0; i < 2; i++) {
+    const p = await context.newPage();
+    await p.goto(`chrome-extension://${extId}/devtools-panel.html`);
+    await p.evaluate(() => {
+      (window as unknown as { __msgs: unknown[] }).__msgs = [];
+      chrome.runtime.onMessage.addListener((m) => {
+        (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+      });
+    });
+    panels.push(p);
+  }
+
+  // One panel starts a pick.
+  await panels[0].evaluate(
+    (id) => chrome.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: id, message: { type: 'START_PICKING', mode: 'add' } }),
+    tabId
+  );
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Both see it. A model held in the panel gave each surface its own rows.
+  for (const p of panels) {
+    await expect
+      .poll(async () =>
+        (
+          await p.evaluate(() => (window as unknown as { __msgs: { type: string; model?: { elements: { name: string }[] } }[] }).__msgs)
+        )
+          .filter((m) => m.type === 'MODEL')
+          .at(-1)?.model?.elements.map((e) => e.name)
+      )
+      .toEqual(['SignIn']);
+  }
+
+  // A panel that opens later asks for the model and gets the same rows.
+  const late = await context.newPage();
+  await late.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await late.evaluate(() => {
+    (window as unknown as { __msgs: unknown[] }).__msgs = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+    });
+  });
+  await late.evaluate((id) => chrome.runtime.sendMessage({ type: 'GET_MODEL', tabId: id }), tabId);
+  await expect
+    .poll(async () =>
+      (await late.evaluate(() => (window as unknown as { __msgs: { type: string; model?: { elements: { name: string }[] } }[] }).__msgs))
+        .filter((m) => m.type === 'MODEL')
+        .at(-1)?.model?.elements.map((e) => e.name)
+    )
+    .toEqual(['SignIn']);
 });

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -174,3 +174,48 @@ test('the background relays panel messages, and reports an unreachable tab', asy
     )
     .toEqual([missingTabId]);
 });
+
+test('a pick reaches a panel page stamped with its tab', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  const { page, tabId } = await openFixture(sw as never, 'frompanel');
+
+  // A real extension page, which is what a panel is. The panel cannot filter on
+  // sender.tab — Firefox does not populate it for a DevTools page — so the
+  // background re-broadcasts content traffic as FROM_TAB with the tab stamped
+  // on it, and this is what proves that arrives.
+  const panel = await context.newPage();
+  await panel.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await panel.evaluate(() => {
+    (window as unknown as { __msgs: unknown[] }).__msgs = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+    });
+  });
+
+  await panel.evaluate(
+    (id) =>
+      chrome.runtime.sendMessage({
+        type: 'RELAY_TO_TAB',
+        tabId: id,
+        message: { type: 'START_PICKING', mode: 'add' },
+      }),
+    tabId
+  );
+
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect
+    .poll(async () =>
+      (
+        await panel.evaluate(
+          () => (window as unknown as { __msgs: { type: string; tabId?: number; message?: { type: string } }[] }).__msgs
+        )
+      )
+        .filter((m) => m.type === 'FROM_TAB' && m.message?.type === 'ELEMENT_PICKED')
+        .map((m) => m.tabId)
+    )
+    .toEqual([tabId]);
+});

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -285,3 +285,63 @@ test('both panels on a tab see the same model (SPEC §5)', async () => {
     )
     .toEqual(['SignIn']);
 });
+
+test('closing the last panel ends the session and drops the models', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  // Earlier tests leave panel pages open, and the real app connects a port on
+  // mount — so the background would never see the count reach zero.
+  for (const open of context.pages()) {
+    if (open.url().startsWith('chrome-extension://')) await open.close();
+  }
+
+  const { page, tabId } = await openFixture(sw as never, 'session');
+
+  /** A panel page holding a port, as the real panels do. */
+  async function openPanel() {
+    const p = await context.newPage();
+    await p.goto(`chrome-extension://${extId}/devtools-panel.html`);
+    await p.evaluate((name) => {
+      (window as unknown as { __port: unknown }).__port = chrome.runtime.connect({ name });
+      (window as unknown as { __msgs: unknown[] }).__msgs = [];
+      chrome.runtime.onMessage.addListener((m) => {
+        (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+      });
+    }, 'page-modeller-panel');
+    return p;
+  }
+
+  const first = await openPanel();
+  const second = await openPanel();
+
+  await first.evaluate(
+    (id) => chrome.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: id, message: { type: 'START_PICKING', mode: 'add' } }),
+    tabId
+  );
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  const namesIn = async (p: typeof first) =>
+    (await p.evaluate(() => (window as unknown as { __msgs: { type: string; model?: { elements: { name: string }[] } }[] }).__msgs))
+      .filter((m) => m.type === 'MODEL')
+      .at(-1)
+      ?.model?.elements.map((e) => e.name);
+
+  await expect.poll(() => namesIn(second)).toEqual(['SignIn']);
+
+  // Closing ONE panel must not end the session — that was the whole point of
+  // moving the model out of the panel.
+  await first.close();
+  const survivor = await openPanel();
+  await survivor.evaluate((id) => chrome.runtime.sendMessage({ type: 'GET_MODEL', tabId: id }), tabId);
+  await expect.poll(() => namesIn(survivor)).toEqual(['SignIn']);
+
+  // Closing them all does: a model with no panel attached is abandoned work.
+  await second.close();
+  await survivor.close();
+
+  const reopened = await openPanel();
+  await reopened.evaluate((id) => chrome.runtime.sendMessage({ type: 'GET_MODEL', tabId: id }), tabId);
+  await expect.poll(() => namesIn(reopened)).toEqual([]);
+});

--- a/v3/tests/engine.fidelity.spec.ts
+++ b/v3/tests/engine.fidelity.spec.ts
@@ -24,6 +24,20 @@ test('locator engine matches real Playwright resolution', async ({ page }) => {
         result: window.__spike.generate(el) as ElementResult,
       }));
 
+      // Every candidate's predicted count must equal Playwright's real count.
+      // The engine's in-page resolver is our own approximation of Playwright
+      // semantics — text matching, `exact`, whitespace normalisation — and the
+      // eye (SPEC §8) reports from it. If the two drift, the count the user is
+      // shown is not the count their test will get.
+      for (const { candidate, predictedCount } of result.candidates) {
+        const actual = await buildLocator(page, candidate).count();
+        if (actual !== predictedCount) {
+          failures.push(
+            `${fixture}/${spikeId}: ${candidate.kind} predicted ${predictedCount}, Playwright resolved ${actual}`
+          );
+        }
+      }
+
       if (result.preferredIndex < 0) {
         failures.push(`${fixture}/${spikeId}: no unique candidate`);
         continue;

--- a/v3/tests/pw-builder.ts
+++ b/v3/tests/pw-builder.ts
@@ -14,13 +14,13 @@ export function buildLocator(page: Page, c: LocatorCandidate): Locator {
     case 'label':
       return page.getByLabel(c.text, { exact: c.exact });
     case 'placeholder':
-      return page.getByPlaceholder(c.text);
+      return page.getByPlaceholder(c.text, { exact: c.exact });
     case 'text':
       return page.getByText(c.text, { exact: c.exact });
     case 'altText':
-      return page.getByAltText(c.text);
+      return page.getByAltText(c.text, { exact: c.exact });
     case 'title':
-      return page.getByTitle(c.text);
+      return page.getByTitle(c.text, { exact: c.exact });
     case 'css':
       return page.locator(c.value);
     case 'xpath':

--- a/v3/tests/unit/ModelTable.test.ts
+++ b/v3/tests/unit/ModelTable.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { Quasar, QBtn, QTooltip } from 'quasar';
+import ModelTable, { type ModelRow } from '../../ui/ModelTable.vue';
+
+const rows: ModelRow[] = [
+  { id: 'a', name: 'SignIn', locator: "getByRole('button', { name: 'Sign in', exact: true })" },
+  { id: 'b', name: 'About', locator: "getByRole('link', { name: 'About', exact: true })" },
+];
+
+function render(props: Partial<{ elements: ModelRow[]; clickToHighlight: boolean }> = {}) {
+  return mount(ModelTable, {
+    props: { elements: rows, clickToHighlight: false, ...props },
+    // @quasar/vite-plugin auto-imports Quasar components when building; in a
+    // test they have to be registered by hand or they render as unknown
+    // elements and every query for a real <button> misses.
+    global: { plugins: [Quasar], components: { QBtn, QTooltip }, stubs: { QTooltip: true } },
+  });
+}
+
+describe('ModelTable', () => {
+  it('renders a row per element', () => {
+    expect(render().findAll('tbody tr')).toHaveLength(2);
+  });
+
+  it('shows the empty state when there is nothing modelled', () => {
+    const w = render({ elements: [] });
+    expect(w.find('[data-testid="empty-state"]').text()).toContain('Scan the page or start adding elements');
+  });
+
+  it('keeps each row on one line', () => {
+    // Regression: `class="row"` collided with Quasar's flex grid utility and
+    // stacked every cell onto its own line.
+    const cells = render().findAll('tbody tr')[0].findAll('td');
+    expect(cells).toHaveLength(3);
+    expect(cells.some((c) => c.classes().includes('row'))).toBe(false);
+  });
+
+  it('does NOT highlight on row click by default (SPEC §6)', () => {
+    const w = render({ clickToHighlight: false });
+    w.findAll('tbody tr')[0].trigger('click');
+    expect(w.emitted('highlight')).toBeUndefined();
+  });
+
+  it('highlights on row click when the setting is on', () => {
+    const w = render({ clickToHighlight: true });
+    w.findAll('tbody tr')[0].trigger('click');
+    expect(w.emitted('highlight')).toEqual([['a']]);
+  });
+
+  it('always opens the editor on double-click', () => {
+    const w = render({ clickToHighlight: false });
+    w.findAll('tbody tr')[1].trigger('dblclick');
+    expect(w.emitted('edit')).toEqual([['b']]);
+  });
+
+  it('emits from the row action buttons regardless of the setting', async () => {
+    const w = render({ clickToHighlight: false });
+    const buttons = w.findAll('tbody tr')[0].findAll('button');
+    await buttons[0].trigger('click');
+    await buttons[2].trigger('click');
+    expect(w.emitted('highlight')).toEqual([['a']]);
+    expect(w.emitted('remove')).toEqual([['a']]);
+  });
+});

--- a/v3/tests/unit/css-collisions.test.ts
+++ b/v3/tests/unit/css-collisions.test.ts
@@ -32,3 +32,24 @@ describe('our templates do not collide with Quasar utility classes', () => {
     });
   }
 });
+
+
+// `browser.tabs` is undefined in a Firefox DevTools panel — a devtools page is
+// granted only devtools.*, runtime.* and a few others. Chrome tolerates the
+// call, so a regression here is invisible on Chrome and on every automated test
+// we can run. The panel must go through the background relay instead.
+describe('the panel never touches browser.tabs directly', () => {
+  const files = readdirSync(UI_DIR).filter((f) => f.endsWith('.vue') || f.endsWith('.ts'));
+
+  for (const file of files) {
+    it(file, () => {
+      const source = readFileSync(join(UI_DIR, file), 'utf8')
+        // Comments explain the rule; they are not calls.
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\/\/.*$/gm, '');
+      expect(source, 'use send() / RELAY_TO_TAB — browser.tabs is undefined in a DevTools panel').not.toMatch(
+        /browser\s*\.\s*tabs/
+      );
+    });
+  }
+});

--- a/v3/tests/unit/display.test.ts
+++ b/v3/tests/unit/display.test.ts
@@ -9,8 +9,13 @@ describe('displayLocator', () => {
     expect(displayLocator({ kind: 'testId', value: 'submit' }, 'playwright-python')).toBe("getByTestId('submit')");
   });
 
-  it('always emits exact: true for a named role (SPEC §12)', () => {
-    expect(playwrightExpr({ kind: 'role', role: 'link', name: 'About' })).toContain('exact: true');
+  it('renders exact faithfully rather than forcing it', () => {
+    // SPEC §12 says generated candidates always carry exact: true — that is the
+    // engine's guarantee, not the renderer's. A hand-edited locator may
+    // deliberately want Playwright's substring default, and must render as such
+    // or the table would lie about what the test will do.
+    expect(playwrightExpr({ kind: 'role', role: 'link', name: 'About', exact: true })).toContain('exact: true');
+    expect(playwrightExpr({ kind: 'role', role: 'link', name: 'About' })).toBe("getByRole('link', { name: 'About' })");
   });
 
   it('renders other frameworks as type: value', () => {

--- a/v3/tests/unit/message-payloads.test.ts
+++ b/v3/tests/unit/message-payloads.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { ref } from 'vue';
+import { activeCandidate, type ModelElement } from '../../src/model';
+
+// Firefox serialises extension messages with the structured clone algorithm.
+// Vue wraps reactive state in Proxies, and structured clone throws
+// DataCloneError on a Proxy — while Chrome's message path tolerates it. So a
+// message carrying model data failed on Firefox only, and looked like an
+// unreachable tab.
+describe('message payloads must survive structured clone', () => {
+  const element: ModelElement = {
+    id: 'el-0',
+    name: 'Home',
+    tag: 'a',
+    role: 'link',
+    accessibleName: 'Home',
+    suggestedName: 'Home',
+    selectedIndex: 0,
+    candidates: [{ candidate: { kind: 'role', role: 'link', name: 'Home', exact: true }, predictedCount: 1 }],
+    preferredIndex: 0,
+  };
+
+  it('a candidate read from reactive state is not cloneable', () => {
+    const reactive = ref<ModelElement[]>([element]);
+    const fromRef = activeCandidate(reactive.value[0]);
+    expect(() => structuredClone(fromRef)).toThrow();
+  });
+
+  it('the JSON round-trip we send is cloneable and identical', () => {
+    const reactive = ref<ModelElement[]>([element]);
+    const payload = JSON.parse(JSON.stringify({ type: 'HIGHLIGHT', candidate: activeCandidate(reactive.value[0]) }));
+    expect(() => structuredClone(payload)).not.toThrow();
+    expect(payload.candidate).toEqual({ kind: 'role', role: 'link', name: 'Home', exact: true });
+  });
+});

--- a/v3/tests/unit/naming.test.ts
+++ b/v3/tests/unit/naming.test.ts
@@ -48,6 +48,20 @@ describe('baseName', () => {
     expect(name(el('<input type="password" data-t />'))).toBe('PasswordElement');
   });
 
+  it('names a static element from its visible text', () => {
+    // accname derives a name from content only for roles that support it, so a
+    // plain span computes to nothing — and Add Element exists to capture these.
+    expect(name(el('<span data-t>Dark</span>'))).toBe('Dark');
+    expect(name(el('<div data-t>Read Wikipedia in your language</div>'))).toBe('ReadWikipediaInYour');
+  });
+
+  it('ignores text too long to be a name', () => {
+    // A container's textContent can be most of the page; truncating that gives
+    // a name no better than the tag index.
+    const long = 'word '.repeat(40);
+    expect(name(el(`<div data-t>${long}</div>`))).toBe('Div1');
+  });
+
   it('falls back to tag and index', () => {
     expect(name(el('<div data-t></div>'))).toBe('Div1');
   });

--- a/v3/tests/unit/text-matching.test.ts
+++ b/v3/tests/unit/text-matching.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { matchesText } from '../../src/engine/candidates';
+
+// Playwright's semantics, which the eye (SPEC §8) has to reproduce or the count
+// it shows will differ from the count the generated test gets. Verified against
+// real Playwright by tests/engine.fidelity.spec.ts; these pin the intent.
+describe('matchesText', () => {
+  describe('exact: true — case-sensitive, whole-string', () => {
+    it('matches the whole string', () => {
+      expect(matchesText('Sign in', 'Sign in', true)).toBe(true);
+    });
+    it('rejects a substring', () => {
+      expect(matchesText('Sign in now', 'Sign in', true)).toBe(false);
+    });
+    it('is case-sensitive', () => {
+      expect(matchesText('Sign In', 'Sign in', true)).toBe(false);
+    });
+    it('still trims whitespace', () => {
+      // "Note that exact match still trims whitespace."
+      expect(matchesText('  Sign in  ', 'Sign in', true)).toBe(true);
+    });
+  });
+
+  describe('exact: false — case-insensitive, substring (Playwright default)', () => {
+    it('matches a substring', () => {
+      expect(matchesText('Sign in now', 'Sign in', false)).toBe(true);
+    });
+    it('ignores case', () => {
+      expect(matchesText('SIGN IN', 'sign in', false)).toBe(true);
+    });
+    it('rejects text that does not contain it', () => {
+      expect(matchesText('Register', 'Sign in', false)).toBe(false);
+    });
+    it('is the behaviour when exact is undefined', () => {
+      expect(matchesText('Sign in now', 'Sign in', undefined)).toBe(true);
+    });
+  });
+
+  it('normalises whitespace in both modes', () => {
+    // Matching by text collapses runs and turns line breaks into spaces.
+    expect(matchesText('Sign\n  in', 'Sign in', true)).toBe(true);
+    expect(matchesText('Sign\tin now', 'sign in', false)).toBe(true);
+  });
+});

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -37,7 +37,7 @@ import { defaultFrameworkId } from '@/src/frameworks';
 import { displayLocator } from '@/src/locators/display';
 import { ModelStore, activeCandidate, type ModelElement } from '@/src/model';
 import { uniqueName } from '@/src/engine/naming';
-import { isMessage, type ContentToPanel, type PanelToContent } from '@/src/messaging';
+import { isMessage, type BackgroundToPanel, type ContentToPanel, type PanelToContent } from '@/src/messaging';
 import { hostKey } from '@/host/types';
 import { defaultSettings } from '@/src/settings';
 
@@ -86,7 +86,7 @@ function onPanelKey(e: KeyboardEvent) {
 }
 
 host.onTabChanged((next) => {
-  if (isPicking() && tabId.value != null) void send(tabId.value, { type: 'STOP_PICKING' });
+  if (isPicking() && tabId.value != null) send(tabId.value, { type: 'STOP_PICKING' });
   isScanning.value = isAdding.value = false;
   tabId.value = next;
   syncFromStore();
@@ -94,8 +94,8 @@ host.onTabChanged((next) => {
 
 const isPicking = () => isScanning.value || isAdding.value;
 
-async function stopPicking() {
-  if (tabId.value != null) await send(tabId.value, { type: 'STOP_PICKING' });
+function stopPicking() {
+  if (tabId.value != null) send(tabId.value, { type: 'STOP_PICKING' });
   isAdding.value = isScanning.value = false;
 }
 
@@ -132,15 +132,30 @@ async function toggleAdd() {
   const target = tabId.value ?? (await host.getTabId());
   tabId.value = target;
   if (target == null) return;
-  if (await send(target, { type: 'START_PICKING', mode: 'add' })) isAdding.value = true;
+  send(target, { type: 'START_PICKING', mode: 'add' });
+  // Optimistic: TAB_UNREACHABLE resets it if the page cannot be reached.
+  isAdding.value = true;
 }
 
 let idSeq = 0;
 
 browser.runtime.onMessage.addListener((msg: unknown, sender: { tab?: { id?: number } }) => {
   if (!isMessage(msg)) return;
-  // Only this panel's tab. Without it, a DevTools panel would absorb every
-  // other tab's picks.
+
+  // The background has no sender.tab, so it is matched on the tab it names.
+  if ((msg as BackgroundToPanel).type === 'TAB_UNREACHABLE') {
+    if ((msg as BackgroundToPanel).tabId !== tabId.value) return;
+    isAdding.value = isScanning.value = false;
+    notice('unreachable', {
+      message: 'Page Modeller can’t reach this page. Reload the tab, or try a normal http(s) page.',
+      icon: 'block',
+      color: 'negative',
+    });
+    return;
+  }
+
+  // Content traffic: only this panel's tab. Without it, a DevTools panel would
+  // absorb every other tab's picks.
   if (sender.tab?.id !== tabId.value || tabId.value == null) return;
   const m = msg as ContentToPanel;
 
@@ -201,23 +216,32 @@ function deleteModel() {
  * pile up a "12". Each kind of notice keeps one slot and replaces it.
  */
 const openNotices: Record<string, (() => void) | undefined> = {};
+let noticeSeq = 0;
 
 function notice(kind: string, opts: Parameters<typeof $q.notify>[0]) {
   openNotices[kind]?.();
-  openNotices[kind] = $q.notify({ group: false, position: 'bottom', timeout: 3000, ...(opts as object) });
+  openNotices[kind] = $q.notify({
+    position: 'bottom',
+    timeout: 3000,
+    ...(opts as object),
+    // A unique group per call, rather than `group: false`. Quasar groups
+    // notifications by content and badges a count; `false` did not reliably
+    // stop it, and a value nothing else shares cannot be grouped with anything.
+    group: `${kind}-${++noticeSeq}`,
+  });
 }
 
 function clearHighlight() {
   if (tabId.value == null) return;
   // Every frame may clear; only the top one ever draws.
-  void browser.tabs.sendMessage(tabId.value, { type: 'CLEAR_HIGHLIGHT' }).catch(() => {});
+  send(tabId.value, { type: 'CLEAR_HIGHLIGHT' });
 }
 
-async function highlight(id: string) {
+function highlight(id: string) {
   const el = elements.value.find((e) => e.id === id);
   if (!el || tabId.value == null) return;
   // Fire and forget; the count arrives as HIGHLIGHT_RESULT.
-  await send(tabId.value, { type: 'HIGHLIGHT', candidate: activeCandidate(el) });
+  send(tabId.value, { type: 'HIGHLIGHT', candidate: activeCandidate(el) });
 }
 
 function showMatchCount(count: number) {

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -147,11 +147,17 @@ function onRuntimeMessage(msg: unknown) {
 // the last panel has closed, at which point the session is over and the models
 // go (SPEC §5). Disconnect happens on its own when the page unloads, which is
 // what covers closing the sidebar or closing DevTools.
-let port: { disconnect(): void } | undefined;
+let port: { disconnect(): void; postMessage(msg: unknown): void } | undefined;
+
+/** Tell the background which tab this panel is showing (SPEC §5). */
+function reportViewing() {
+  port?.postMessage({ tabId: tabId.value });
+}
 
 onMounted(async () => {
   port = browser.runtime.connect({ name: PANEL_PORT });
   tabId.value = await host.getTabId();
+  reportViewing();
   if (tabId.value != null) toBackground({ type: 'GET_MODEL', tabId: tabId.value });
   // The content script listens for Escape too, but after clicking Add Element
   // focus is in the panel, so the page never sees the keydown. Cover both.
@@ -169,6 +175,7 @@ host.onTabChanged((next) => {
   if (isPicking() && tabId.value != null) send(tabId.value, { type: 'STOP_PICKING' });
   isScanning.value = isAdding.value = false;
   tabId.value = next;
+  reportViewing();
   model.value = emptyModel(defaultFrameworkId);
   if (next != null) toBackground({ type: 'GET_MODEL', tabId: next });
 });

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -37,7 +37,7 @@ import { defaultFrameworkId } from '@/src/frameworks';
 import { displayLocator } from '@/src/locators/display';
 import { ModelStore, activeCandidate, type ModelElement } from '@/src/model';
 import { uniqueName } from '@/src/engine/naming';
-import { isMessage, type BackgroundToPanel, type ContentToPanel, type PanelToContent } from '@/src/messaging';
+import { isMessage, type BackgroundToPanel, type PanelToContent } from '@/src/messaging';
 import { hostKey } from '@/host/types';
 import { defaultSettings } from '@/src/settings';
 
@@ -146,12 +146,12 @@ let idSeq = 0;
  * store and refs are per-instance, so a pick could land in an instance that is
  * no longer rendered — the table simply stayed empty.
  */
-function onRuntimeMessage(msg: unknown, sender: { tab?: { id?: number } }) {
+function onRuntimeMessage(msg: unknown) {
   if (!isMessage(msg)) return;
+  const incoming = msg as BackgroundToPanel;
 
-  // The background has no sender.tab, so it is matched on the tab it names.
-  if ((msg as BackgroundToPanel).type === 'TAB_UNREACHABLE') {
-    if ((msg as BackgroundToPanel).tabId !== tabId.value) return;
+  if (incoming.type === 'TAB_UNREACHABLE') {
+    if (incoming.tabId !== tabId.value) return;
     isAdding.value = isScanning.value = false;
     notice('unreachable', {
       message: 'Page Modeller can’t reach this page. Reload the tab, or try a normal http(s) page.',
@@ -161,10 +161,12 @@ function onRuntimeMessage(msg: unknown, sender: { tab?: { id?: number } }) {
     return;
   }
 
-  // Content traffic: only this panel's tab. Without it, a DevTools panel would
-  // absorb every other tab's picks.
-  if (sender.tab?.id !== tabId.value || tabId.value == null) return;
-  const m = msg as ContentToPanel;
+  // Content traffic arrives re-broadcast from the background with its tab
+  // stamped on it, since sender.tab is not reliable in a DevTools page. Only
+  // this panel's tab, or a DevTools panel would absorb every other tab's picks.
+  if (incoming.type !== 'FROM_TAB') return;
+  if (incoming.tabId !== tabId.value || tabId.value == null) return;
+  const m = incoming.message;
 
   if (m.type === 'ELEMENT_PICKED') {
     const model = store.get(tabId.value);

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -15,7 +15,13 @@
 
     <q-page-container>
       <q-page>
-        <ModelTable :elements="rows" @highlight="highlight" @edit="notYet('Edit')" @remove="removeElement" />
+        <ModelTable
+          :elements="rows"
+          :click-to-highlight="settings.clickTableRowsToViewMatchedElements"
+          @highlight="highlight"
+          @edit="notYet('Edit')"
+          @remove="removeElement"
+        />
       </q-page>
     </q-page-container>
   </q-layout>
@@ -33,10 +39,14 @@ import { ModelStore, activeCandidate, type ModelElement } from '@/src/model';
 import { uniqueName } from '@/src/engine/naming';
 import { isMessage, type ContentToPanel, type HighlightResult, type PickMode } from '@/src/messaging';
 import { hostKey } from '@/host/types';
+import { defaultSettings } from '@/src/settings';
 
 const $q = useQuasar();
 const host = inject(hostKey)!;
 
+// Storage and the options page arrive with REWRITE-PLAN §12 step 13; until then
+// the panel runs on the defaults.
+const settings = ref({ ...defaultSettings });
 const frameworkId = ref(defaultFrameworkId);
 const tabId = ref<number | undefined>();
 const isScanning = ref(false);
@@ -174,6 +184,10 @@ function deleteModel() {
  * in the page, and report the count. Exactly one match is the whole point of
  * the model, so the three outcomes are visually distinct.
  */
+// Quasar groups identical notifications and badges a count, so repeated eye
+// clicks piled up a "4". Each check should replace the last one's answer.
+let dismissMatchCount: (() => void) | undefined;
+
 async function highlight(id: string) {
   const el = elements.value.find((e) => e.id === id);
   if (!el || tabId.value == null) return;
@@ -202,9 +216,11 @@ async function highlight(id: string) {
         ? { icon: 'error', color: 'negative' }
         : { icon: 'warning', color: 'warning' };
 
-  $q.notify({
+  dismissMatchCount?.();
+  dismissMatchCount = $q.notify({
     ...tone,
     message: `${count} element${count === 1 ? '' : 's'} match${count === 1 ? 'es' : ''} that locator`,
+    group: false,
     timeout: 3000,
     position: 'bottom',
     actions: [{ label: 'Close', color: 'white' }],

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -188,6 +188,11 @@ function deleteModel() {
 // clicks piled up a "4". Each check should replace the last one's answer.
 let dismissMatchCount: (() => void) | undefined;
 
+function clearHighlight() {
+  if (tabId.value == null) return;
+  void browser.tabs.sendMessage(tabId.value, { type: 'CLEAR_HIGHLIGHT' }, { frameId: 0 }).catch(() => {});
+}
+
 async function highlight(id: string) {
   const el = elements.value.find((e) => e.id === id);
   if (!el || tabId.value == null) return;
@@ -223,7 +228,12 @@ async function highlight(id: string) {
     group: false,
     timeout: 3000,
     position: 'bottom',
-    actions: [{ label: 'Close', color: 'white' }],
+    // Close takes the highlight with it, so the page is never left marked up
+    // with no explanation. Only on the explicit action: onDismiss would also
+    // fire when this notification is *replaced* by the next eye click, wiping
+    // the highlight that click had just applied. Natural expiry needs no
+    // handler — both timers are 3s.
+    actions: [{ label: 'Close', color: 'white', handler: clearHighlight }],
   });
 }
 

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -99,32 +99,29 @@ function stopPicking() {
   isAdding.value = isScanning.value = false;
 }
 
-async function send(target: number, msg: PanelToContent): Promise<boolean> {
-  try {
-    // Vue wraps reactive state in Proxies, and anything read out of `elements`
-    // is one. Firefox serialises messages with the structured clone algorithm,
-    // which throws DataCloneError on a Proxy; Chrome's path tolerates it. So a
-    // message carrying model data — HIGHLIGHT — failed on Firefox while
-    // START_PICKING, whose payload is a plain literal, worked on the same page.
-    // Messages are plain data, so a JSON round-trip is an exact copy.
-    await browser.tabs.sendMessage(target, JSON.parse(JSON.stringify(msg)) as PanelToContent);
-    return true;
-  } catch (err) {
-    // Surface the reason: the notice below is a guess at the cause, and the
-    // real message is the only way to tell a missing content script from a
-    // messaging fault.
-    console.error('[Page Modeller] sendMessage failed', msg.type, err);
-    // No content script: a browser-internal page, the web store, or a tab that
-    // was already open when the extension loaded.
-    $q.notify({
-      message: 'Page Modeller can’t reach this page. Reload the tab, or try a normal http(s) page.',
-      icon: 'block',
-      color: 'negative',
-      timeout: 3000,
-      position: 'bottom',
-    });
-    return false;
-  }
+/**
+ * Panel → page, always via the background.
+ *
+ * `browser.tabs` is UNDEFINED in a Firefox DevTools panel: a devtools page is
+ * granted only devtools.*, runtime.* and a few others. Calling tabs.sendMessage
+ * there throws "can't access property sendMessage, tabs is undefined", which
+ * the panel reported as an unreachable page. Chrome tolerates the direct call,
+ * so this failed on one surface of one browser.
+ *
+ * Relaying through the background works everywhere, and using it for all three
+ * surfaces keeps one path rather than a working one and a broken one. Delivery
+ * failures come back as TAB_UNREACHABLE — the panel cannot see the
+ * background's rejection.
+ */
+function send(target: number, msg: PanelToContent) {
+  // Vue wraps reactive state in Proxies, and anything read out of `elements` is
+  // one. Firefox serialises messages with structured clone, which throws
+  // DataCloneError on a Proxy; Chrome's path tolerates it. Messages are plain
+  // data, so a JSON round-trip is an exact copy.
+  const message = JSON.parse(JSON.stringify(msg)) as PanelToContent;
+  void browser.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: target, message }).catch((err) => {
+    console.error('[Page Modeller] relay send failed', msg.type, err);
+  });
 }
 
 async function toggleAdd() {

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -37,7 +37,7 @@ import ModelTable, { type ModelRow } from './ModelTable.vue';
 import { defaultFrameworkId } from '@/src/frameworks';
 import { displayLocator } from '@/src/locators/display';
 import { activeCandidate, emptyModel, type TabModel } from '@/src/model';
-import { isMessage, type BackgroundToPanel, type PanelToBackground, type PanelToContent } from '@/src/messaging';
+import { isMessage, PANEL_PORT, type BackgroundToPanel, type PanelToBackground, type PanelToContent } from '@/src/messaging';
 import { hostKey } from '@/host/types';
 import { defaultSettings } from '@/src/settings';
 
@@ -143,7 +143,14 @@ function onRuntimeMessage(msg: unknown) {
   }
 }
 
+// Held open for the panel's lifetime. The background counts these to know when
+// the last panel has closed, at which point the session is over and the models
+// go (SPEC §5). Disconnect happens on its own when the page unloads, which is
+// what covers closing the sidebar or closing DevTools.
+let port: { disconnect(): void } | undefined;
+
 onMounted(async () => {
+  port = browser.runtime.connect({ name: PANEL_PORT });
   tabId.value = await host.getTabId();
   if (tabId.value != null) toBackground({ type: 'GET_MODEL', tabId: tabId.value });
   // The content script listens for Escape too, but after clicking Add Element
@@ -155,6 +162,7 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onPanelKey, true);
   browser.runtime.onMessage.removeListener(onRuntimeMessage);
+  port?.disconnect();
 });
 
 host.onTabChanged((next) => {

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -37,7 +37,7 @@ import { defaultFrameworkId } from '@/src/frameworks';
 import { displayLocator } from '@/src/locators/display';
 import { ModelStore, activeCandidate, type ModelElement } from '@/src/model';
 import { uniqueName } from '@/src/engine/naming';
-import { isMessage, type ContentToPanel, type HighlightResult, type PickMode } from '@/src/messaging';
+import { isMessage, type ContentToPanel, type PanelToContent } from '@/src/messaging';
 import { hostKey } from '@/host/types';
 import { defaultSettings } from '@/src/settings';
 
@@ -99,11 +99,15 @@ async function stopPicking() {
   isAdding.value = isScanning.value = false;
 }
 
-async function send(target: number, msg: { type: 'START_PICKING'; mode: PickMode } | { type: 'STOP_PICKING' }): Promise<boolean> {
+async function send(target: number, msg: PanelToContent): Promise<boolean> {
   try {
     await browser.tabs.sendMessage(target, msg);
     return true;
-  } catch {
+  } catch (err) {
+    // Surface the reason: the notice below is a guess at the cause, and the
+    // real message is the only way to tell a missing content script from a
+    // messaging fault.
+    console.error('[Page Modeller] sendMessage failed', msg.type, err);
     // No content script: a browser-internal page, the web store, or a tab that
     // was already open when the extension loaded.
     $q.notify({
@@ -147,6 +151,8 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: { tab?: { id?: numb
     syncFromStore();
   } else if (m.type === 'PICKING_STOPPED') {
     isAdding.value = isScanning.value = false;
+  } else if (m.type === 'HIGHLIGHT_RESULT') {
+    showMatchCount(m.count);
   }
 });
 
@@ -184,36 +190,31 @@ function deleteModel() {
  * in the page, and report the count. Exactly one match is the whole point of
  * the model, so the three outcomes are visually distinct.
  */
-// Quasar groups identical notifications and badges a count, so repeated eye
-// clicks piled up a "4". Each check should replace the last one's answer.
-let dismissMatchCount: (() => void) | undefined;
+/**
+ * Quasar groups identical notifications and badges a count, so repeated clicks
+ * pile up a "12". Each kind of notice keeps one slot and replaces it.
+ */
+const openNotices: Record<string, (() => void) | undefined> = {};
+
+function notice(kind: string, opts: Parameters<typeof $q.notify>[0]) {
+  openNotices[kind]?.();
+  openNotices[kind] = $q.notify({ group: false, position: 'bottom', timeout: 3000, ...(opts as object) });
+}
 
 function clearHighlight() {
   if (tabId.value == null) return;
-  void browser.tabs.sendMessage(tabId.value, { type: 'CLEAR_HIGHLIGHT' }, { frameId: 0 }).catch(() => {});
+  // Every frame may clear; only the top one ever draws.
+  void browser.tabs.sendMessage(tabId.value, { type: 'CLEAR_HIGHLIGHT' }).catch(() => {});
 }
 
 async function highlight(id: string) {
   const el = elements.value.find((e) => e.id === id);
   if (!el || tabId.value == null) return;
+  // Fire and forget; the count arrives as HIGHLIGHT_RESULT.
+  await send(tabId.value, { type: 'HIGHLIGHT', candidate: activeCandidate(el) });
+}
 
-  let count = 0;
-  try {
-    const res = (await browser.tabs.sendMessage(tabId.value, { type: 'HIGHLIGHT', candidate: activeCandidate(el) }, { frameId: 0 })) as
-      | HighlightResult
-      | undefined;
-    count = res?.count ?? 0;
-  } catch {
-    $q.notify({
-      message: 'Page Modeller can’t reach this page. Reload the tab, or try a normal http(s) page.',
-      icon: 'block',
-      color: 'negative',
-      timeout: 3000,
-      position: 'bottom',
-    });
-    return;
-  }
-
+function showMatchCount(count: number) {
   const tone =
     count === 1
       ? { icon: 'check_circle', color: 'positive' }
@@ -221,16 +222,12 @@ async function highlight(id: string) {
         ? { icon: 'error', color: 'negative' }
         : { icon: 'warning', color: 'warning' };
 
-  dismissMatchCount?.();
-  dismissMatchCount = $q.notify({
+  notice('matchCount', {
     ...tone,
     message: `${count} element${count === 1 ? '' : 's'} match${count === 1 ? 'es' : ''} that locator`,
-    group: false,
-    timeout: 3000,
-    position: 'bottom',
     // Close takes the highlight with it, so the page is never left marked up
-    // with no explanation. Only on the explicit action: onDismiss would also
-    // fire when this notification is *replaced* by the next eye click, wiping
+    // with no explanation. Only on the explicit action: a dismiss handler would
+    // also fire when this notice is *replaced* by the next eye click, wiping
     // the highlight that click had just applied. Natural expiry needs no
     // handler — both timers are 3s.
     actions: [{ label: 'Close', color: 'white', handler: clearHighlight }],
@@ -238,6 +235,6 @@ async function highlight(id: string) {
 }
 
 function notYet(what: string) {
-  $q.notify({ message: `${what} — not built yet`, icon: 'construction', timeout: 1500, position: 'bottom' });
+  notice('notYet', { message: `${what} — not built yet`, icon: 'construction', timeout: 1500 });
 }
 </script>

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -101,7 +101,13 @@ async function stopPicking() {
 
 async function send(target: number, msg: PanelToContent): Promise<boolean> {
   try {
-    await browser.tabs.sendMessage(target, msg);
+    // Vue wraps reactive state in Proxies, and anything read out of `elements`
+    // is one. Firefox serialises messages with the structured clone algorithm,
+    // which throws DataCloneError on a Proxy; Chrome's path tolerates it. So a
+    // message carrying model data — HIGHLIGHT — failed on Firefox while
+    // START_PICKING, whose payload is a plain literal, worked on the same page.
+    // Messages are plain data, so a JSON round-trip is an exact copy.
+    await browser.tabs.sendMessage(target, JSON.parse(JSON.stringify(msg)) as PanelToContent);
     return true;
   } catch (err) {
     // Surface the reason: the notice below is a guess at the cause, and the

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -2,10 +2,11 @@
   <q-layout view="hHh lpR fFf">
     <q-header>
       <AppToolbar
-        v-model:framework-id="frameworkId"
-        :has-model="elements.length > 0"
+        :framework-id="model.frameworkId"
+        :has-model="model.elements.length > 0"
         :is-scanning="isScanning"
         :is-adding="isAdding"
+        @update:framework-id="setFramework"
         @scan="notYet('Scan')"
         @add="toggleAdd"
         @delete-model="deleteModel"
@@ -35,43 +36,116 @@ import AppToolbar from './AppToolbar.vue';
 import ModelTable, { type ModelRow } from './ModelTable.vue';
 import { defaultFrameworkId } from '@/src/frameworks';
 import { displayLocator } from '@/src/locators/display';
-import { ModelStore, activeCandidate, type ModelElement } from '@/src/model';
-import { uniqueName } from '@/src/engine/naming';
-import { isMessage, type BackgroundToPanel, type PanelToContent } from '@/src/messaging';
+import { activeCandidate, emptyModel, type TabModel } from '@/src/model';
+import { isMessage, type BackgroundToPanel, type PanelToBackground, type PanelToContent } from '@/src/messaging';
 import { hostKey } from '@/host/types';
 import { defaultSettings } from '@/src/settings';
 
+// The panel is a VIEW. The background owns the model, one per tab (SPEC §5), so
+// a sidebar and a DevTools panel on the same tab show the same rows and a pick
+// made in one appears in both.
 const $q = useQuasar();
 const host = inject(hostKey)!;
 
 // Storage and the options page arrive with REWRITE-PLAN §12 step 13; until then
 // the panel runs on the defaults.
 const settings = ref({ ...defaultSettings });
-const frameworkId = ref(defaultFrameworkId);
 const tabId = ref<number | undefined>();
+const model = ref<TabModel>(emptyModel(defaultFrameworkId));
 const isScanning = ref(false);
 const isAdding = ref(false);
 
-// One model per tab (SPEC §5). `elements` is a shallow copy of the active tab's
-// list so Vue tracks it; the store owns the real thing.
-const store = new ModelStore();
-const elements = ref<ModelElement[]>([]);
-
-function syncFromStore() {
-  elements.value = tabId.value == null ? [] : [...store.get(tabId.value).elements];
-}
-
 const rows = computed<ModelRow[]>(() =>
-  elements.value.map((el) => ({
+  model.value.elements.map((el) => ({
     id: el.id,
     name: el.name,
-    locator: displayLocator(activeCandidate(el), frameworkId.value),
+    locator: displayLocator(activeCandidate(el), model.value.frameworkId),
   }))
 );
 
+/**
+ * Quasar groups identical notifications and badges a count. Each kind of notice
+ * keeps one slot and replaces it.
+ */
+const openNotices: Record<string, (() => void) | undefined> = {};
+let noticeSeq = 0;
+
+function notice(kind: string, opts: Parameters<typeof $q.notify>[0]) {
+  openNotices[kind]?.();
+  openNotices[kind] = $q.notify({
+    position: 'bottom',
+    timeout: 3000,
+    ...(opts as object),
+    // A unique group per call, rather than `group: false`. Quasar groups by
+    // content and badges a count; `false` did not reliably stop it, and a value
+    // nothing else shares cannot be grouped with anything.
+    group: `${kind}-${++noticeSeq}`,
+  });
+}
+
+/** Every panel → background message. Plain data only; see send(). */
+function toBackground(msg: PanelToBackground) {
+  // Vue wraps reactive state in Proxies, and anything read out of a ref is one.
+  // Firefox serialises messages with structured clone, which throws
+  // DataCloneError on a Proxy; Chrome's path tolerates it. Messages are plain
+  // data, so a JSON round-trip is an exact copy.
+  void browser.runtime.sendMessage(JSON.parse(JSON.stringify(msg))).catch((err) => {
+    console.error('[Page Modeller] background message failed', msg.type, err);
+  });
+}
+
+/**
+ * Panel → page, always via the background. `browser.tabs` is UNDEFINED in a
+ * Firefox DevTools panel — only devtools.*, runtime.* and a few others are
+ * granted there. Delivery failures come back as TAB_UNREACHABLE.
+ */
+function send(target: number, msg: PanelToContent) {
+  toBackground({ type: 'RELAY_TO_TAB', tabId: target, message: msg });
+}
+
+const isPicking = () => isScanning.value || isAdding.value;
+
+function stopPicking() {
+  if (tabId.value != null) send(tabId.value, { type: 'STOP_PICKING' });
+  isAdding.value = isScanning.value = false;
+}
+
+function onPanelKey(e: KeyboardEvent) {
+  if (e.key !== 'Escape' || !isPicking()) return;
+  e.preventDefault();
+  stopPicking();
+}
+
+/**
+ * Registered on mount and removed on unmount. Registering at setup leaked a
+ * listener per instance: on HMR the replaced component kept receiving.
+ */
+function onRuntimeMessage(msg: unknown) {
+  if (!isMessage(msg)) return;
+  const incoming = msg as BackgroundToPanel;
+  // Everything from the background names its tab, because Firefox does not
+  // populate sender.tab for a message delivered to a DevTools page.
+  if (!('tabId' in incoming) || incoming.tabId !== tabId.value || tabId.value == null) return;
+
+  if (incoming.type === 'MODEL') {
+    model.value = incoming.model;
+  } else if (incoming.type === 'TAB_UNREACHABLE') {
+    isAdding.value = isScanning.value = false;
+    notice('unreachable', {
+      message: 'Page Modeller can\u2019t reach this page. Reload the tab, or try a normal http(s) page.',
+      icon: 'block',
+      color: 'negative',
+    });
+  } else if (incoming.type === 'FROM_TAB') {
+    const m = incoming.message;
+    if (m.type === 'PICKING_STOPPED') isAdding.value = isScanning.value = false;
+    else if (m.type === 'HIGHLIGHT_RESULT') showMatchCount(m.count);
+  }
+}
+
 onMounted(async () => {
   tabId.value = await host.getTabId();
-  syncFromStore();
+  if (tabId.value != null) toBackground({ type: 'GET_MODEL', tabId: tabId.value });
   // The content script listens for Escape too, but after clicking Add Element
   // focus is in the panel, so the page never sees the keydown. Cover both.
   window.addEventListener('keydown', onPanelKey, true);
@@ -83,50 +157,13 @@ onBeforeUnmount(() => {
   browser.runtime.onMessage.removeListener(onRuntimeMessage);
 });
 
-function onPanelKey(e: KeyboardEvent) {
-  if (e.key !== 'Escape' || !isPicking()) return;
-  e.preventDefault();
-  void stopPicking();
-}
-
 host.onTabChanged((next) => {
   if (isPicking() && tabId.value != null) send(tabId.value, { type: 'STOP_PICKING' });
   isScanning.value = isAdding.value = false;
   tabId.value = next;
-  syncFromStore();
+  model.value = emptyModel(defaultFrameworkId);
+  if (next != null) toBackground({ type: 'GET_MODEL', tabId: next });
 });
-
-const isPicking = () => isScanning.value || isAdding.value;
-
-function stopPicking() {
-  if (tabId.value != null) send(tabId.value, { type: 'STOP_PICKING' });
-  isAdding.value = isScanning.value = false;
-}
-
-/**
- * Panel → page, always via the background.
- *
- * `browser.tabs` is UNDEFINED in a Firefox DevTools panel: a devtools page is
- * granted only devtools.*, runtime.* and a few others. Calling tabs.sendMessage
- * there throws "can't access property sendMessage, tabs is undefined", which
- * the panel reported as an unreachable page. Chrome tolerates the direct call,
- * so this failed on one surface of one browser.
- *
- * Relaying through the background works everywhere, and using it for all three
- * surfaces keeps one path rather than a working one and a broken one. Delivery
- * failures come back as TAB_UNREACHABLE — the panel cannot see the
- * background's rejection.
- */
-function send(target: number, msg: PanelToContent) {
-  // Vue wraps reactive state in Proxies, and anything read out of `elements` is
-  // one. Firefox serialises messages with structured clone, which throws
-  // DataCloneError on a Proxy; Chrome's path tolerates it. Messages are plain
-  // data, so a JSON round-trip is an exact copy.
-  const message = JSON.parse(JSON.stringify(msg)) as PanelToContent;
-  void browser.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: target, message }).catch((err) => {
-    console.error('[Page Modeller] relay send failed', msg.type, err);
-  });
-}
 
 async function toggleAdd() {
   if (isAdding.value) return stopPicking();
@@ -138,106 +175,9 @@ async function toggleAdd() {
   isAdding.value = true;
 }
 
-let idSeq = 0;
-
-/**
- * Registered on mount and removed on unmount. Registering at setup leaked a
- * listener per instance: on HMR the replaced component kept receiving, and its
- * store and refs are per-instance, so a pick could land in an instance that is
- * no longer rendered — the table simply stayed empty.
- */
-function onRuntimeMessage(msg: unknown) {
-  if (!isMessage(msg)) return;
-  const incoming = msg as BackgroundToPanel;
-
-  if (incoming.type === 'TAB_UNREACHABLE') {
-    if (incoming.tabId !== tabId.value) return;
-    isAdding.value = isScanning.value = false;
-    notice('unreachable', {
-      message: 'Page Modeller can’t reach this page. Reload the tab, or try a normal http(s) page.',
-      icon: 'block',
-      color: 'negative',
-    });
-    return;
-  }
-
-  // Content traffic arrives re-broadcast from the background with its tab
-  // stamped on it, since sender.tab is not reliable in a DevTools page. Only
-  // this panel's tab, or a DevTools panel would absorb every other tab's picks.
-  if (incoming.type !== 'FROM_TAB') return;
-  if (incoming.tabId !== tabId.value || tabId.value == null) return;
-  const m = incoming.message;
-
-  if (m.type === 'ELEMENT_PICKED') {
-    const model = store.get(tabId.value);
-    model.elements.push({
-      ...m.result,
-      id: `el-${idSeq++}`,
-      name: uniqueName(m.result.suggestedName, model.usedNames),
-      selectedIndex: m.result.preferredIndex >= 0 ? m.result.preferredIndex : 0,
-    });
-    // Picking is one-shot (SPEC §4); the content script has already stopped.
-    isAdding.value = isScanning.value = false;
-    syncFromStore();
-  } else if (m.type === 'PICKING_STOPPED') {
-    isAdding.value = isScanning.value = false;
-  } else if (m.type === 'HIGHLIGHT_RESULT') {
-    showMatchCount(m.count);
-  }
-}
-
-function removeElement(id: string) {
-  const el = elements.value.find((e) => e.id === id);
-  if (!el || tabId.value == null) return;
-  $q.dialog({
-    title: 'Delete Element',
-    message: `Really delete ${el.name}?`,
-    cancel: true,
-    ok: { label: 'Yes', flat: true },
-  }).onOk(() => {
-    const model = store.get(tabId.value!);
-    model.elements = model.elements.filter((e) => e.id !== id);
-    model.usedNames.delete(el.name);
-    syncFromStore();
-  });
-}
-
-function deleteModel() {
+function setFramework(frameworkId: string) {
   if (tabId.value == null) return;
-  $q.dialog({
-    title: 'Delete Model',
-    message: 'Really delete the model?',
-    cancel: true,
-    ok: { label: 'Yes', flat: true },
-  }).onOk(() => {
-    store.clear(tabId.value!);
-    syncFromStore();
-  });
-}
-
-/**
- * View Matched Elements (SPEC §8): run the locator live, highlight every match
- * in the page, and report the count. Exactly one match is the whole point of
- * the model, so the three outcomes are visually distinct.
- */
-/**
- * Quasar groups identical notifications and badges a count, so repeated clicks
- * pile up a "12". Each kind of notice keeps one slot and replaces it.
- */
-const openNotices: Record<string, (() => void) | undefined> = {};
-let noticeSeq = 0;
-
-function notice(kind: string, opts: Parameters<typeof $q.notify>[0]) {
-  openNotices[kind]?.();
-  openNotices[kind] = $q.notify({
-    position: 'bottom',
-    timeout: 3000,
-    ...(opts as object),
-    // A unique group per call, rather than `group: false`. Quasar groups
-    // notifications by content and badges a count; `false` did not reliably
-    // stop it, and a value nothing else shares cannot be grouped with anything.
-    group: `${kind}-${++noticeSeq}`,
-  });
+  toBackground({ type: 'SET_FRAMEWORK', tabId: tabId.value, frameworkId });
 }
 
 function clearHighlight() {
@@ -247,7 +187,7 @@ function clearHighlight() {
 }
 
 function highlight(id: string) {
-  const el = elements.value.find((e) => e.id === id);
+  const el = model.value.elements.find((e) => e.id === id);
   if (!el || tabId.value == null) return;
   // Fire and forget; the count arrives as HIGHLIGHT_RESULT.
   send(tabId.value, { type: 'HIGHLIGHT', candidate: activeCandidate(el) });
@@ -266,11 +206,31 @@ function showMatchCount(count: number) {
     message: `${count} element${count === 1 ? '' : 's'} match${count === 1 ? 'es' : ''} that locator`,
     // Close takes the highlight with it, so the page is never left marked up
     // with no explanation. Only on the explicit action: a dismiss handler would
-    // also fire when this notice is *replaced* by the next eye click, wiping
-    // the highlight that click had just applied. Natural expiry needs no
-    // handler — both timers are 3s.
+    // also fire when this notice is replaced by the next eye click, wiping the
+    // highlight that click had just applied.
     actions: [{ label: 'Close', color: 'white', handler: clearHighlight }],
   });
+}
+
+function removeElement(id: string) {
+  const el = model.value.elements.find((e) => e.id === id);
+  if (!el || tabId.value == null) return;
+  $q.dialog({
+    title: 'Delete Element',
+    message: `Really delete ${el.name}?`,
+    cancel: true,
+    ok: { label: 'Yes', flat: true },
+  }).onOk(() => toBackground({ type: 'DELETE_ELEMENT', tabId: tabId.value!, id }));
+}
+
+function deleteModel() {
+  if (tabId.value == null) return;
+  $q.dialog({
+    title: 'Delete Model',
+    message: 'Really delete the model?',
+    cancel: true,
+    ok: { label: 'Yes', flat: true },
+  }).onOk(() => toBackground({ type: 'DELETE_MODEL', tabId: tabId.value! }));
 }
 
 function notYet(what: string) {

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -75,9 +75,13 @@ onMounted(async () => {
   // The content script listens for Escape too, but after clicking Add Element
   // focus is in the panel, so the page never sees the keydown. Cover both.
   window.addEventListener('keydown', onPanelKey, true);
+  browser.runtime.onMessage.addListener(onRuntimeMessage);
 });
 
-onBeforeUnmount(() => window.removeEventListener('keydown', onPanelKey, true));
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onPanelKey, true);
+  browser.runtime.onMessage.removeListener(onRuntimeMessage);
+});
 
 function onPanelKey(e: KeyboardEvent) {
   if (e.key !== 'Escape' || !isPicking()) return;
@@ -136,7 +140,13 @@ async function toggleAdd() {
 
 let idSeq = 0;
 
-browser.runtime.onMessage.addListener((msg: unknown, sender: { tab?: { id?: number } }) => {
+/**
+ * Registered on mount and removed on unmount. Registering at setup leaked a
+ * listener per instance: on HMR the replaced component kept receiving, and its
+ * store and refs are per-instance, so a pick could land in an instance that is
+ * no longer rendered — the table simply stayed empty.
+ */
+function onRuntimeMessage(msg: unknown, sender: { tab?: { id?: number } }) {
   if (!isMessage(msg)) return;
 
   // The background has no sender.tab, so it is matched on the tab it names.
@@ -172,7 +182,7 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: { tab?: { id?: numb
   } else if (m.type === 'HIGHLIGHT_RESULT') {
     showMatchCount(m.count);
   }
-});
+}
 
 function removeElement(id: string) {
   const el = elements.value.find((e) => e.id === id);

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -15,7 +15,7 @@
 
     <q-page-container>
       <q-page>
-        <ModelTable :elements="rows" @highlight="notYet('View Matched Elements')" @edit="notYet('Edit')" @remove="removeElement" />
+        <ModelTable :elements="rows" @highlight="highlight" @edit="notYet('Edit')" @remove="removeElement" />
       </q-page>
     </q-page-container>
   </q-layout>
@@ -31,7 +31,7 @@ import { defaultFrameworkId } from '@/src/frameworks';
 import { displayLocator } from '@/src/locators/display';
 import { ModelStore, activeCandidate, type ModelElement } from '@/src/model';
 import { uniqueName } from '@/src/engine/naming';
-import { isMessage, type ContentToPanel, type PickMode } from '@/src/messaging';
+import { isMessage, type ContentToPanel, type HighlightResult, type PickMode } from '@/src/messaging';
 import { hostKey } from '@/host/types';
 
 const $q = useQuasar();
@@ -166,6 +166,48 @@ function deleteModel() {
   }).onOk(() => {
     store.clear(tabId.value!);
     syncFromStore();
+  });
+}
+
+/**
+ * View Matched Elements (SPEC §8): run the locator live, highlight every match
+ * in the page, and report the count. Exactly one match is the whole point of
+ * the model, so the three outcomes are visually distinct.
+ */
+async function highlight(id: string) {
+  const el = elements.value.find((e) => e.id === id);
+  if (!el || tabId.value == null) return;
+
+  let count = 0;
+  try {
+    const res = (await browser.tabs.sendMessage(tabId.value, { type: 'HIGHLIGHT', candidate: activeCandidate(el) }, { frameId: 0 })) as
+      | HighlightResult
+      | undefined;
+    count = res?.count ?? 0;
+  } catch {
+    $q.notify({
+      message: 'Page Modeller can’t reach this page. Reload the tab, or try a normal http(s) page.',
+      icon: 'block',
+      color: 'negative',
+      timeout: 3000,
+      position: 'bottom',
+    });
+    return;
+  }
+
+  const tone =
+    count === 1
+      ? { icon: 'check_circle', color: 'positive' }
+      : count === 0
+        ? { icon: 'error', color: 'negative' }
+        : { icon: 'warning', color: 'warning' };
+
+  $q.notify({
+    ...tone,
+    message: `${count} element${count === 1 ? '' : 's'} match${count === 1 ? 'es' : ''} that locator`,
+    timeout: 3000,
+    position: 'bottom',
+    actions: [{ label: 'Close', color: 'white' }],
   });
 }
 

--- a/v3/ui/ModelTable.vue
+++ b/v3/ui/ModelTable.vue
@@ -16,7 +16,8 @@
           v-for="el in elements"
           :key="el.id"
           class="pm-row"
-          @click="$emit('highlight', el.id)"
+          :class="{ clickable: clickToHighlight }"
+          @click="clickToHighlight && $emit('highlight', el.id)"
           @dblclick="$emit('edit', el.id)"
         >
           <td class="col-name">{{ el.name }}</td>
@@ -49,7 +50,11 @@ export interface ModelRow {
   locator: string;
 }
 
-defineProps<{ elements: ModelRow[] }>();
+defineProps<{
+  elements: ModelRow[];
+  /** Single-click a row runs View Matched Elements — off by default (SPEC §6). */
+  clickToHighlight: boolean;
+}>();
 
 defineEmits<{
   highlight: [id: string];
@@ -114,6 +119,10 @@ td {
 .pm-row {
   cursor: default;
   user-select: none;
+}
+
+.pm-row.clickable {
+  cursor: pointer;
 }
 
 .pm-row:hover {

--- a/v3/vitest.config.ts
+++ b/v3/vitest.config.ts
@@ -1,8 +1,23 @@
 import { defineConfig } from 'vitest/config';
+import vue from '@vitejs/plugin-vue';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      // Mirrors WXT's alias so component tests import the way the app does.
+      '@': fileURLToPath(new URL('.', import.meta.url)),
+      // Outside a Vite dev server, `quasar` resolves to the SSR build, which
+      // refuses to install without an ssrContext. @quasar/vite-plugin sets this
+      // alias when serving; Vitest needs it set explicitly.
+      quasar: 'quasar/dist/quasar.client.js',
+    },
+  },
   test: {
     include: ['tests/unit/**/*.test.ts'],
+    // Pure-core tests declare nothing and run in node; component tests opt in
+    // with `// @vitest-environment jsdom`.
     environment: 'node',
   },
 });


### PR DESCRIPTION
`REWRITE-PLAN.md` §12 step 7 (SPEC §8). The eye runs the locator live in the page, highlights every match in yellow with a red outline, scrolls the first into view, and reports the count — green for 1, red for 0, amber for more. Highlight clears after ~3s.

## The interesting part isn't the overlay

You flagged that the matched-elements engine would need real smarts around things like `exact`. It did — more than I expected, and I couldn't have reasoned my way to it.

The in-page resolver is *our own approximation* of Playwright's matching, and the eye reports from it. If it drifts, we show the user a number their test won't reproduce. So the fidelity spec now asserts **every candidate's** predicted count against real Playwright, not just the preferred one. It found three divergences on the first run:

| Divergence | Cause |
|---|---|
| `exact` ignored entirely | Every comparison was `===`. Harmless while we only *emit* `exact: true` — but the Edit dialog is about to let people hand-edit locators. |
| `role predicted 9, Playwright resolved 7` | `getByRole` defaults to `includeHidden: false`, so `display:none` and `aria-hidden` buttons were inflating our count. The same ARIA tree exclusion as SPEC §4. |
| `text predicted 2, Playwright resolved 1` | Playwright matches the *smallest* element containing the text, so a `<fieldset>` was matching alongside its `<legend>`. |

`exact` now means what Playwright means: `true` is case-sensitive whole-string, the default is case-insensitive substring, whitespace normalised either way (exact match still trims; text matching collapses runs and turns line breaks into spaces). Verified against the docs, not from memory.

The IR gains `exact` on `placeholder`, `altText` and `title` — Playwright supports it there and we were silently dropping it.

## One deliberate asymmetry

Display renders `exact` **faithfully** rather than forcing it. Generation guarantees `exact: true` (§12); the renderer's job is to show what the locator actually does, because a hand-edited one may want the substring default and the table must not lie about it. My original test asserted the opposite and was wrong.

## Frames

`HIGHLIGHT` targets the main frame only. The content script runs in every frame and `tabs.sendMessage` delivers just the first reply — so a frame with no matches could answer for one that has them. Cross-frame highlighting arrives with SPEC §16.

## Tests

- Fidelity: 43 elements × every candidate, counts compared against real Playwright.
- 10 new unit assertions pinning `matchesText` semantics in both modes.
- Full gate green.

## Hand-test

The eye on rows: yellow fill + red outline on every match, first one scrolled into view, three-state snackbar, highlight gone after ~3s. Row *click* deliberately does nothing — that's setting-gated (`clickTableRowsToViewMatchedElements`, default off) and settings aren't built yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)