### PR TITLE
Spike 6: Firefox E2E is not reachable with playwright-webextext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,8 @@ exploited.
 
 - **`browser.tabs` is undefined in a Firefox DevTools panel.** A devtools page is granted only
   `devtools.*`, `runtime.*` and a few others. Chrome tolerates the direct call, so a regression is
-  invisible on Chrome and in every test we can run — Playwright cannot load a Firefox extension. The
-  panel goes through the background relay (`RELAY_TO_TAB`); a unit test scans `ui/` to keep it that way.
+  invisible on Chrome and in every test we can run. The panel goes through the background relay
+  (`RELAY_TO_TAB`); a unit test scans `ui/` to keep it that way.
 - **`sender.tab` is not reliable in a Firefox DevTools page.** A content script's `runtime.sendMessage`
   arrives without it, so a `sender.tab.id === myTab` filter silently drops every message. The background
   always sees the sender, so it stamps the tab and re-broadcasts as `FROM_TAB`; panels filter on that.
@@ -90,6 +90,11 @@ exploited.
   in `ui/App.vue` JSON round-trips for this reason; anything bypassing it must do the same.
 
 ## Verification — manual testing is the completion gate
+
+**Firefox has no automated coverage, and cannot easily get any.** Playwright *installs* a Firefox
+extension fine (`playwright-webextext`), but Juggler cannot navigate to `moz-extension://` pages, so the
+panel is undrivable — see `docs/v3/spikes/SPIKE6-FIREFOX-E2E.md`. Every cross-browser bug so far passed
+the Chrome suite. Hand-test Firefox.
 
 **Automated tests are a net, not the criterion for done.** Nothing is complete until it has been
 exercised by hand in a real browser, on real pages, across browsers and varied DOM structures. Do not

--- a/docs/v3/spikes/SPIKE6-FIREFOX-E2E.md
+++ b/docs/v3/spikes/SPIKE6-FIREFOX-E2E.md
@@ -1,0 +1,61 @@
+# Spike 6 — Automating Firefox extension tests
+
+**Question.** Can Playwright drive the extension on Firefox, so hand-testing stops being the only
+Firefox gate? Every cross-browser bug found so far passed the Chrome suite.
+
+**Answer: not with `playwright-webextext`.** The extension installs; its *pages* are unreachable.
+
+## What was tried
+
+[`playwright-webextext`](https://github.com/ueokande/playwright-webextext) (7.3k weekly downloads),
+which installs an unpacked add-on over Firefox's Remote Debugging Protocol via `installTemporaryAddon`
+— no signing, and no patching of Playwright's bundled Firefox. Firefox assigns a random internal UUID
+per profile, so `moz-extension://` URLs were pinned with the `extensions.webextensions.uuids` pref,
+which needs the stable `gecko.id` the manifest already carries.
+
+## Result
+
+| Navigation target | Outcome |
+|---|---|
+| Bogus extension UUID | fails in **2 ms** — `NS_ERROR_NOT_AVAILABLE` |
+| Our pinned UUID, `sidepanel.html` | **times out** (6 s), `load` and `commit` alike |
+| Our pinned UUID, a file that does not exist | times out (6 s) |
+| An ordinary web page | loads in 108 ms |
+
+The timing is the finding. Firefox rejects an unknown extension UUID instantly, so ours not being
+rejected proves **the add-on installed and the UUID pref took effect**. Navigation under it then hangs:
+Juggler, Playwright's Firefox protocol, never reports it. This is exactly what DuckDuckGo's
+[`firefox-webext-playwright-harness`](https://github.com/duckduckgo/firefox-webext-playwright-harness)
+patches `omni.ja` in place to fix — *"let Juggler interact with `moz-extension://` pages"*.
+
+## Why content-script-only coverage is not a consolation prize
+
+The obvious fallback is to skip the panel and test the content script. It does not work either: the
+content script does nothing until a message tells it to, and sending one requires an extension context
+— a panel page or the background — which is the thing that cannot be reached. The DDG harness solves
+this by evaluating in the background over RDP.
+
+It would also have caught nothing. All four Firefox bugs found by hand were panel-side:
+
+- `browser.tabs` is undefined in a DevTools panel
+- `sender.tab` is not populated for a message delivered to one
+- Vue reactive proxies fail structured clone
+- `sendResponse` + `return true` is not portable
+
+## Options not taken
+
+- **The DDG harness.** Would work — it patches Firefox precisely for this. But it is unpublished, zero
+  stars, ships a privileged XPCOM extension for network interception we do not need, patches a binary
+  in place, and its author writes: *"I don't recommend using this for anything important for now."*
+- **WebDriver BiDi / geckodriver.** `webExtension.install` is in the [BiDi
+  spec](https://w3c.github.io/webdriver-bidi/) and the limitation above is Juggler-specific, not a
+  Firefox one — Marionette navigates to `moz-extension://` routinely, which is how Selenium suites test
+  extension option pages. A separate runner alongside Playwright, so a real cost, but no patched
+  binaries. **The remaining candidate if this becomes worth revisiting.**
+
+## Consequence
+
+`Playwright cannot load a Firefox extension` was imprecise and is corrected in CLAUDE.md: it loads
+fine, but its pages cannot be driven. Firefox stays a hand-testing gate, and the structural unit tests
+that stand in for it — scanning `ui/` for `browser.tabs`, and for Quasar utility-class collisions —
+earn their place because they are the only automated cover for rules Chrome cannot exercise.


### PR DESCRIPTION
Docs only — the dependency was installed, tested, and removed.

**Question:** can Playwright drive the extension on Firefox, so hand-testing stops being the only Firefox gate? Worth asking, because every cross-browser bug found so far passed the Chrome suite.

**Answer: not with `playwright-webextext`.** The extension installs; its *pages* are unreachable.

## The evidence

[`playwright-webextext`](https://github.com/ueokande/playwright-webextext) (7.3k weekly downloads) installs an unpacked add-on over Firefox's RDP via `installTemporaryAddon` — no signing, no patched binary. Firefox randomises the internal UUID per profile, so I pinned it with the `extensions.webextensions.uuids` pref, which works because the manifest already carries a stable `gecko.id`.

| Navigation target | Outcome |
|---|---|
| Bogus extension UUID | fails in **2 ms** — `NS_ERROR_NOT_AVAILABLE` |
| Our pinned UUID, `sidepanel.html` | **times out** (6 s), `load` and `commit` alike |
| Our pinned UUID, a nonexistent file | times out (6 s) |
| An ordinary web page | loads in 108 ms |

The timing is the finding. Firefox rejects an unknown UUID instantly, so ours *not* being rejected proves the add-on installed and the pref took. Navigation under it then hangs — Juggler never reports it. That's exactly what DuckDuckGo's harness patches `omni.ja` in place to fix: *"let Juggler interact with `moz-extension://` pages."*

## Content-script-only isn't a consolation prize

The obvious fallback — skip the panel, test the content script — doesn't work either. The content script does nothing until messaged, and sending a message needs an extension context, which is the thing that can't be reached.

It would also have caught nothing. All four Firefox bugs found by hand this week were panel-side: `browser.tabs` undefined in a DevTools panel; `sender.tab` not populated there; Vue proxies failing structured clone; `sendResponse` + `return true` not being portable.

## Options not taken

- **The DDG harness** would work — it patches Firefox precisely for this. But it's unpublished, zero stars, ships a privileged XPCOM extension for network interception we don't need, patches a binary in place, and its author says *"I don't recommend using this for anything important for now."*
- **WebDriver BiDi / geckodriver** is the remaining candidate. `webExtension.install` is in the spec, and this limitation is *Juggler's*, not Firefox's — Marionette navigates to `moz-extension://` routinely, which is how Selenium suites test extension option pages. It means a second runner alongside Playwright, so a real cost, but nothing patched.

## What changes

`docs/v3/spikes/SPIKE6-FIREFOX-E2E.md`, and a correction in CLAUDE.md. I'd been asserting "Playwright cannot load a Firefox extension" — imprecise. It loads fine; its pages can't be driven. CLAUDE.md now says so, and states plainly that Firefox must be hand-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)