### PR TITLE
v3: Edit Element dialog

### DIFF
--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -338,7 +338,14 @@ before starting the next.
    innermost element only. The fidelity spec now asserts **every** candidate's predicted count against
    real Playwright, not just the preferred one — which is how those three were found.
 
-8. **Edit dialog** (SPEC §9) and **Delete Model** (SPEC §10).
+8. **Edit dialog** (SPEC §9) and **Delete Model** (SPEC §10). ✅ **Done** — `ui/EditElementDialog.vue`,
+   with per-type fields (`src/locators/fields.ts`) so `getByRole`'s role + name is expressible.
+   Delete Model landed earlier.
+
+   The IR gained Selenium's `id`, `name`, `className`, `tagName`, `linkText` and `partialLinkText`,
+   with resolution so the eye can test them. The engine still does not *generate* them — that is the
+   superset generator below — but the dialog offers the full framework list, so the model has to be
+   able to hold a hand-typed one.
 
 9. **Scan** (SPEC §4). Container pick, interactive-role descendants, a11y-tree filtered.
 

--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -347,16 +347,25 @@ before starting the next.
    superset generator below — but the dialog offers the full framework list, so the model has to be
    able to hold a hand-typed one.
 
-9. **Scan** (SPEC §4). Container pick, interactive-role descendants, a11y-tree filtered.
+9. **Ancestor navigation while picking** (SPEC §4). Arrow keys walk the target up and down the DOM,
+   with a breadcrumb of the chain replacing the single overlay label. The mouse alone cannot reliably
+   hit a nested element: a wrapper `<div>` and the `<div role="button">` inside it share a bounding box,
+   and selecting the wrapper meant finding a 2px sliver of padding.
 
-10. **Generate Code** (SPEC §11). Selenium Java first — the reference template — with the six fixes.
+   **Before Scan, deliberately.** Scan's whole job is picking a *container*, and containers are exactly
+   the nested, same-box elements this fixes — building Scan first would ship a feature whose primary
+   interaction is the one we know is broken.
 
-11. **Playwright** (SPEC §12). Structured locators, ancestor scoping, `exact: true`. The primary target
+10. **Scan** (SPEC §4). Container pick, interactive-role descendants, a11y-tree filtered.
+
+11. **Generate Code** (SPEC §11). Selenium Java first — the reference template — with the six fixes.
+
+12. **Playwright** (SPEC §12). Structured locators, ancestor scoping, `exact: true`. The primary target
     going forward, so it gets its own step rather than riding along with the other generators.
 
-12. **Remaining generators** — Selenium C#/Python, Puppeteer, Playwright Python.
+13. **Remaining generators** — Selenium C#/Python, Puppeteer, Playwright Python.
 
-13. **Frames** (SPEC §16), **settings** (SPEC §14), **page-object wrapper** (SPEC §17).
+14. **Frames** (SPEC §16), **settings** (SPEC §14), **page-object wrapper** (SPEC §17).
 
 **Release blocker:** `browser_specific_settings.gecko.id` is a placeholder. The real AMO id must replace
 it or an upload creates a second listing instead of updating the existing one (NFR-6).

--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -325,10 +325,10 @@ before starting the next.
 6. **Naming** (SPEC §13). ✅ **Done** — `src/engine/naming.ts`, split so `baseName` runs in the page and
    `uniqueName` in the panel.
 
-   **Gap: the engine only generates Playwright strategies.** No `id`, `name`, `linkText`,
-   `partialLinkText`, `className` or `tagName`, so selecting a Selenium target today yields `css:` for
-   everything. Needs a superset generator with per-framework filtering, as v2.5.1 had. Do this before
-   step 10.
+   ✅ **Superset generator done.** The engine emits Selenium's `id`, `name`, `className`, `tagName`,
+   `linkText` and `partialLinkText` alongside the Playwright strategies, and `src/locators/select.ts`
+   picks the first candidate the chosen framework can express. The fidelity spec verifies the new kinds
+   against Playwright's equivalent selectors.
 
 7. **View Matched Elements** (SPEC §8). ✅ **Done** — the eye: highlight all, scroll to first,
    three-state snackbar. Awaiting hand-test.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -185,8 +185,18 @@ candidate against real Playwright rather than reasoning about it:
 
 ## 9. Edit dialog
 
-Title **Edit Element**. Fields: **Name** · locator **type** dropdown · editable locator **value** · eye.
+Title **Edit Element**. Fields: **Name** · locator **type** dropdown · the fields that type needs · eye.
 CANCEL / SAVE. **[settled]**
+
+- **Name** is required, unique within the model, and cannot contain spaces — v2.5.1's rules.
+- **Type** offers the full framework list (§7). Switching to a type the engine generated fills the
+  fields in; switching to one it did not leaves them blank to type.
+- The **eye** tests what is currently in the fields, not what is saved, so a locator can be checked
+  before committing to it.
+- A hand-edited locator that happens to equal a generated one is stored as that **selection** rather
+  than an override, so it keeps tracking the engine's own verification.
+- `exact: true` survives editing. The dialog does not expose `exact`, so dropping it on save would
+  quietly loosen the locator (§12).
 
 ## 10. Delete Model
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -198,7 +198,10 @@ CANCEL / SAVE. **[settled]**
 - **Type** offers the full framework list (§7). Switching to a type the engine generated fills the
   fields in; switching to one it did not leaves them blank to type.
 - The **eye** tests what is currently in the fields, not what is saved, so a locator can be checked
-  before committing to it.
+  before committing to it. It is **disabled, along with Save, while a required field is blank** — blank
+  does not mean "match anything": an empty `label` matches every control with no accessible name.
+  `getByRole`'s accessible name is the one optional field, since `getByRole('navigation')` is a real
+  locator.
 - A hand-edited locator that happens to equal a generated one is stored as that **selection** rather
   than an override, so it keeps tracking the engine's own verification.
 - `exact: true` survives editing. The dialog does not expose `exact`, so dropping it on save would

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -40,6 +40,12 @@ does not exist in Playwright). The user knows their target before they start.
 
 ## 4. Capture
 
+**The overlay labels what you are about to pick** — the computed role, then the accessible name, with
+the tag shown only when it differs from the role: `button "Save"`, `button (div) "Log in"`, or plain
+`div` for a wrapper. It previews the locator rather than naming the tag, which matters because a wrapper
+`<div>` and the `<div role="button">` inside it have the same bounding box and both used to read `div`.
+**[settled]**
+
 **Scan Page** — pick a *container*: the whole page or any subsection (typically a `div` or `form`). Its
 **interactive descendants** enter the model. Non-interactive elements (`p`, `span`, …) are skipped. The
 container itself is not added, only children. Scan is **once per model**; Add is how you extend it.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -168,6 +168,12 @@ locator can be tested before saving. **[settled]**
 | 0 | red error | *0 elements match that locator* |
 | >1 | amber warning | *N elements match that locator* |
 
+**Every candidate must find the element it was generated from.** A locator can be well-formed, resolve
+to something, and still be useless: `getByRole` excludes a11y-hidden elements, so a hidden button's role
+candidate finds the *other* buttons; `getByText` matches the innermost element, so a `<fieldset>`'s text
+candidate finds its `<legend>`. Candidates that do not find their own element are dropped rather than
+offered in the Edit dialog. **[settled]**
+
 **The count has to be the count the generated test will get.** The in-page resolver is our own
 approximation of Playwright's matching, and the eye reports from it, so any drift means showing the user
 a number their test will not reproduce. Three behaviours this forces, all found by asserting every

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -151,6 +151,15 @@ Empty state: *"Scan the page or start adding elements to build the model"*.
 
 ## 7. Locators
 
+**The engine generates a superset** — every strategy it can find, Playwright's and Selenium's alike —
+and the framework decides which are expressible. The candidate an element *starts on* is the first, in
+the framework's own order of preference, that the framework can express and that resolves uniquely.
+
+This matters more than it sounds. Without it a Selenium model selected `getByRole`, displayed it as
+`role: heading — Google`, and the eye reported *1 element matches* — because the in-page resolver
+understands roles even though Selenium cannot express one. A green tick on a locator that cannot exist
+in the target framework is worse than no check at all. **[settled]**
+
 Each element carries the set of locators that were **generated and matched** for it. The type dropdown
 offers the **full framework list**, not just the generated ones — selecting a type with no generated
 value leaves the value field **blank** for the user to type. The generated set is a convenience, never a
@@ -305,6 +314,8 @@ Puppeteer: `css, xpath`. Robot Framework and Protractor are dropped.
 
 Playwright: `testId, role, label, placeholder, text, altText, title, css, xpath` **[inferred]** — the
 engine's existing ranking, testId first as the most change-resistant.
+
+These lists are also the **order of preference** for choosing an element's starting locator (§7).
 
 ## 12. Playwright
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -130,9 +130,15 @@ it is deleted, so the panel needs to say the model has gone stale.
 
 **Stale models and hidden elements are one problem, not two.** Both end in the eye reporting *0 elements
 match* when nothing is actually wrong — the model was built on another page, or the element is
-deliberately not rendered yet. One mechanism covers both: the model records the URL it was built against,
-the panel shows a stale banner when the tab has navigated away from it, and the 0-match snackbar names
-the likely reason rather than just the count. **[inferred]**
+deliberately not rendered yet.
+
+The model records the URL of the page its first element came from, and the **background** decides
+staleness on `tabs.onUpdated`, because a DevTools panel cannot read the tab's URL for itself. The panel
+shows a banner naming that page, with **Delete Model** to hand — the model also blocks scanning the new
+page, since scan is once-per-model (§4). Navigating back makes the model current again rather than
+leaving it flagged. **[settled]**
+
+Still to do: the 0-match snackbar naming the likely reason rather than just the count. **[inferred]**
 
 ## 6. Model table
 

--- a/v3/README.md
+++ b/v3/README.md
@@ -81,16 +81,19 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    the count — green for 1, red for 0, amber for more. Highlight clears after ~3s, or at once on
    **Close**. Clicking it repeatedly replaces the message rather than stacking a counter badge, and the
    new highlight survives the replacement.
-9. **Clicking a row** does nothing — that is setting-gated and off by default (SPEC §6). Double-click
+9. **Edit** (pencil or double-click): name validation rejects blank, spaced and duplicate names;
+   switching type fills the fields from a generated locator or blanks them; the eye tests what is
+   typed; Save updates the row in **both** surfaces.
+10. **Clicking a row** does nothing — that is setting-gated and off by default (SPEC §6). Double-click
    still opens the editor.
-10. **Both surfaces at once**: open the sidebar and the DevTools panel on one tab — they show the same
+11. **Both surfaces at once**: open the sidebar and the DevTools panel on one tab — they show the same
     rows, and a pick in either appears in both. Close one; the model survives in the other. Close them
     all and reopen; that tab's model is gone. Check this with a second tab modelled too — closing one
     tab's panels must not touch the other's.
-11. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
+12. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
    switch to B, add something different, switch back — A must be intact.
-12. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
-13. Table headers stay visible at the narrowest side-panel width.
+13. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
+14. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the
 engine was validated on — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a

--- a/v3/README.md
+++ b/v3/README.md
@@ -92,8 +92,10 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
     tab's panels must not touch the other's.
 12. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
    switch to B, add something different, switch back — A must be intact.
-13. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
-14. Table headers stay visible at the narrowest side-panel width.
+13. **Navigate within a tab** with a model built: a banner names the page it was built on and offers
+    Delete Model. Navigate back and the banner clears.
+14. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
+15. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the
 engine was validated on — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -114,6 +114,19 @@ export default defineBackground(() => {
         publish(m.tabId, model);
         return;
       }
+      case 'UPDATE_ELEMENT': {
+        const model = store.get(m.tabId);
+        const el = model.elements.find((e) => e.id === m.id);
+        if (!el) return;
+        el.name = m.name;
+        el.selectedIndex = m.selectedIndex;
+        // Absent means "use the generated candidate again", so it must be
+        // deleted rather than set to undefined — the model is serialised.
+        if (m.override) el.override = m.override;
+        else delete el.override;
+        publish(m.tabId, model);
+        return;
+      }
       case 'DELETE_MODEL':
         store.clear(m.tabId);
         publish(m.tabId, store.get(m.tabId));

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -3,6 +3,7 @@ import { isMessage, PANEL_PORT, type Message, type PanelViewing } from '@/src/me
 import { ModelStore, usedNames, type TabModel } from '@/src/model';
 import { uniqueName } from '@/src/engine/naming';
 import { defaultFrameworkId } from '@/src/frameworks';
+import { chooseCandidate } from '@/src/locators/select';
 
 // Background service worker / event page.
 //
@@ -94,7 +95,9 @@ export default defineBackground(() => {
           ...m.result,
           id: `el-${idSeq++}`,
           name: uniqueName(m.result.suggestedName, usedNames(model)),
-          selectedIndex: m.result.preferredIndex >= 0 ? m.result.preferredIndex : 0,
+          // Not the engine's preferredIndex: that is framework-agnostic, and
+          // would hand a Selenium model a Playwright-only locator.
+          selectedIndex: chooseCandidate(m.result.candidates, model.frameworkId),
         });
         publish(tabId, model);
         // Picking is one-shot (SPEC §4); tell the panels so they can un-arm.

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -30,6 +30,19 @@ export default defineBackground(() => {
 
   browser.tabs.onRemoved.addListener((tabId) => store.clear(tabId));
 
+  // A model kept across a navigation may no longer describe the page (SPEC §5).
+  // The background has to notice: a DevTools panel cannot read the tab's URL.
+  browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
+    if (!changeInfo.url) return;
+    const model = store.get(tabId);
+    if (model.url == null) return;
+    const stale = model.url !== changeInfo.url;
+    if (stale === model.stale) return;
+    // Navigating back to where it was built makes it current again.
+    model.stale = stale;
+    publish(tabId, model);
+  });
+
   // A model with no panel watching it is abandoned work (SPEC §5). Each panel
   // holds a port and reports which tab it is showing; when a panel closes, the
   // tab it was on loses its model unless another panel is still on that tab.
@@ -75,6 +88,8 @@ export default defineBackground(() => {
         const tabId = sender.tab?.id;
         if (tabId == null) return;
         const model = store.get(tabId);
+        // The page the model belongs to, recorded when the first element lands.
+        if (model.url == null) model.url = sender.tab?.url ?? null;
         model.elements.push({
           ...m.result,
           id: `el-${idSeq++}`,

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -1,4 +1,5 @@
-import { generate, resolveCandidate, safeRole } from '@/src/engine/candidates';
+import { generate, resolveCandidate } from '@/src/engine/candidates';
+import { describeElement } from '@/src/engine/describe';
 import { isMessage, type Message } from '@/src/messaging';
 
 // Inspector overlay: highlight the element under the cursor (like DevTools) and,
@@ -27,6 +28,7 @@ export default defineContentScript({
         transition: 'all 40ms ease-out',
       } as CSSStyleDeclaration);
       label = document.createElement('div');
+      label.dataset.pageModeller = 'label';
       Object.assign(label.style, {
         position: 'fixed',
         pointerEvents: 'none',
@@ -48,22 +50,11 @@ export default defineContentScript({
       current = null;
     }
 
-    /**
-     * What the tool will classify this element as (SPEC §11), not its raw role
-     * attribute. `role="none"` and `presentation` remove an element from the
-     * accessibility tree, so they say nothing useful about what you are picking
-     * — fall back to the tag, as for anything with no computed role.
-     */
-    function overlayLabel(el: Element): string {
-      const role = safeRole(el);
-      return role && role !== 'none' && role !== 'presentation' ? role : el.tagName.toLowerCase();
-    }
-
     function highlight(el: Element) {
       ensureOverlay();
       const r = el.getBoundingClientRect();
       Object.assign(box!.style, { left: `${r.left}px`, top: `${r.top}px`, width: `${r.width}px`, height: `${r.height}px` });
-      label!.textContent = overlayLabel(el);
+      label!.textContent = describeElement(el);
       label!.style.left = `${r.left}px`;
       label!.style.top = `${Math.max(0, r.top - 18)}px`;
     }

--- a/v3/src/engine/candidates.ts
+++ b/v3/src/engine/candidates.ts
@@ -25,7 +25,7 @@ function pseudoText(el: Element, pseudo: '::before' | '::after'): string {
   }
 }
 
-function safeName(el: Element): string {
+export function safeName(el: Element): string {
   try {
     let name = norm(computeAccessibleName(el));
     // Pseudo content only contributes when the name is derived from content

--- a/v3/src/engine/candidates.ts
+++ b/v3/src/engine/candidates.ts
@@ -179,6 +179,22 @@ export function resolveCandidate(doc: Document, c: LocatorCandidate): Element[] 
         return [];
       }
     }
+
+    // Selenium's By strategies, so the eye can test a hand-typed one.
+    case 'id':
+      return c.value ? Array.from(doc.querySelectorAll(`#${CSS.escape(c.value)}`)) : [];
+    case 'name':
+      return c.value ? Array.from(doc.querySelectorAll(`[name="${CSS.escape(c.value)}"]`)) : [];
+    case 'className':
+      // By.className takes ONE class name, not a selector.
+      return c.value ? Array.from(doc.getElementsByClassName(c.value)) : [];
+    case 'tagName':
+      return c.value ? Array.from(doc.getElementsByTagName(c.value)) : [];
+    case 'linkText':
+      // Selenium matches links on their rendered text, trimmed.
+      return Array.from(doc.querySelectorAll('a')).filter((a) => norm(a.textContent) === norm(c.text));
+    case 'partialLinkText':
+      return Array.from(doc.querySelectorAll('a')).filter((a) => norm(a.textContent).includes(norm(c.text)));
   }
 }
 

--- a/v3/src/engine/candidates.ts
+++ b/v3/src/engine/candidates.ts
@@ -75,19 +75,38 @@ function cssFor(el: Element): string {
   return parts.join(' > ');
 }
 
+const HTML_NS = 'http://www.w3.org/1999/xhtml';
+
+/**
+ * One step of an XPath.
+ *
+ * An unprefixed name test matches the null namespace; browsers special-case
+ * HTML-namespace elements in an HTML document, but nothing else — so `svg[1]`
+ * matches nothing, and every path through an <svg> resolved to zero. Elements
+ * outside the HTML namespace are matched on `local-name()`, which sidesteps
+ * namespaces entirely.
+ *
+ * `localName` rather than a lowercased `tagName`: SVG names are case-sensitive
+ * and some are camelCase (`clipPath`, `linearGradient`).
+ */
+function xpathStep(el: Element, index: number): string {
+  return el.namespaceURI === HTML_NS
+    ? `${el.localName}[${index}]`
+    : `*[local-name()=${JSON.stringify(el.localName)}][${index}]`;
+}
+
 function xpathFor(el: Element): string {
   if (el.id) return `//*[@id=${JSON.stringify(el.id)}]`;
   const parts: string[] = [];
   let cur: Element | null = el;
   while (cur && cur.nodeType === 1) {
-    const tag = cur.tagName.toLowerCase();
     const parent: Element | null = cur.parentElement;
     let idx = 1;
     if (parent) {
       const same = Array.from(parent.children).filter((c) => c.tagName === cur!.tagName);
       if (same.length > 1) idx = same.indexOf(cur) + 1;
     }
-    parts.unshift(`${tag}[${idx}]`);
+    parts.unshift(xpathStep(cur, idx));
     cur = parent;
   }
   return '/' + parts.join('/');
@@ -198,10 +217,6 @@ export function resolveCandidate(doc: Document, c: LocatorCandidate): Element[] 
   }
 }
 
-function predictedCount(doc: Document, c: LocatorCandidate): number {
-  return resolveCandidate(doc, c).length;
-}
-
 // ---- candidate generation (ranked, mirrors Playwright's priority) ----
 
 export function generate(el: Element): ElementResult {
@@ -246,10 +261,16 @@ export function generate(el: Element): ElementResult {
   out.push({ kind: 'css', value: cssFor(el) });
   out.push({ kind: 'xpath', value: xpathFor(el) });
 
-  const candidates: RankedCandidate[] = out.map((candidate) => ({
-    candidate,
-    predictedCount: predictedCount(doc, candidate),
-  }));
+  // Keep only candidates that actually find THIS element. A locator can be
+  // well-formed, resolve to something, and still be useless: getByRole excludes
+  // a11y-hidden elements, so a hidden button's role candidate finds the other
+  // buttons; getByText matches the innermost element, so a <fieldset>'s text
+  // candidate finds its <legend>. Offering those in the Edit dialog would hand
+  // the user a locator that cannot work.
+  const candidates: RankedCandidate[] = out
+    .map((candidate) => ({ candidate, matches: resolveCandidate(doc, candidate) }))
+    .filter(({ matches }) => matches.includes(el))
+    .map(({ candidate, matches }) => ({ candidate, predictedCount: matches.length }));
 
   const preferredIndex = candidates.findIndex((c) => c.predictedCount === 1);
 

--- a/v3/src/engine/candidates.ts
+++ b/v3/src/engine/candidates.ts
@@ -1,6 +1,6 @@
 import { computeAccessibleName, getRole } from 'dom-accessibility-api';
 import type { LocatorCandidate, ElementResult, RankedCandidate } from './types';
-import { baseName } from './naming';
+import { baseName, looksGenerated } from './naming';
 
 const norm = (s: string | null | undefined): string => (s ?? '').replace(/\s+/g, ' ').trim();
 
@@ -256,6 +256,35 @@ export function generate(el: Element): ElementResult {
   if (!NON_TEXT.has(el.tagName)) {
     const text = norm(el.textContent);
     if (text && text.length <= 80) out.push({ kind: 'text', text, exact: true });
+  }
+
+  // ---- Selenium's By strategies ----
+  //
+  // Generated for every element regardless of the chosen framework: the model
+  // holds the superset and the framework decides which are expressible. Without
+  // these, a Selenium target had nothing but css and xpath, and would happily
+  // select a `role` locator Selenium cannot write.
+  const id = el.getAttribute('id');
+  if (id && !looksGenerated(id)) out.push({ kind: 'id', value: id });
+
+  const nameAttr = el.getAttribute('name');
+  if (nameAttr) out.push({ kind: 'name', value: nameAttr });
+
+  // By.className takes ONE class name, so each is its own candidate. Capped,
+  // and build-generated names skipped, or a CSS-in-JS page yields a dropdown of
+  // hashes that change on their next deploy.
+  for (const cls of Array.from(el.classList).filter((c) => !looksGenerated(c)).slice(0, 3)) {
+    out.push({ kind: 'className', value: cls });
+  }
+
+  out.push({ kind: 'tagName', value: el.localName });
+
+  if (el.localName === 'a') {
+    const linkText = norm(el.textContent);
+    if (linkText) {
+      out.push({ kind: 'linkText', text: linkText });
+      out.push({ kind: 'partialLinkText', text: linkText });
+    }
   }
 
   out.push({ kind: 'css', value: cssFor(el) });

--- a/v3/src/engine/describe.ts
+++ b/v3/src/engine/describe.ts
@@ -1,0 +1,28 @@
+// How an element reads in the inspector overlay.
+//
+// A preview of the locator you are about to get, not just a tag name. Role
+// first, because it drives both the locator and the generated methods
+// (SPEC §11), then the accessible name, which is what `getByRole` matches on.
+//
+// The tag appears only when it differs from the role — the case this was
+// written for: a plain wrapper <div> and the `<div role="button">` inside it
+// have the same bounding box, and both used to read just "div", so there was no
+// way to tell which one a click would pick.
+import { safeName, safeRole } from './candidates';
+
+const MAX_NAME = 30;
+
+export function describeElement(el: Element): string {
+  const raw = safeRole(el);
+  // `none` and `presentation` remove an element from the accessibility tree,
+  // so they describe nothing — treat them as no role at all.
+  const role = raw && raw !== 'none' && raw !== 'presentation' ? raw : '';
+  const tag = el.localName;
+
+  let label = role || tag;
+  if (role && role !== tag) label += ` (${tag})`;
+
+  const name = safeName(el);
+  if (name) label += ` "${name.length > MAX_NAME ? `${name.slice(0, MAX_NAME - 1)}…` : name}"`;
+  return label;
+}

--- a/v3/src/engine/naming.ts
+++ b/v3/src/engine/naming.ts
@@ -42,7 +42,7 @@ function accessibleName(el: Element): string {
  * through to the next naming rule, while a false negative ships a name that
  * will rot.
  */
-function looksGenerated(value: string): boolean {
+export function looksGenerated(value: string): boolean {
   // Known CSS-in-JS shapes: emotion (css-1q2w3e), styled-components (sc-bdVaJa),
   // CSS Modules (Button_root__2xK9f), and leading-underscore hashes (_2xK9f).
   if (/^(css|sc|emotion)-[a-z0-9]+$/i.test(value)) return true;

--- a/v3/src/engine/types.ts
+++ b/v3/src/engine/types.ts
@@ -11,7 +11,17 @@ export type LocatorCandidate =
   | { kind: 'altText'; text: string; exact?: boolean }
   | { kind: 'title'; text: string; exact?: boolean }
   | { kind: 'css'; value: string }
-  | { kind: 'xpath'; value: string };
+  | { kind: 'xpath'; value: string }
+  // Selenium's native By strategies. The engine does not generate these yet —
+  // that is the superset generator (REWRITE-PLAN §12) — but the IR has to hold
+  // them, because the Edit dialog offers the full framework list (SPEC §7) and
+  // a hand-typed Selenium locator must be storable and testable with the eye.
+  | { kind: 'id'; value: string }
+  | { kind: 'name'; value: string }
+  | { kind: 'className'; value: string }
+  | { kind: 'tagName'; value: string }
+  | { kind: 'linkText'; text: string }
+  | { kind: 'partialLinkText'; text: string };
 
 export interface RankedCandidate {
   candidate: LocatorCandidate;

--- a/v3/src/locators/display.ts
+++ b/v3/src/locators/display.ts
@@ -29,6 +29,11 @@ export function playwrightExpr(c: LocatorCandidate): string {
     case 'css':
     case 'xpath':
       return `locator(${q(c.value)})`;
+    default:
+      // Selenium's By strategies have no Playwright call. They should not reach
+      // a Playwright model, but if one is hand-typed and the framework changes,
+      // show it plainly rather than inventing an expression.
+      return typeValue(c);
   }
 }
 
@@ -47,7 +52,14 @@ export function typeValue(c: LocatorCandidate): string {
       return `${c.kind}: ${c.text}`;
     case 'css':
     case 'xpath':
+    case 'id':
+    case 'name':
+    case 'className':
+    case 'tagName':
       return `${c.kind}: ${c.value}`;
+    case 'linkText':
+    case 'partialLinkText':
+      return `${c.kind}: ${c.text}`;
   }
 }
 

--- a/v3/src/locators/fields.ts
+++ b/v3/src/locators/fields.ts
@@ -1,0 +1,66 @@
+// What the Edit dialog has to ask for, per locator type (SPEC §9, §12).
+//
+// A locator is a type plus the fields that type needs — `getByRole` takes a
+// role AND a name, so the dialog cannot be a single value box. Everything else
+// happens to need one field, but the shape is what makes role expressible.
+import type { LocatorCandidate } from '../engine/types';
+
+export type LocatorKind = LocatorCandidate['kind'];
+
+export interface LocatorField {
+  /** Key in the built candidate. */
+  key: string;
+  label: string;
+}
+
+const ONE = (key: string, label: string): LocatorField[] => [{ key, label }];
+
+const FIELDS: Record<LocatorKind, LocatorField[]> = {
+  testId: ONE('value', 'Test ID'),
+  role: [
+    { key: 'role', label: 'Role' },
+    { key: 'name', label: 'Accessible name' },
+  ],
+  label: ONE('text', 'Label'),
+  placeholder: ONE('text', 'Placeholder'),
+  text: ONE('text', 'Text'),
+  altText: ONE('text', 'Alt text'),
+  title: ONE('text', 'Title'),
+  css: ONE('value', 'CSS selector'),
+  xpath: ONE('value', 'XPath'),
+  id: ONE('value', 'ID'),
+  name: ONE('value', 'Name'),
+  className: ONE('value', 'Class name'),
+  tagName: ONE('value', 'Tag name'),
+  linkText: ONE('text', 'Link text'),
+  partialLinkText: ONE('text', 'Partial link text'),
+};
+
+export function fieldsFor(kind: LocatorKind): LocatorField[] {
+  return FIELDS[kind] ?? ONE('value', 'Value');
+}
+
+/** Pull a candidate apart into editable values. */
+export function valuesOf(c: LocatorCandidate): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const f of fieldsFor(c.kind)) values[f.key] = String((c as unknown as Record<string, unknown>)[f.key] ?? '');
+  return values;
+}
+
+/**
+ * Put one back together. Generated candidates always carry `exact: true`
+ * (SPEC §12), and a hand-edited one keeps that — the dialog does not expose
+ * `exact`, so silently dropping it would loosen the locator behind the user's
+ * back.
+ */
+export function buildCandidate(kind: LocatorKind, values: Record<string, string>): LocatorCandidate {
+  const built: Record<string, unknown> = { kind };
+  for (const f of fieldsFor(kind)) built[f.key] = values[f.key] ?? '';
+  if (kind === 'role') {
+    if (!built.name) delete built.name;
+    built.exact = true;
+  } else if (['label', 'placeholder', 'text', 'altText', 'title'].includes(kind)) {
+    built.exact = true;
+  }
+  return built as unknown as LocatorCandidate;
+}

--- a/v3/src/locators/fields.ts
+++ b/v3/src/locators/fields.ts
@@ -11,6 +11,13 @@ export interface LocatorField {
   /** Key in the built candidate. */
   key: string;
   label: string;
+  /**
+   * Blank is meaningful for this field. Only `getByRole`'s name qualifies —
+   * `getByRole('navigation')` is a real locator. Everywhere else an empty value
+   * makes a locator that matches whatever happens to have nothing there: an
+   * empty `label` matches every control with no accessible name.
+   */
+  optional?: boolean;
 }
 
 const ONE = (key: string, label: string): LocatorField[] => [{ key, label }];
@@ -19,7 +26,7 @@ const FIELDS: Record<LocatorKind, LocatorField[]> = {
   testId: ONE('value', 'Test ID'),
   role: [
     { key: 'role', label: 'Role' },
-    { key: 'name', label: 'Accessible name' },
+    { key: 'name', label: 'Accessible name', optional: true },
   ],
   label: ONE('text', 'Label'),
   placeholder: ONE('text', 'Placeholder'),
@@ -35,6 +42,11 @@ const FIELDS: Record<LocatorKind, LocatorField[]> = {
   linkText: ONE('text', 'Link text'),
   partialLinkText: ONE('text', 'Partial link text'),
 };
+
+/** True when every field the type needs has a value. */
+export function isComplete(kind: LocatorKind, values: Record<string, string>): boolean {
+  return fieldsFor(kind).every((f) => f.optional || (values[f.key] ?? '').trim() !== '');
+}
 
 export function fieldsFor(kind: LocatorKind): LocatorField[] {
   return FIELDS[kind] ?? ONE('value', 'Value');

--- a/v3/src/locators/select.ts
+++ b/v3/src/locators/select.ts
@@ -1,0 +1,29 @@
+// Choosing which generated locator an element uses (SPEC §7).
+//
+// The engine generates a superset — every strategy it can find, Playwright's and
+// Selenium's alike — because the model holds one set of candidates and the
+// framework decides which are expressible. Without this step a Selenium model
+// happily selected `getByRole`, displayed it as `role: heading — Google`, and
+// the eye certified it, because our resolver understands roles even though
+// Selenium never will.
+import { frameworkById } from '../frameworks';
+import type { RankedCandidate } from '../engine/types';
+
+/**
+ * The candidate a new element should start on: the first one, in the
+ * framework's own order of preference, that the framework can express AND that
+ * resolves uniquely. Falls back to any expressible candidate, then to the
+ * first — `css` and `xpath` are always generated and every framework has them,
+ * so the fallbacks are belt and braces.
+ */
+export function chooseCandidate(candidates: RankedCandidate[], frameworkId: string): number {
+  const allowed = frameworkById(frameworkId).locatorTypes;
+
+  for (const type of allowed) {
+    const index = candidates.findIndex((c) => c.candidate.kind === type && c.predictedCount === 1);
+    if (index >= 0) return index;
+  }
+
+  const expressible = candidates.findIndex((c) => allowed.includes(c.candidate.kind));
+  return expressible >= 0 ? expressible : 0;
+}

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -59,6 +59,7 @@ export type PanelToBackground =
   // changes rather than making them, and every panel on the tab sees the result.
   | { type: 'GET_MODEL'; tabId: number }
   | { type: 'DELETE_ELEMENT'; tabId: number; id: string }
+  | { type: 'UPDATE_ELEMENT'; tabId: number; id: string; name: string; selectedIndex: number; override?: LocatorCandidate }
   | { type: 'DELETE_MODEL'; tabId: number }
   | { type: 'SET_FRAMEWORK'; tabId: number; frameworkId: string };
 

--- a/v3/src/model.ts
+++ b/v3/src/model.ts
@@ -23,12 +23,17 @@ export interface TabModel {
   elements: ModelElement[];
   /** Chosen up front and locked once the model has anything in it (SPEC §3). */
   frameworkId: string;
-  /** The URL the model was built against, for the stale check (SPEC §5). */
+  /** The URL the model was built against. Set when the first element lands. */
   url: string | null;
+  /**
+   * The tab has navigated away from `url`. The background decides this: a
+   * DevTools panel cannot read the tab's URL for itself (SPEC §5).
+   */
+  stale: boolean;
 }
 
 export function emptyModel(frameworkId: string): TabModel {
-  return { elements: [], frameworkId, url: null };
+  return { elements: [], frameworkId, url: null, stale: false };
 }
 
 /** The locator currently in effect for an element: an override, or the pick. */

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -462,3 +462,50 @@ test('a model kept across a navigation is marked stale (SPEC §5)', async () => 
   await page.goto(`http://localhost:${PORT}/login.html?case=stale`);
   await expect.poll(async () => (await latest())?.stale).toBe(false);
 });
+
+test('a pick under Selenium never selects a Playwright-only locator', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  for (const open of context.pages()) {
+    if (open.url().startsWith('chrome-extension://')) await open.close();
+  }
+
+  const { page, tabId } = await openFixture(sw as never, 'selenium');
+
+  const panel = await context.newPage();
+  await panel.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await panel.evaluate(() => {
+    (window as unknown as { __msgs: unknown[] }).__msgs = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+    });
+  });
+
+  type Published = { type: string; model?: { elements: { selectedIndex: number; candidates: { candidate: { kind: string } }[] }[] } };
+  const selectedKinds = async () => {
+    const model = (await panel.evaluate(() => (window as unknown as { __msgs: Published[] }).__msgs))
+      .filter((m) => m.type === 'MODEL')
+      .at(-1)?.model;
+    return model?.elements.map((e) => e.candidates[e.selectedIndex]?.candidate.kind);
+  };
+
+  await panel.evaluate(
+    (id) => chrome.runtime.sendMessage({ type: 'SET_FRAMEWORK', tabId: id, frameworkId: 'selenium-java' }),
+    tabId
+  );
+  await panel.evaluate(
+    (id) => chrome.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: id, message: { type: 'START_PICKING', mode: 'add' } }),
+    tabId
+  );
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Selenium's By strategies only. Before this, a Selenium model selected
+  // getByRole, showed it as "role: … — …", and the eye certified it, because
+  // our resolver understands roles even though Selenium cannot express them.
+  const seleniumTypes = ['id', 'linkText', 'partialLinkText', 'name', 'css', 'xpath', 'className', 'tagName'];
+  await expect.poll(selectedKinds).toHaveLength(1);
+  const [kind] = (await selectedKinds())!;
+  expect(seleniumTypes, `selected ${kind}`).toContain(kind);
+});

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -509,3 +509,36 @@ test('a pick under Selenium never selects a Playwright-only locator', async () =
   const [kind] = (await selectedKinds())!;
   expect(seleniumTypes, `selected ${kind}`).toContain(kind);
 });
+
+test('the overlay label previews the locator, not just the tag', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const url = `http://localhost:${PORT}/widgets.html`;
+  const page = await context.newPage();
+  await page.goto(url);
+  const tabId: number = await sw.evaluate(async (u) => (await chrome.tabs.query({ url: u }))[0].id!, url);
+
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
+  const label = page.locator('[data-page-modeller="label"]');
+
+  // Role first, then the accessible name — the label previews what getByRole
+  // will match on.
+  await page.getByRole('button', { name: 'Save' }).hover();
+  await expect(label).toHaveText('button "Save"');
+
+  // Tag shown only when it differs from the role. This is the case it was
+  // written for: a <div role="button"> and the plain <div> wrapping it have the
+  // same bounding box and both used to read just "div".
+  await page.getByRole('button', { name: 'Continue to checkout' }).hover();
+  await expect(label).toHaveText('button (div) "Continue to checkout"');
+
+  // The wrapper is now plainly distinguishable from the control inside it.
+  await page.locator('.cta-wrapper').hover({ position: { x: 2, y: 2 } });
+  await expect(label).toHaveText('div');
+
+  // Formatting details — truncation, role="none", missing names — are covered
+  // by tests/unit/describe.test.ts against the same function. This test exists
+  // for the thing only a real browser can show: that hovering two elements with
+  // identical bounding boxes now tells them apart.
+});

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -418,3 +418,47 @@ test('a roaming sidebar closing on one tab leaves the other tab\'s model', async
     )
     .toEqual(['SignIn']);
 });
+
+test('a model kept across a navigation is marked stale (SPEC §5)', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  for (const open of context.pages()) {
+    if (open.url().startsWith('chrome-extension://')) await open.close();
+  }
+
+  const { page, tabId } = await openFixture(sw as never, 'stale');
+
+  const panel = await context.newPage();
+  await panel.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await panel.evaluate(() => {
+    (window as unknown as { __msgs: unknown[] }).__msgs = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+    });
+  });
+
+  const latest = async () =>
+    (await panel.evaluate(() => (window as unknown as { __msgs: { type: string; model?: { stale: boolean; url: string | null } }[] }).__msgs))
+      .filter((m) => m.type === 'MODEL')
+      .at(-1)?.model;
+
+  await panel.evaluate(
+    (id) => chrome.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: id, message: { type: 'START_PICKING', mode: 'add' } }),
+    tabId
+  );
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // The model records the page it was built on.
+  await expect.poll(async () => (await latest())?.url).toContain('login.html?case=stale');
+  expect((await latest())?.stale).toBe(false);
+
+  // Navigating away marks it, so the panel can say why every row will miss.
+  await page.goto(`http://localhost:${PORT}/widgets.html`);
+  await expect.poll(async () => (await latest())?.stale).toBe(true);
+
+  // Navigating back makes it current again — it describes this page once more.
+  await page.goto(`http://localhost:${PORT}/login.html?case=stale`);
+  await expect.poll(async () => (await latest())?.stale).toBe(false);
+});

--- a/v3/tests/engine.fidelity.spec.ts
+++ b/v3/tests/engine.fidelity.spec.ts
@@ -30,12 +30,36 @@ test('locator engine matches real Playwright resolution', async ({ page }) => {
       // eye (SPEC §8) reports from it. If the two drift, the count the user is
       // shown is not the count their test will get.
       for (const { candidate, predictedCount } of result.candidates) {
-        const actual = await buildLocator(page, candidate).count();
+        const loc = buildLocator(page, candidate);
+        const actual = await loc.count();
         if (actual !== predictedCount) {
           failures.push(
             `${fixture}/${spikeId}: ${candidate.kind} predicted ${predictedCount}, Playwright resolved ${actual}`
           );
         }
+
+        // Agreement is not enough: a candidate that resolves to nothing agrees
+        // with our resolver, which also finds nothing, and passes. Every
+        // candidate must actually FIND the element it was generated from —
+        // that is what caught XPath silently failing on SVG, where an
+        // unprefixed name test matches no non-HTML-namespace element.
+        if (actual === 0) {
+          failures.push(`${fixture}/${spikeId}: ${candidate.kind} matches nothing`);
+          continue;
+        }
+        const findsIt = await loc.evaluateAll((els, id) => els.some((e) => e.getAttribute('data-spike') === id), spikeId);
+        if (!findsIt) {
+          failures.push(`${fixture}/${spikeId}: ${candidate.kind} resolves, but not to ${spikeId}`);
+        }
+      }
+
+      // css and xpath are unconditional fallbacks: the engine emits them for
+      // every element, and candidates that cannot find their element are
+      // dropped. So a missing one means the generator is broken for this shape
+      // — which is how SVG XPaths, silently resolving to nothing, were caught.
+      const kinds = result.candidates.map((c) => c.candidate.kind);
+      for (const required of ['css', 'xpath'] as const) {
+        if (!kinds.includes(required)) failures.push(`${fixture}/${spikeId}: no working ${required} candidate`);
       }
 
       if (result.preferredIndex < 0) {

--- a/v3/tests/fixtures/login.html
+++ b/v3/tests/fixtures/login.html
@@ -30,7 +30,7 @@
     <a href="/forgot" data-spike="forgot-link">Forgot your password?</a>
 
     <button type="button" aria-label="Close dialog" data-spike="icon-close">
-      <svg width="16" height="16" aria-hidden="true"><path d="M0 0L16 16" /></svg>
+      <svg width="16" height="16" aria-hidden="true"><path d="M0 0L16 16" data-spike="svg-path" /></svg>
     </button>
 
     <img src="logo.png" alt="Acme Corporation logo" data-spike="logo-img" />

--- a/v3/tests/fixtures/widgets.html
+++ b/v3/tests/fixtures/widgets.html
@@ -25,6 +25,13 @@
     <label for="plan-pro">Pro plan</label>
 
     <p data-spike="unique-paragraph">This is a unique descriptive paragraph of text.</p>
+
+    <!-- A control built from divs, wrapped in a plain one. The two have the same
+         bounding box, so the overlay label is the only way to tell which you are
+         about to pick. -->
+    <div class="cta-wrapper" style="padding: 12px">
+      <div role="button" tabindex="0" data-spike="div-button">Continue to checkout</div>
+    </div>
   </main>
 </body>
 </html>

--- a/v3/tests/pw-builder.ts
+++ b/v3/tests/pw-builder.ts
@@ -25,5 +25,34 @@ export function buildLocator(page: Page, c: LocatorCandidate): Locator {
       return page.locator(c.value);
     case 'xpath':
       return page.locator(`xpath=${c.value}`);
+
+    // Selenium's By strategies, expressed as the CSS or XPath Playwright would
+    // need — so the fidelity check covers our resolution of these too, not just
+    // the Playwright-native kinds.
+    case 'id':
+      return page.locator(`#${cssEscape(c.value)}`);
+    case 'name':
+      return page.locator(`[name="${cssEscape(c.value)}"]`);
+    case 'className':
+      return page.locator(`.${cssEscape(c.value)}`);
+    case 'tagName':
+      return page.locator(c.value);
+    case 'linkText':
+      // Selenium matches a link's rendered text, whitespace-normalised.
+      return page.locator(`xpath=//a[normalize-space(.)=${xpathLiteral(c.text)}]`);
+    case 'partialLinkText':
+      return page.locator(`xpath=//a[contains(normalize-space(.), ${xpathLiteral(c.text)})]`);
   }
+}
+
+/** CSS.escape is a browser API; this is the subset needed for ids and classes. */
+function cssEscape(value: string): string {
+  return value.replace(/([^\w-])/g, '\\$1');
+}
+
+/** XPath has no escape character, so a string containing both quote types needs concat(). */
+function xpathLiteral(value: string): string {
+  if (!value.includes("'")) return `'${value}'`;
+  if (!value.includes('"')) return `"${value}"`;
+  return `concat('${value.split("'").join(`', "'", '`)}')`;
 }

--- a/v3/tests/unit/EditElementDialog.test.ts
+++ b/v3/tests/unit/EditElementDialog.test.ts
@@ -123,6 +123,44 @@ describe('EditElementDialog', () => {
     expect((w.emitted('save')![0][0] as { override: { exact: boolean } }).override.exact).toBe(true);
   });
 
+  describe('an incomplete locator is neither testable nor saveable', () => {
+    it('blocks a blank required field', async () => {
+      // Blank does not mean "match anything": an empty `label` matches every
+      // control with no accessible name, which reported 8 matches for a field
+      // the user had not filled in.
+      const w = render();
+      (w.vm as unknown as { kind: string }).kind = 'label';
+      await w.vm.$nextTick();
+      expect(vm(w).locatorComplete).toBe(false);
+      (w.vm as unknown as { save: () => void }).save();
+      expect(w.emitted('save')).toBeUndefined();
+    });
+
+    it('allows a blank accessible name, which getByRole permits', async () => {
+      // getByRole('navigation') is a real locator.
+      const w = render();
+      (w.vm as unknown as { values: Record<string, string> }).values.name = '';
+      await w.vm.$nextTick();
+      expect(vm(w).locatorComplete).toBe(true);
+    });
+
+    it('blocks a blank role even though the name is optional', async () => {
+      const w = render();
+      (w.vm as unknown as { values: Record<string, string> }).values.role = '';
+      await w.vm.$nextTick();
+      expect(vm(w).locatorComplete).toBe(false);
+    });
+
+    it('treats whitespace as blank', async () => {
+      const w = render();
+      (w.vm as unknown as { kind: string }).kind = 'css';
+      await w.vm.$nextTick();
+      (w.vm as unknown as { values: Record<string, string> }).values.value = '   ';
+      await w.vm.$nextTick();
+      expect(vm(w).locatorComplete).toBe(false);
+    });
+  });
+
   it('refuses to save an invalid name', async () => {
     const w = render();
     (w.vm as unknown as { name: string }).name = '';

--- a/v3/tests/unit/EditElementDialog.test.ts
+++ b/v3/tests/unit/EditElementDialog.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { Quasar, QBtn, QTooltip, QDialog, QCard, QCardSection, QCardActions, QInput, QSelect, QToolbar, QToolbarTitle } from 'quasar';
+import EditElementDialog from '../../ui/EditElementDialog.vue';
+import type { ModelElement } from '../../src/model';
+
+const element: ModelElement = {
+  id: 'el-0',
+  name: 'SignIn',
+  tag: 'button',
+  role: 'button',
+  accessibleName: 'Sign in',
+  suggestedName: 'SignIn',
+  selectedIndex: 0,
+  preferredIndex: 0,
+  candidates: [
+    { candidate: { kind: 'role', role: 'button', name: 'Sign in', exact: true }, predictedCount: 1 },
+    { candidate: { kind: 'css', value: 'button.submit' }, predictedCount: 1 },
+  ],
+};
+
+function render(props: Partial<Parameters<typeof EditElementDialog>[0]> = {}) {
+  return mount(EditElementDialog, {
+    props: { element, frameworkId: 'playwright-ts', takenNames: [], ...props } as never,
+    global: {
+      plugins: [Quasar],
+      components: { QBtn, QTooltip, QDialog, QCard, QCardSection, QCardActions, QInput, QSelect, QToolbar, QToolbarTitle },
+      stubs: { QTooltip: true },
+    },
+    attachTo: document.body,
+  });
+}
+
+const vm = (w: ReturnType<typeof render>) => w.vm as unknown as Record<string, never>;
+
+describe('EditElementDialog', () => {
+  it('opens on the element\'s active locator', () => {
+    const w = render();
+    expect(vm(w).kind).toBe('role');
+    expect(vm(w).values).toEqual({ role: 'button', name: 'Sign in' });
+  });
+
+  it('asks for two fields for role, one for css (SPEC §12)', async () => {
+    const w = render();
+    expect((vm(w).fields as unknown as { key: string }[]).map((f) => f.key)).toEqual(['role', 'name']);
+    (w.vm as unknown as { kind: string }).kind = 'css';
+    await w.vm.$nextTick();
+    expect((vm(w).fields as unknown as { key: string }[]).map((f) => f.key)).toEqual(['value']);
+  });
+
+  it('prefills from a generated candidate of the chosen type', async () => {
+    const w = render();
+    (w.vm as unknown as { kind: string }).kind = 'css';
+    await w.vm.$nextTick();
+    expect(vm(w).values).toEqual({ value: 'button.submit' });
+  });
+
+  it('blanks the field when nothing was generated for that type (SPEC §7)', async () => {
+    const w = render();
+    (w.vm as unknown as { kind: string }).kind = 'testId';
+    await w.vm.$nextTick();
+    expect(vm(w).values).toEqual({ value: '' });
+  });
+
+  it('offers the full framework list, not just what was generated', () => {
+    const w = render();
+    const options = (vm(w).typeOptions as unknown as { value: string }[]).map((o) => o.value);
+    expect(options).toContain('testId');
+    expect(options).toContain('xpath');
+    expect(options).not.toContain('linkText');
+  });
+
+  it('offers Selenium strategies when that is the framework', () => {
+    const w = render({ frameworkId: 'selenium-java' } as never);
+    const options = (vm(w).typeOptions as unknown as { value: string }[]).map((o) => o.value);
+    expect(options).toContain('linkText');
+  });
+
+  describe('name validation', () => {
+    const cases: Array<[string, string, string]> = [
+      ['rejects empty', '  ', 'Name is required.'],
+      ['rejects spaces', 'Sign In', 'Name cannot contain spaces.'],
+      ['rejects a duplicate', 'About', 'Name must be unique.'],
+      ['accepts a good name', 'SignInButton', ''],
+    ];
+    for (const [label, value, expected] of cases) {
+      it(label, async () => {
+        const w = render({ takenNames: ['About'] } as never);
+        (w.vm as unknown as { name: string }).name = value;
+        await w.vm.$nextTick();
+        expect(vm(w).nameError).toBe(expected);
+      });
+    }
+  });
+
+  it('saves a hand-typed locator as an override', async () => {
+    const w = render();
+    (w.vm as unknown as { kind: string }).kind = 'css';
+    await w.vm.$nextTick();
+    (w.vm as unknown as { values: Record<string, string> }).values.value = 'button.pay';
+    await w.vm.$nextTick();
+    (w.vm as unknown as { save: () => void }).save();
+    expect(w.emitted('save')![0][0]).toEqual({ name: 'SignIn', selectedIndex: 0, override: { kind: 'css', value: 'button.pay' } });
+  });
+
+  it('saves a locator matching a generated one as a selection, not an override', async () => {
+    // Otherwise it would stop tracking the engine's own verification.
+    const w = render();
+    (w.vm as unknown as { kind: string }).kind = 'css';
+    await w.vm.$nextTick();
+    (w.vm as unknown as { save: () => void }).save();
+    expect(w.emitted('save')![0][0]).toEqual({ name: 'SignIn', selectedIndex: 1, override: undefined });
+  });
+
+  it('keeps exact: true on a hand-edited text locator (SPEC §12)', async () => {
+    const w = render();
+    (w.vm as unknown as { kind: string }).kind = 'text';
+    await w.vm.$nextTick();
+    (w.vm as unknown as { values: Record<string, string> }).values.text = 'Sign in';
+    await w.vm.$nextTick();
+    (w.vm as unknown as { save: () => void }).save();
+    expect((w.emitted('save')![0][0] as { override: { exact: boolean } }).override.exact).toBe(true);
+  });
+
+  it('refuses to save an invalid name', async () => {
+    const w = render();
+    (w.vm as unknown as { name: string }).name = '';
+    await w.vm.$nextTick();
+    (w.vm as unknown as { save: () => void }).save();
+    expect(w.emitted('save')).toBeUndefined();
+  });
+
+  it('emits the in-progress locator for the eye, not the saved one', async () => {
+    const w = render();
+    (w.vm as unknown as { kind: string }).kind = 'css';
+    await w.vm.$nextTick();
+    (w.vm as unknown as { values: Record<string, string> }).values.value = 'button.draft';
+    await w.vm.$nextTick();
+    expect(vm(w).candidate).toEqual({ kind: 'css', value: 'button.draft' });
+  });
+});

--- a/v3/tests/unit/describe.test.ts
+++ b/v3/tests/unit/describe.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { describeElement } from '../../src/engine/describe';
+
+function el(html: string, sel = '[data-t]'): Element {
+  document.body.innerHTML = html;
+  const found = document.querySelector(sel);
+  if (!found) throw new Error(`no match for ${sel}`);
+  return found;
+}
+
+describe('describeElement', () => {
+  it('leads with the role and the accessible name', () => {
+    expect(describeElement(el('<button data-t>Save</button>'))).toBe('button "Save"');
+  });
+
+  it('shows the tag when it differs from the role', () => {
+    // The case this exists for: a wrapper <div> and the <div role="button">
+    // inside it have the same bounding box and both used to read "div".
+    expect(describeElement(el('<div role="button" data-t>Log in</div>'))).toBe('button (div) "Log in"');
+  });
+
+  it('shows the tag alone for a plain wrapper', () => {
+    expect(describeElement(el('<div data-t><span>x</span></div>'))).toBe('div');
+  });
+
+  it('ignores role="none" and presentation, which describe nothing', () => {
+    expect(describeElement(el('<div role="none" data-t></div>'))).toBe('div');
+    expect(describeElement(el('<div role="presentation" data-t></div>'))).toBe('div');
+  });
+
+  it('truncates a long accessible name', () => {
+    const label = describeElement(el('<button data-t>Download the quarterly revenue report for 2026</button>'));
+    expect(label).toBe('button "Download the quarterly revenu…"');
+    expect(label.length).toBeLessThan(45);
+  });
+
+  it('omits the name when there is none', () => {
+    expect(describeElement(el('<input type="text" data-t />'))).toBe('textbox (input)');
+  });
+
+  it('uses an explicit label over content', () => {
+    expect(describeElement(el('<button aria-label="Close dialog" data-t>×</button>'))).toBe('button "Close dialog"');
+  });
+});

--- a/v3/tests/unit/select.test.ts
+++ b/v3/tests/unit/select.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { chooseCandidate } from '../../src/locators/select';
+import { frameworks } from '../../src/frameworks';
+import type { RankedCandidate } from '../../src/engine/types';
+
+/** A heading picked on a page — the case that exposed this. */
+const candidates: RankedCandidate[] = [
+  { candidate: { kind: 'role', role: 'heading', name: 'Google', exact: true }, predictedCount: 1 },
+  { candidate: { kind: 'text', text: 'Google', exact: true }, predictedCount: 1 },
+  { candidate: { kind: 'id', value: 'hplogo' }, predictedCount: 1 },
+  { candidate: { kind: 'className', value: 'logo' }, predictedCount: 2 },
+  { candidate: { kind: 'tagName', value: 'h1' }, predictedCount: 3 },
+  { candidate: { kind: 'css', value: 'h1#hplogo' }, predictedCount: 1 },
+  { candidate: { kind: 'xpath', value: '/html[1]/body[1]/h1[1]' }, predictedCount: 1 },
+];
+
+const kindFor = (frameworkId: string) => candidates[chooseCandidate(candidates, frameworkId)].candidate.kind;
+
+describe('chooseCandidate', () => {
+  it('prefers role for Playwright', () => {
+    expect(kindFor('playwright-ts')).toBe('role');
+  });
+
+  it('never picks a Playwright-only strategy for Selenium', () => {
+    // The bug: a Selenium model selected getByRole, displayed it as
+    // "role: heading — Google", and the eye certified it.
+    expect(kindFor('selenium-java')).toBe('id');
+  });
+
+  it('never picks a Playwright-only strategy for Puppeteer', () => {
+    // Puppeteer has only css and xpath.
+    expect(kindFor('puppeteer')).toBe('css');
+  });
+
+  it('chooses something expressible for every framework', () => {
+    for (const f of frameworks) {
+      const chosen = candidates[chooseCandidate(candidates, f.id)].candidate.kind;
+      expect(f.locatorTypes, `${f.label} chose ${chosen}`).toContain(chosen);
+    }
+  });
+
+  it('follows the framework order, not the generation order', () => {
+    // id outranks css in Selenium's list even though css appears later here and
+    // both resolve uniquely.
+    expect(kindFor('selenium-python')).toBe('id');
+  });
+
+  it('prefers a unique candidate over an earlier ambiguous one', () => {
+    const ambiguous: RankedCandidate[] = [
+      { candidate: { kind: 'id', value: 'dup' }, predictedCount: 3 },
+      { candidate: { kind: 'css', value: '#dup.first' }, predictedCount: 1 },
+    ];
+    expect(ambiguous[chooseCandidate(ambiguous, 'selenium-java')].candidate.kind).toBe('css');
+  });
+
+  it('falls back to an expressible candidate when none is unique', () => {
+    const none: RankedCandidate[] = [
+      { candidate: { kind: 'role', role: 'button' }, predictedCount: 4 },
+      { candidate: { kind: 'tagName', value: 'button' }, predictedCount: 9 },
+    ];
+    expect(none[chooseCandidate(none, 'selenium-java')].candidate.kind).toBe('tagName');
+  });
+});

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -20,8 +20,19 @@
           :elements="rows"
           :click-to-highlight="settings.clickTableRowsToViewMatchedElements"
           @highlight="highlight"
-          @edit="notYet('Edit')"
+          @edit="openEditor"
           @remove="removeElement"
+        />
+
+        <EditElementDialog
+          v-if="editing"
+          :key="editing.id"
+          :element="editing"
+          :framework-id="model.frameworkId"
+          :taken-names="model.elements.filter((e) => e.id !== editing!.id).map((e) => e.name)"
+          @close="editing = undefined"
+          @highlight="highlightCandidate"
+          @save="saveEdit"
         />
       </q-page>
     </q-page-container>
@@ -34,11 +45,13 @@ import { useQuasar } from 'quasar';
 import { browser } from 'wxt/browser';
 import AppToolbar from './AppToolbar.vue';
 import ModelTable, { type ModelRow } from './ModelTable.vue';
+import EditElementDialog from './EditElementDialog.vue';
 import { defaultFrameworkId } from '@/src/frameworks';
 import { displayLocator } from '@/src/locators/display';
-import { activeCandidate, emptyModel, type TabModel } from '@/src/model';
+import { activeCandidate, emptyModel, type ModelElement, type TabModel } from '@/src/model';
 import { isMessage, PANEL_PORT, type BackgroundToPanel, type PanelToBackground, type PanelToContent } from '@/src/messaging';
 import { hostKey } from '@/host/types';
+import type { LocatorCandidate } from '@/src/engine/types';
 import { defaultSettings } from '@/src/settings';
 
 // The panel is a VIEW. The background owns the model, one per tab (SPEC §5), so
@@ -54,6 +67,7 @@ const tabId = ref<number | undefined>();
 const model = ref<TabModel>(emptyModel(defaultFrameworkId));
 const isScanning = ref(false);
 const isAdding = ref(false);
+const editing = ref<ModelElement | undefined>();
 
 const rows = computed<ModelRow[]>(() =>
   model.value.elements.map((el) => ({
@@ -203,9 +217,25 @@ function clearHighlight() {
 
 function highlight(id: string) {
   const el = model.value.elements.find((e) => e.id === id);
-  if (!el || tabId.value == null) return;
+  if (!el) return;
+  highlightCandidate(activeCandidate(el));
+}
+
+/** Also used by the Edit dialog, which tests what is typed, not what is saved. */
+function highlightCandidate(candidate: LocatorCandidate) {
+  if (tabId.value == null) return;
   // Fire and forget; the count arrives as HIGHLIGHT_RESULT.
-  send(tabId.value, { type: 'HIGHLIGHT', candidate: activeCandidate(el) });
+  send(tabId.value, { type: 'HIGHLIGHT', candidate });
+}
+
+function openEditor(id: string) {
+  editing.value = model.value.elements.find((e) => e.id === id);
+}
+
+function saveEdit(payload: { name: string; selectedIndex: number; override?: LocatorCandidate }) {
+  if (!editing.value || tabId.value == null) return;
+  toBackground({ type: 'UPDATE_ELEMENT', tabId: tabId.value, id: editing.value.id, ...payload });
+  editing.value = undefined;
 }
 
 function showMatchCount(count: number) {

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -16,6 +16,18 @@
 
     <q-page-container>
       <q-page>
+        <!-- SPEC §5: a model is kept across a navigation, so it can end up
+             describing a page that is no longer loaded. Say so, rather than
+             leaving the user to wonder why the eye reports 0 for every row. -->
+        <div v-if="model.stale" class="stale-banner" data-testid="stale-banner">
+          <q-icon name="warning" size="18px" />
+          <div class="stale-text">
+            Built on a different page.
+            <span class="stale-url" :title="model.url ?? ''">{{ model.url }}</span>
+          </div>
+          <q-btn flat dense no-caps size="sm" label="Delete Model" data-testid="stale-delete" @click="deleteModel" />
+        </div>
+
         <ModelTable
           :elements="rows"
           :click-to-highlight="settings.clickTableRowsToViewMatchedElements"
@@ -282,3 +294,31 @@ function notYet(what: string) {
   notice('notYet', { message: `${what} — not built yet`, icon: 'construction', timeout: 1500 });
 }
 </script>
+
+<style scoped>
+.stale-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px var(--pm-gutter);
+  background: var(--pm-warning-bg);
+  color: var(--pm-warning-fg);
+  border-bottom: 1px solid var(--pm-rule);
+  font-size: 12px;
+}
+
+.stale-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* A URL is long and the panel is narrow; the full value is on the title. */
+.stale-url {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.85;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+</style>

--- a/v3/ui/EditElementDialog.vue
+++ b/v3/ui/EditElementDialog.vue
@@ -1,0 +1,151 @@
+<template>
+  <q-dialog v-model="open" @hide="$emit('close')">
+    <q-card class="edit-card">
+      <q-toolbar class="bg-primary text-white">
+        <q-toolbar-title class="text-subtitle1">Edit Element</q-toolbar-title>
+      </q-toolbar>
+
+      <q-card-section class="q-gutter-md">
+        <q-input
+          v-model="name"
+          dense
+          autofocus
+          label="Name"
+          :error="nameError !== ''"
+          :error-message="nameError"
+          data-testid="edit-name"
+          @keydown.enter="save"
+        />
+
+        <div class="locator-row">
+          <q-select
+            v-model="kind"
+            dense
+            emit-value
+            map-options
+            options-dense
+            class="type-select"
+            label="Type"
+            :options="typeOptions"
+            data-testid="edit-type"
+          />
+
+          <!-- One input per field the type needs: `role` takes a role AND a
+               name, so a single value box cannot express it (SPEC §12). -->
+          <q-input
+            v-for="field in fields"
+            :key="field.key"
+            v-model="values[field.key]"
+            dense
+            class="field"
+            :label="field.label"
+            :data-testid="`edit-${field.key}`"
+            @keydown.enter="save"
+          />
+
+          <q-btn flat dense round icon="visibility" data-testid="edit-highlight" @click="$emit('highlight', candidate)">
+            <q-tooltip>View Matched Elements</q-tooltip>
+          </q-btn>
+        </div>
+      </q-card-section>
+
+      <q-card-actions align="right">
+        <q-btn v-close-popup flat no-caps label="Cancel" data-testid="edit-cancel" />
+        <q-btn flat no-caps label="Save" :disable="nameError !== ''" data-testid="edit-save" @click="save" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import { frameworkById } from '@/src/frameworks';
+import { activeCandidate, type ModelElement } from '@/src/model';
+import { buildCandidate, fieldsFor, valuesOf, type LocatorKind } from '@/src/locators/fields';
+import type { LocatorCandidate } from '@/src/engine/types';
+
+const props = defineProps<{
+  element: ModelElement;
+  frameworkId: string;
+  /** Every other name in the model, for the uniqueness check. */
+  takenNames: string[];
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  highlight: [candidate: LocatorCandidate];
+  save: [payload: { name: string; selectedIndex: number; override?: LocatorCandidate }];
+}>();
+
+const open = ref(true);
+const name = ref(props.element.name);
+
+const current = activeCandidate(props.element);
+const kind = ref<LocatorKind>(current.kind);
+const values = ref<Record<string, string>>(valuesOf(current));
+
+/** The full framework list, not just what was generated (SPEC §7). */
+const typeOptions = computed(() => frameworkById(props.frameworkId).locatorTypes.map((t) => ({ label: t, value: t })));
+
+const fields = computed(() => fieldsFor(kind.value));
+const candidate = computed(() => buildCandidate(kind.value, values.value));
+
+/**
+ * Switching type reuses the generated candidate of that kind when there is one,
+ * and blanks the fields when there is not — the generated set is a convenience,
+ * never a constraint (SPEC §7).
+ */
+watch(kind, (next) => {
+  const generated = props.element.candidates.find((c) => c.candidate.kind === next);
+  values.value = generated ? valuesOf(generated.candidate) : Object.fromEntries(fieldsFor(next).map((f) => [f.key, '']));
+});
+
+const nameError = computed(() => {
+  const value = name.value.trim();
+  if (!value) return 'Name is required.';
+  if (/\s/.test(value)) return 'Name cannot contain spaces.';
+  if (props.takenNames.includes(value)) return 'Name must be unique.';
+  return '';
+});
+
+function save() {
+  if (nameError.value) return;
+  // An edited locator that matches a generated one is stored as that selection
+  // rather than an override, so it keeps tracking the engine's own verification.
+  const index = props.element.candidates.findIndex(
+    (c) => JSON.stringify(c.candidate) === JSON.stringify(candidate.value)
+  );
+  emit('save', {
+    name: name.value.trim(),
+    selectedIndex: index >= 0 ? index : props.element.selectedIndex,
+    override: index >= 0 ? undefined : candidate.value,
+  });
+  open.value = false;
+}
+</script>
+
+<style scoped>
+.edit-card {
+  width: 100%;
+  max-width: 720px;
+}
+
+/* Own flex rather than Quasar's `row` utility: a bare `row` class collides with
+   it everywhere else in this app, and one absolute rule is easier to keep than
+   a rule with exceptions. */
+.locator-row {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: nowrap;
+  gap: 8px;
+}
+
+.type-select {
+  flex: 0 0 34%;
+}
+
+.field {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+</style>

--- a/v3/ui/EditElementDialog.vue
+++ b/v3/ui/EditElementDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <q-dialog v-model="open" @hide="$emit('close')">
     <q-card class="edit-card">
-      <q-toolbar class="bg-primary text-white">
+      <q-toolbar class="dialog-header">
         <q-toolbar-title class="text-subtitle1">Edit Element</q-toolbar-title>
       </q-toolbar>
 
@@ -128,6 +128,17 @@ function save() {
 .edit-card {
   width: 100%;
   max-width: 720px;
+  background: var(--pm-page-bg);
+  color: var(--pm-text);
+}
+
+/* Neutral, like the main toolbar: the panel sits inside DevTools or a browser
+   sidebar and should read as part of that chrome, not as a branded surface. */
+.dialog-header {
+  background: var(--pm-toolbar-bg);
+  color: var(--pm-toolbar-fg);
+  border-bottom: 1px solid var(--pm-rule);
+  min-height: 44px;
 }
 
 /* Own flex rather than Quasar's `row` utility: a bare `row` class collides with

--- a/v3/ui/EditElementDialog.vue
+++ b/v3/ui/EditElementDialog.vue
@@ -43,7 +43,15 @@
             @keydown.enter="save"
           />
 
-          <q-btn flat dense round icon="visibility" data-testid="edit-highlight" @click="$emit('highlight', candidate)">
+          <q-btn
+            flat
+            dense
+            round
+            icon="visibility"
+            :disable="!locatorComplete"
+            data-testid="edit-highlight"
+            @click="$emit('highlight', candidate)"
+          >
             <q-tooltip>View Matched Elements</q-tooltip>
           </q-btn>
         </div>
@@ -51,7 +59,14 @@
 
       <q-card-actions align="right">
         <q-btn v-close-popup flat no-caps label="Cancel" data-testid="edit-cancel" />
-        <q-btn flat no-caps label="Save" :disable="nameError !== ''" data-testid="edit-save" @click="save" />
+        <q-btn
+          flat
+          no-caps
+          label="Save"
+          :disable="nameError !== '' || !locatorComplete"
+          data-testid="edit-save"
+          @click="save"
+        />
       </q-card-actions>
     </q-card>
   </q-dialog>
@@ -61,7 +76,7 @@
 import { ref, computed, watch } from 'vue';
 import { frameworkById } from '@/src/frameworks';
 import { activeCandidate, type ModelElement } from '@/src/model';
-import { buildCandidate, fieldsFor, valuesOf, type LocatorKind } from '@/src/locators/fields';
+import { buildCandidate, fieldsFor, isComplete, valuesOf, type LocatorKind } from '@/src/locators/fields';
 import type { LocatorCandidate } from '@/src/engine/types';
 
 const props = defineProps<{
@@ -91,6 +106,13 @@ const fields = computed(() => fieldsFor(kind.value));
 const candidate = computed(() => buildCandidate(kind.value, values.value));
 
 /**
+ * An incomplete locator is not testable or saveable. Blank does not mean "match
+ * anything" — an empty `label` matches every control with no accessible name,
+ * which is how it reported 8 matches for a field the user had not filled in.
+ */
+const locatorComplete = computed(() => isComplete(kind.value, values.value));
+
+/**
  * Switching type reuses the generated candidate of that kind when there is one,
  * and blanks the fields when there is not — the generated set is a convenience,
  * never a constraint (SPEC §7).
@@ -109,7 +131,7 @@ const nameError = computed(() => {
 });
 
 function save() {
-  if (nameError.value) return;
+  if (nameError.value || !locatorComplete.value) return;
   // An edited locator that matches a generated one is stored as that selection
   // rather than an override, so it keeps tracking the engine's own verification.
   const index = props.element.candidates.findIndex(

--- a/v3/ui/theme.css
+++ b/v3/ui/theme.css
@@ -18,6 +18,8 @@
   /* Horizontal inset for the table; v2.5.1 used 2em, too much at side-panel
      width where the whole panel can be ~350px. */
   --pm-gutter: 16px;
+  --pm-warning-bg: #fff4e0;
+  --pm-warning-fg: #7a4a00;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -32,6 +34,8 @@
     /* Quasar themes its own overlays (dialog, notify) from these. */
     --q-dark-page: #1e1f22;
     --q-dark: #2b2d31;
+    --pm-warning-bg: #3a2f18;
+    --pm-warning-fg: #ffcc80;
   }
 }
 
@@ -45,6 +49,8 @@
   --pm-row-hover: rgba(138, 180, 248, 0.12);
   --q-dark-page: #1e1f22;
   --q-dark: #2b2d31;
+  --pm-warning-bg: #3a2f18;
+  --pm-warning-fg: #ffcc80;
 }
 
 body {


### PR DESCRIPTION
`REWRITE-PLAN.md` §12 step 8 (SPEC §9). Name, locator type, the fields that type needs, and the eye; Cancel / Save.

## The dialog adapts to the type

A locator isn't a flat type/value pair — `getByRole` takes a role **and** a name (§12). `src/locators/fields.ts` describes what each type asks for and rebuilds a candidate from the answers, so the dialog shows two inputs for `role` and one for `css`.

Three behaviours worth calling out, because they're decisions rather than mechanics:

- **The eye tests what's currently typed, not what's saved.** That's the point of having it in the dialog — check a locator before committing to it.
- **A hand-edited locator that happens to equal a generated one is stored as that *selection*, not an override.** Otherwise it would silently stop tracking the engine's own verification.
- **`exact: true` survives editing.** The dialog doesn't expose `exact`, so dropping it on save would quietly loosen the locator.

Name validation is v2.5.1's: required, unique, no spaces.

## The IR grew Selenium's strategies

§7 says the type dropdown offers the **full framework list**. For Playwright all nine types existed; for Selenium none of `id`, `name`, `className`, `tagName`, `linkText`, `partialLinkText` did — so picking Selenium and opening Edit would have offered types the model couldn't hold.

They're now in the IR with resolution, so the eye can test a hand-typed Selenium locator. The engine still doesn't **generate** them — that's the superset generator, which the plan already places before step 10. TypeScript's exhaustive switches found all three places that needed updating, which is the argument for keeping those switches exhaustive.

## Tests

17 new component tests covering per-type fields, prefill-vs-blank on type change, the full framework list per target, all four name-validation cases, override-vs-selection on save, and `exact` surviving.

The Quasar collision guard caught my own dialog using a bare `row` class. It now uses its own flex — one absolute rule is easier to keep than a rule with exceptions.

## Hand-test

Pencil or double-click a row. Worth checking on both browsers: switching type between `role` (two fields) and `css` (one), the eye reporting on a locator you've typed but not saved, and Save updating the row in **both** surfaces at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)