### PR TITLE
v3: arrow keys walk the pick target up and down the DOM

### DIFF
--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -347,14 +347,10 @@ before starting the next.
    superset generator below — but the dialog offers the full framework list, so the model has to be
    able to hold a hand-typed one.
 
-9. **Ancestor navigation while picking** (SPEC §4). Arrow keys walk the target up and down the DOM,
-   with a breadcrumb of the chain replacing the single overlay label. The mouse alone cannot reliably
-   hit a nested element: a wrapper `<div>` and the `<div role="button">` inside it share a bounding box,
-   and selecting the wrapper meant finding a 2px sliver of padding.
-
-   **Before Scan, deliberately.** Scan's whole job is picking a *container*, and containers are exactly
-   the nested, same-box elements this fixes — building Scan first would ship a feature whose primary
-   interaction is the one we know is broken.
+9. **Ancestor navigation while picking** (SPEC §4). ✅ **Done** — arrow keys walk the target up and
+   down the DOM, with a breadcrumb of the chain replacing the single overlay label. Sequenced before
+   Scan deliberately: Scan's job is picking a *container*, and containers are exactly the nested,
+   same-box elements this fixes.
 
 10. **Scan** (SPEC §4). Container pick, interactive-role descendants, a11y-tree filtered.
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -125,8 +125,15 @@ assumptions: it is per *window*, it follows the active tab, and it outlives navi
 | Close the **last panel watching a tab** | that tab's model is dropped |
 | Both surfaces open | **the same model**, and a pick in one appears in the other |
 
-A model can therefore never be displayed against a page it was not built from. Nothing is persisted to
-storage; a model is session work, not a saved artifact.
+A model can therefore never be displayed against a page it was not built from. A model is session work,
+not a saved artifact: it is held in `chrome.storage.session`, which lives in memory, is cleared when the
+browser closes, and is never written to disk.
+
+**Not in the background's own memory**, which is where it started. An MV3 service worker is terminated
+after 30 seconds of inactivity, and since Chrome 114 an open port does not reset that timer — so every
+model silently vanished after half a minute of not clicking, and appeared to come back only because
+restarting the browser gave you a fresh worker. Panels reconnect their port when the worker restarts,
+or the background stops knowing which tab each panel is on.
 
 **The background owns it, and panels are views** — they render what it broadcasts and mutate it by
 sending commands. Held in a panel it was one model per *panel*: a sidebar and a DevTools panel on the

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -51,7 +51,10 @@ tag shown only when it differs from the role. It previews the locator rather tha
 at three ancestors, elided with `…` beyond that. **[settled]**
 
 **Arrow keys move the target up and down the chain** — ↑ to the parent, ↓ back towards the element under
-the cursor; moving the mouse starts again from there, and a click picks whatever is currently targeted.
+the cursor; moving the mouse starts again from there. **Enter commits the target**, as does a click —
+whichever is currently targeted, not what is under the pointer. Enter matters because hands are already
+on the arrows by then, and because the Add Element button still has focus: an unhandled Enter would
+re-activate it and cancel the pick.
 The mouse alone cannot reliably hit a nested element: a wrapper `<div>` and the `<div role="button">`
 inside it share a bounding box, so selecting the wrapper meant finding a sliver of padding. Arrow keys
 are swallowed while picking even at the ends of the chain, so the page cannot scroll out from under a

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -249,7 +249,12 @@ CANCEL / SAVE. **[settled]**
 
 ## 10. Delete Model
 
-Confirm dialog — *"Really delete the model?"* — YES / CANCEL. **[settled]**
+Confirm dialog — *"Really delete the model?"* — YES / CANCEL, with **Yes** styled as destructive.
+Same for deleting a single element. **[settled]**
+
+Both set their button colours explicitly: Quasar's dialog plugin defaults to `isDark() ? 'amber' :
+'primary'`, which made a delete confirm yellow on a dark panel and gave it the same weight as any other
+dialog.
 
 ## 11. Generate Code
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -57,6 +57,11 @@ inside it share a bounding box, so selecting the wrapper meant finding a sliver 
 are swallowed while picking even at the ends of the chain, so the page cannot scroll out from under a
 pick. ↑ stops at `<body>`. **[settled]**
 
+The panel handles these keys too, and only while picking: after clicking Add Element focus is in the
+panel, so the page never receives the keydown — the same reason the panel also handles Escape. It stands
+aside when the keystroke belongs to a control, since the framework dropdown is reachable while the model
+is still empty.
+
 **Scan Page** — pick a *container*: the whole page or any subsection (typically a `div` or `form`). Its
 **interactive descendants** enter the model. Non-interactive elements (`p`, `span`, …) are skipped. The
 container itself is not added, only children. Scan is **once per model**; Add is how you extend it.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -40,11 +40,22 @@ does not exist in Playwright). The user knows their target before they start.
 
 ## 4. Capture
 
-**The overlay labels what you are about to pick** — the computed role, then the accessible name, with
-the tag shown only when it differs from the role: `button "Save"`, `button (div) "Log in"`, or plain
-`div` for a wrapper. It previews the locator rather than naming the tag, which matters because a wrapper
-`<div>` and the `<div role="button">` inside it have the same bounding box and both used to read `div`.
-**[settled]**
+**The overlay labels what you are about to pick**, as a breadcrumb of the nesting ending in the target:
+
+```
+body › main › div › button (div) "Continue to checkout"
+```
+
+Ancestors are role-or-tag only; the target carries its computed role, then the accessible name, with its
+tag shown only when it differs from the role. It previews the locator rather than naming the tag. Capped
+at three ancestors, elided with `…` beyond that. **[settled]**
+
+**Arrow keys move the target up and down the chain** — ↑ to the parent, ↓ back towards the element under
+the cursor; moving the mouse starts again from there, and a click picks whatever is currently targeted.
+The mouse alone cannot reliably hit a nested element: a wrapper `<div>` and the `<div role="button">`
+inside it share a bounding box, so selecting the wrapper meant finding a sliver of padding. Arrow keys
+are swallowed while picking even at the ends of the chain, so the page cannot scroll out from under a
+pick. ↑ stops at `<body>`. **[settled]**
 
 **Scan Page** — pick a *container*: the whole page or any subsection (typically a `div` or `form`). Its
 **interactive descendants** enter the model. Non-interactive elements (`p`, `span`, …) are skipped. The

--- a/v3/README.md
+++ b/v3/README.md
@@ -75,7 +75,8 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    again without pressing Add must not add a second row.
    - The label is a breadcrumb ending in the target: `body › main › div › button (div) "Log in"`.
    - **↑ / ↓** walk the target up and down the nesting; moving the mouse starts again from the cursor.
-     A click picks the walked-to element, not what is under the pointer. The page must not scroll.
+     **Enter** or a click picks the walked-to element, not what is under the pointer. The page must not
+     scroll, and Enter must not re-trigger the Add Element button.
 5. **Escape** cancels Add Element — both with focus in the panel and with focus in the page.
 6. The row's name and locator look right, **on one line** — Name, Locator and Actions across, not
    stacked; a second element with the same name becomes `About2`.

--- a/v3/README.md
+++ b/v3/README.md
@@ -73,6 +73,9 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    Generate Code visibly disabled while the model is empty (SPEC §3).
 4. **Add Element** → hover highlights → click adds one row, then picking *stops* (SPEC §4). Clicking
    again without pressing Add must not add a second row.
+   - The label is a breadcrumb ending in the target: `body › main › div › button (div) "Log in"`.
+   - **↑ / ↓** walk the target up and down the nesting; moving the mouse starts again from the cursor.
+     A click picks the walked-to element, not what is under the pointer. The page must not scroll.
 5. **Escape** cancels Add Element — both with focus in the panel and with focus in the page.
 6. The row's name and locator look right, **on one line** — Name, Locator and Actions across, not
    stacked; a second element with the same name becomes `About2`.

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -22,11 +22,16 @@ export default defineBackground(() => {
   console.log('[Page Modeller] background ready', import.meta.env.MODE, import.meta.env.BROWSER);
 
   const store = new ModelStore(defaultFrameworkId);
-  let idSeq = 0;
 
   /** Every panel gets the model; each ignores tabs that are not its own. */
   function publish(tabId: number, model: TabModel) {
     browser.runtime.sendMessage({ type: 'MODEL', tabId, model }).catch(() => {});
+  }
+
+  /** Apply a change and tell every panel. The store is async now: it lives in
+   *  storage.session, because the worker itself does not survive 30s idle. */
+  async function change(tabId: number, mutate: (model: TabModel) => void) {
+    publish(tabId, await store.mutate(tabId, mutate));
   }
 
   browser.tabs.onRemoved.addListener((tabId) => store.clear(tabId));
@@ -35,13 +40,12 @@ export default defineBackground(() => {
   // The background has to notice: a DevTools panel cannot read the tab's URL.
   browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
     if (!changeInfo.url) return;
-    const model = store.get(tabId);
-    if (model.url == null) return;
-    const stale = model.url !== changeInfo.url;
-    if (stale === model.stale) return;
-    // Navigating back to where it was built makes it current again.
-    model.stale = stale;
-    publish(tabId, model);
+    const url = changeInfo.url;
+    void store.mutate(tabId, (model) => {
+      if (model.url == null) return;
+      // Navigating back to where it was built makes it current again.
+      model.stale = model.url !== url;
+    }).then((model) => publish(tabId, model));
   });
 
   // A model with no panel watching it is abandoned work (SPEC §5). Each panel
@@ -73,9 +77,11 @@ export default defineBackground(() => {
         console.log('[Page Modeller] panel closed; was watching tab', wasOn, stillWatched ? '— still watched' : '— dropping model');
       }
       if (wasOn == null || stillWatched) return;
-      store.clear(wasOn);
-      // Any panel still listening shows an empty table rather than stale rows.
-      publish(wasOn, store.get(wasOn));
+      void store
+        .clear(wasOn)
+        .then(() => store.get(wasOn))
+        // Any panel still listening shows an empty table rather than stale rows.
+        .then((model) => publish(wasOn, model));
     });
   });
 
@@ -88,18 +94,21 @@ export default defineBackground(() => {
       case 'ELEMENT_PICKED': {
         const tabId = sender.tab?.id;
         if (tabId == null) return;
-        const model = store.get(tabId);
-        // The page the model belongs to, recorded when the first element lands.
-        if (model.url == null) model.url = sender.tab?.url ?? null;
-        model.elements.push({
-          ...m.result,
-          id: `el-${idSeq++}`,
-          name: uniqueName(m.result.suggestedName, usedNames(model)),
-          // Not the engine's preferredIndex: that is framework-agnostic, and
-          // would hand a Selenium model a Playwright-only locator.
-          selectedIndex: chooseCandidate(m.result.candidates, model.frameworkId),
+        const url = sender.tab?.url ?? null;
+        void change(tabId, (model) => {
+          // The page the model belongs to, recorded when the first element lands.
+          if (model.url == null) model.url = url;
+          model.elements.push({
+            ...m.result,
+            // Unique within the model rather than a worker-lifetime counter:
+            // the worker restarts, and the counter would restart with it.
+            id: `el-${Date.now().toString(36)}-${model.elements.length}`,
+            name: uniqueName(m.result.suggestedName, usedNames(model)),
+            // Not the engine's preferredIndex: that is framework-agnostic, and
+            // would hand a Selenium model a Playwright-only locator.
+            selectedIndex: chooseCandidate(m.result.candidates, model.frameworkId),
+          });
         });
-        publish(tabId, model);
         // Picking is one-shot (SPEC §4); tell the panels so they can un-arm.
         browser.runtime.sendMessage({ type: 'FROM_TAB', tabId, message: { type: 'PICKING_STOPPED' } }).catch(() => {});
         return;
@@ -124,37 +133,33 @@ export default defineBackground(() => {
         return;
       }
       case 'GET_MODEL':
-        publish(m.tabId, store.get(m.tabId));
+        void store.get(m.tabId).then((model) => publish(m.tabId, model));
         return;
-      case 'DELETE_ELEMENT': {
-        const model = store.get(m.tabId);
-        model.elements = model.elements.filter((e) => e.id !== m.id);
-        publish(m.tabId, model);
+      case 'DELETE_ELEMENT':
+        void change(m.tabId, (model) => {
+          model.elements = model.elements.filter((e) => e.id !== m.id);
+        });
         return;
-      }
-      case 'UPDATE_ELEMENT': {
-        const model = store.get(m.tabId);
-        const el = model.elements.find((e) => e.id === m.id);
-        if (!el) return;
-        el.name = m.name;
-        el.selectedIndex = m.selectedIndex;
-        // Absent means "use the generated candidate again", so it must be
-        // deleted rather than set to undefined — the model is serialised.
-        if (m.override) el.override = m.override;
-        else delete el.override;
-        publish(m.tabId, model);
+      case 'UPDATE_ELEMENT':
+        void change(m.tabId, (model) => {
+          const el = model.elements.find((e) => e.id === m.id);
+          if (!el) return;
+          el.name = m.name;
+          el.selectedIndex = m.selectedIndex;
+          // Absent means "use the generated candidate again", so it must be
+          // deleted rather than set to undefined — the model is serialised.
+          if (m.override) el.override = m.override;
+          else delete el.override;
+        });
         return;
-      }
       case 'DELETE_MODEL':
-        store.clear(m.tabId);
-        publish(m.tabId, store.get(m.tabId));
+        void store.clear(m.tabId).then(() => store.get(m.tabId)).then((model) => publish(m.tabId, model));
         return;
-      case 'SET_FRAMEWORK': {
-        const model = store.get(m.tabId);
-        model.frameworkId = m.frameworkId;
-        publish(m.tabId, model);
+      case 'SET_FRAMEWORK':
+        void change(m.tabId, (model) => {
+          model.frameworkId = m.frameworkId;
+        });
         return;
-      }
     }
   });
 

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -1,5 +1,5 @@
 import { generate, resolveCandidate } from '@/src/engine/candidates';
-import { describeElement } from '@/src/engine/describe';
+import { describeBrief, describeElement } from '@/src/engine/describe';
 import { isMessage, type Message } from '@/src/messaging';
 
 // Inspector overlay: highlight the element under the cursor (like DevTools) and,
@@ -12,6 +12,8 @@ export default defineContentScript({
     let box: HTMLDivElement | null = null;
     let label: HTMLDivElement | null = null;
     let current: Element | null = null;
+    /** Last element under the cursor; the floor for walking back down. */
+    let hovered: Element | null = null;
 
     const Z = '2147483647';
 
@@ -47,14 +49,57 @@ export default defineContentScript({
       box?.remove();
       label?.remove();
       box = label = null;
-      current = null;
+      current = hovered = null;
+    }
+
+    /** How many ancestors the breadcrumb shows before eliding. */
+    const CRUMB_DEPTH = 3;
+
+    /**
+     * The chain from a few ancestors down to the target, target emphasised.
+     *
+     * Two jobs: say where you are in the nesting, and make it obvious that
+     * wrappers exist at all — before this there was no way to know a
+     * same-sized parent was there until you accidentally hit it.
+     *
+     * Built as elements rather than innerHTML: the text comes from the page.
+     */
+    function renderBreadcrumb(el: Element) {
+      const chain: Element[] = [];
+      for (let cur: Element | null = el.parentElement; cur && cur !== document.documentElement; cur = cur.parentElement) {
+        chain.unshift(cur);
+      }
+      const shown = chain.slice(-CRUMB_DEPTH);
+
+      label!.replaceChildren();
+      if (chain.length > shown.length) label!.appendChild(crumb('…', false));
+      for (const ancestor of shown) {
+        label!.appendChild(crumb(describeBrief(ancestor), false));
+      }
+      label!.appendChild(crumb(describeElement(el), true));
+    }
+
+    function crumb(text: string, isTarget: boolean): HTMLSpanElement {
+      const span = document.createElement('span');
+      span.textContent = text;
+      Object.assign(span.style, {
+        opacity: isTarget ? '1' : '0.55',
+        fontWeight: isTarget ? '600' : '400',
+      } as CSSStyleDeclaration);
+      if (label!.childNodes.length > 0) {
+        const sep = document.createElement('span');
+        sep.textContent = ' › ';
+        sep.style.opacity = '0.4';
+        label!.appendChild(sep);
+      }
+      return span;
     }
 
     function highlight(el: Element) {
       ensureOverlay();
       const r = el.getBoundingClientRect();
       Object.assign(box!.style, { left: `${r.left}px`, top: `${r.top}px`, width: `${r.width}px`, height: `${r.height}px` });
-      label!.textContent = describeElement(el);
+      renderBreadcrumb(el);
       label!.style.left = `${r.left}px`;
       label!.style.top = `${Math.max(0, r.top - 18)}px`;
     }
@@ -109,7 +154,10 @@ export default defineContentScript({
     const onMove = (e: MouseEvent) => {
       if (!active) return;
       const el = e.target as Element | null;
-      if (!el || el === current) return;
+      if (!el || el === hovered) return;
+      // Moving the mouse abandons any arrow-key walk and starts again from
+      // whatever is under the cursor.
+      hovered = el;
       current = el;
       highlight(el);
     };
@@ -118,7 +166,9 @@ export default defineContentScript({
       if (!active) return;
       e.preventDefault();
       e.stopPropagation();
-      const el = e.target as Element;
+      // The CURRENT target, not e.target: the arrows may have walked away from
+      // the element under the cursor, and that is the whole point of them.
+      const el = current ?? (e.target as Element);
       const result = generate(el);
       // Both modes are one-shot (SPEC §4) — stop before reporting, so the
       // overlay is gone by the time the panel re-renders.
@@ -127,8 +177,40 @@ export default defineContentScript({
       browser.runtime.sendMessage({ type: 'ELEMENT_PICKED', result }).catch(() => {});
     };
 
+    /** The child of `of` that contains `hovered`, for walking back down. */
+    function childTowardsHovered(of: Element): Element | null {
+      if (!hovered || of === hovered) return null;
+      let cur: Element | null = hovered;
+      while (cur && cur.parentElement && cur.parentElement !== of) cur = cur.parentElement;
+      return cur?.parentElement === of ? cur : null;
+    }
+
     const onKey = (e: KeyboardEvent) => {
-      if (active && e.key === 'Escape') stop();
+      if (!active) return;
+      if (e.key === 'Escape') return stop();
+
+      // Arrow keys walk the target up and down the DOM. The mouse alone cannot
+      // reliably hit a nested element: a wrapper <div> and the
+      // <div role="button"> inside it share a bounding box, so selecting the
+      // wrapper meant finding a sliver of padding.
+      let next: Element | null = null;
+      if (e.key === 'ArrowUp') {
+        const parent = current?.parentElement;
+        // Stop at <body>: <html> is never a useful target.
+        if (parent && parent !== document.documentElement) next = parent;
+      } else if (e.key === 'ArrowDown') {
+        next = current ? childTowardsHovered(current) : null;
+      } else {
+        return;
+      }
+
+      // Swallow the key even at the ends of the chain, so the page does not
+      // scroll out from under a pick that is mid-flight.
+      e.preventDefault();
+      e.stopPropagation();
+      if (!next) return;
+      current = next;
+      highlight(next);
     };
 
     function start() {

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -162,19 +162,25 @@ export default defineContentScript({
       highlight(el);
     };
 
+    /** Commit the current target. Shared by clicking and by Enter. */
+    function pickCurrent() {
+      if (!active || !current) return;
+      const result = generate(current);
+      // Both modes are one-shot (SPEC §4) — stop before reporting, so the
+      // overlay is gone by the time the panel re-renders.
+      stop({ notify: false });
+      // Rejects when no panel is open; that's fine, drop it.
+      browser.runtime.sendMessage({ type: 'ELEMENT_PICKED', result }).catch(() => {});
+    }
+
     const onClick = (e: MouseEvent) => {
       if (!active) return;
       e.preventDefault();
       e.stopPropagation();
       // The CURRENT target, not e.target: the arrows may have walked away from
       // the element under the cursor, and that is the whole point of them.
-      const el = current ?? (e.target as Element);
-      const result = generate(el);
-      // Both modes are one-shot (SPEC §4) — stop before reporting, so the
-      // overlay is gone by the time the panel re-renders.
-      stop({ notify: false });
-      // Rejects when no panel is open; that's fine, drop it.
-      browser.runtime.sendMessage({ type: 'ELEMENT_PICKED', result }).catch(() => {});
+      if (!current) current = e.target as Element;
+      pickCurrent();
     };
 
     /** The child of `of` that contains `hovered`, for walking back down. */
@@ -208,6 +214,14 @@ export default defineContentScript({
     const onKey = (e: KeyboardEvent) => {
       if (!active) return;
       if (e.key === 'Escape') return stop();
+
+      if (e.key === 'Enter') {
+        // Hands are already on the arrows; Enter is the obvious commit.
+        e.preventDefault();
+        e.stopPropagation();
+        return pickCurrent();
+      }
+
       if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
 
       // Swallow the key even at the ends of the chain, so the page does not
@@ -246,6 +260,7 @@ export default defineContentScript({
       else if (m.type === 'STOP_PICKING') stop();
       else if (m.type === 'CLEAR_HIGHLIGHT') clearMarks();
       else if (m.type === 'MOVE_TARGET') moveTarget(m.direction);
+      else if (m.type === 'PICK_TARGET') pickCurrent();
       else if (m.type === 'HIGHLIGHT') {
         // This script runs in every frame, but only the top one answers — a
         // sub-frame with no matches would otherwise report 0 over the top

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -185,32 +185,36 @@ export default defineContentScript({
       return cur?.parentElement === of ? cur : null;
     }
 
+    /**
+     * Walk the target up or down the DOM. The mouse alone cannot reliably hit a
+     * nested element: a wrapper <div> and the <div role="button"> inside it
+     * share a bounding box, so selecting the wrapper meant finding a sliver of
+     * padding.
+     */
+    function moveTarget(direction: 'up' | 'down') {
+      if (!active || !current) return;
+      const next =
+        direction === 'up'
+          ? // Stop at <body>: <html> is never a useful target.
+            current.parentElement && current.parentElement !== document.documentElement
+            ? current.parentElement
+            : null
+          : childTowardsHovered(current);
+      if (!next) return;
+      current = next;
+      highlight(next);
+    }
+
     const onKey = (e: KeyboardEvent) => {
       if (!active) return;
       if (e.key === 'Escape') return stop();
-
-      // Arrow keys walk the target up and down the DOM. The mouse alone cannot
-      // reliably hit a nested element: a wrapper <div> and the
-      // <div role="button"> inside it share a bounding box, so selecting the
-      // wrapper meant finding a sliver of padding.
-      let next: Element | null = null;
-      if (e.key === 'ArrowUp') {
-        const parent = current?.parentElement;
-        // Stop at <body>: <html> is never a useful target.
-        if (parent && parent !== document.documentElement) next = parent;
-      } else if (e.key === 'ArrowDown') {
-        next = current ? childTowardsHovered(current) : null;
-      } else {
-        return;
-      }
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
 
       // Swallow the key even at the ends of the chain, so the page does not
       // scroll out from under a pick that is mid-flight.
       e.preventDefault();
       e.stopPropagation();
-      if (!next) return;
-      current = next;
-      highlight(next);
+      moveTarget(e.key === 'ArrowUp' ? 'up' : 'down');
     };
 
     function start() {
@@ -241,6 +245,7 @@ export default defineContentScript({
       if (m.type === 'START_PICKING') start();
       else if (m.type === 'STOP_PICKING') stop();
       else if (m.type === 'CLEAR_HIGHLIGHT') clearMarks();
+      else if (m.type === 'MOVE_TARGET') moveTarget(m.direction);
       else if (m.type === 'HIGHLIGHT') {
         // This script runs in every frame, but only the top one answers — a
         // sub-frame with no matches would otherwise report 0 over the top

--- a/v3/host/sidepanel.ts
+++ b/v3/host/sidepanel.ts
@@ -17,15 +17,22 @@ export function sidePanelHost(): PanelHost {
   // tabs.onActivated fires for every window, but `currentWindow` keeps the
   // answer scoped to ours — so announce only when the answer actually moves,
   // otherwise another window's tab switch would reset this panel.
-  async function announce() {
+  async function announce(reason: string) {
     const tabId = await getTabId();
+    if (import.meta.env.DEV) console.log('[Page Modeller] side panel', reason, '→ tab', tabId, tabId === last ? '(unchanged)' : '(changed)');
     if (tabId === last) return;
     last = tabId;
     for (const cb of listeners) cb(tabId);
   }
 
-  browser.tabs.onActivated.addListener(announce);
-  browser.windows.onFocusChanged.addListener(announce);
+  // The standard trio for following the active tab from a side panel. onUpdated
+  // is not redundant: a tab can become the one we should be showing without
+  // onActivated firing — a fresh tab that then navigates, for instance.
+  browser.tabs.onActivated.addListener(() => announce('tabs.onActivated'));
+  browser.tabs.onUpdated.addListener((_id, _change, tab) => {
+    if (tab.active) void announce('tabs.onUpdated');
+  });
+  browser.windows.onFocusChanged.addListener(() => announce('windows.onFocusChanged'));
 
   return {
     kind: 'sidepanel',

--- a/v3/src/engine/describe.ts
+++ b/v3/src/engine/describe.ts
@@ -12,6 +12,13 @@ import { safeName, safeRole } from './candidates';
 
 const MAX_NAME = 30;
 
+/** Role or tag only — for ancestors in the breadcrumb, where names are noise. */
+export function describeBrief(el: Element): string {
+  const raw = safeRole(el);
+  const role = raw && raw !== 'none' && raw !== 'presentation' ? raw : '';
+  return role || el.localName;
+}
+
 export function describeElement(el: Element): string {
   const raw = safeRole(el);
   // `none` and `presentation` remove an element from the accessibility tree,

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -14,6 +14,8 @@ export type PanelToContent =
   // because focus is there after clicking Add Element, so the page never sees
   // the keydown — the same reason the panel also handles Escape.
   | { type: 'MOVE_TARGET'; direction: 'up' | 'down' }
+  // Commit the current target — Enter, for when the arrows are being used.
+  | { type: 'PICK_TARGET' }
   // View Matched Elements (SPEC §8). Answered by HIGHLIGHT_RESULT, not by a
   // reply — see the note on ContentToPanel below.
   | { type: 'HIGHLIGHT'; candidate: LocatorCandidate }

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -10,6 +10,10 @@ export type PickMode = 'add' | 'scan';
 export type PanelToContent =
   | { type: 'START_PICKING'; mode: PickMode }
   | { type: 'STOP_PICKING' }
+  // Walk the pick target up or down the DOM (SPEC §4). Sent by the panel
+  // because focus is there after clicking Add Element, so the page never sees
+  // the keydown — the same reason the panel also handles Escape.
+  | { type: 'MOVE_TARGET'; direction: 'up' | 'down' }
   // View Matched Elements (SPEC §8). Answered by HIGHLIGHT_RESULT, not by a
   // reply — see the note on ContentToPanel below.
   | { type: 'HIGHLIGHT'; candidate: LocatorCandidate }

--- a/v3/src/model.ts
+++ b/v3/src/model.ts
@@ -7,6 +7,7 @@
 // to be listening.
 //
 // Nothing is persisted. A model lives as long as its tab.
+import { browser } from 'wxt/browser';
 import type { ElementResult, LocatorCandidate } from './engine/types';
 
 export interface ModelElement extends ElementResult {
@@ -50,23 +51,67 @@ export function usedNames(model: TabModel): Set<string> {
   return new Set(model.elements.map((e) => e.name));
 }
 
-/** Per-tab store. Lives in the background; entries die with their tab. */
+/**
+ * Per-tab store, backed by `chrome.storage.session`.
+ *
+ * NOT a plain Map in the background's memory, which is where this started. An
+ * MV3 service worker is terminated after 30 seconds of inactivity, and since
+ * Chrome 114 an open port does not reset that timer — so every model silently
+ * vanished after half a minute of not clicking, and came back only because
+ * restarting the browser gave you a fresh worker.
+ *
+ * `storage.session` is the right store rather than `storage.local`: it lives in
+ * memory, is cleared when the browser closes, and is never written to disk, so
+ * SPEC §5 still holds — a model is session work, not a saved artifact. It just
+ * outlives the worker now.
+ *
+ * Writes are serialised through one chain: every change is a read-modify-write
+ * of the whole map, and two overlapping ones would lose an update.
+ */
+const KEY = 'models';
+
+type Models = Record<string, TabModel>;
+
 export class ModelStore {
-  private byTab = new Map<number, TabModel>();
+  private queue: Promise<unknown> = Promise.resolve();
 
   constructor(private defaultFrameworkId: string) {}
 
-  get(tabId: number): TabModel {
-    let m = this.byTab.get(tabId);
-    if (!m) {
-      m = emptyModel(this.defaultFrameworkId);
-      this.byTab.set(tabId, m);
-    }
-    return m;
+  private async read(): Promise<Models> {
+    const stored = (await browser.storage.session.get(KEY)) as { models?: Models };
+    return stored.models ?? {};
   }
 
-  clear(tabId: number): void {
-    this.byTab.delete(tabId);
+  /** Run `change` against the stored map, serialised, and return the result. */
+  private update<T>(change: (models: Models) => T): Promise<T> {
+    const next = this.queue.then(async () => {
+      const models = await this.read();
+      const result = change(models);
+      await browser.storage.session.set({ [KEY]: models });
+      return result;
+    });
+    // Keep the chain going even if one change throws.
+    this.queue = next.catch(() => undefined);
+    return next;
   }
 
+  /** The model for a tab, created empty if this is the first time. */
+  get(tabId: number): Promise<TabModel> {
+    return this.update((models) => (models[tabId] ??= emptyModel(this.defaultFrameworkId)));
+  }
+
+  /** Read, change, and store in one serialised step. */
+  mutate(tabId: number, change: (model: TabModel) => void): Promise<TabModel> {
+    return this.update((models) => {
+      const model = (models[tabId] ??= emptyModel(this.defaultFrameworkId));
+      change(model);
+      return model;
+    });
+  }
+
+  clear(tabId: number): Promise<void> {
+    return this.update((models) => {
+      delete models[tabId];
+    });
+  }
 }

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -32,8 +32,12 @@ test.afterAll(async () => {
  * accumulate across tests in one persistent context, and tabs.query({url})
  * would otherwise return an earlier test's tab.
  */
-async function openFixture(sw: { evaluate: (fn: never, arg?: unknown) => Promise<unknown> }, caseName: string) {
-  const url = `http://localhost:${PORT}/login.html?case=${caseName}`;
+async function openFixture(
+  sw: { evaluate: (fn: never, arg?: unknown) => Promise<unknown> },
+  caseName: string,
+  file = 'login.html'
+) {
+  const url = `http://localhost:${PORT}/${file}?case=${caseName}`;
   const page = await context.newPage();
   await page.goto(url);
   const tabId = (await (sw as unknown as { evaluate: (f: (u: string) => Promise<number>, a: string) => Promise<number> }).evaluate(
@@ -514,31 +518,70 @@ test('the overlay label previews the locator, not just the tag', async () => {
   let [sw] = context.serviceWorkers();
   if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
 
-  const url = `http://localhost:${PORT}/widgets.html`;
-  const page = await context.newPage();
-  await page.goto(url);
-  const tabId: number = await sw.evaluate(async (u) => (await chrome.tabs.query({ url: u }))[0].id!, url);
-
+  const { page, tabId } = await openFixture(sw as never, 'label', 'widgets.html');
   await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
   const label = page.locator('[data-page-modeller="label"]');
 
-  // Role first, then the accessible name — the label previews what getByRole
-  // will match on.
+  // The label is a breadcrumb ending in the target; the chain itself is covered
+  // by the arrow-key test. Here it is the target's description that matters:
+  // role first, then the accessible name, previewing what getByRole matches on.
   await page.getByRole('button', { name: 'Save' }).hover();
-  await expect(label).toHaveText('button "Save"');
+  await expect(label).toHaveText(/› button "Save"$/);
 
   // Tag shown only when it differs from the role. This is the case it was
   // written for: a <div role="button"> and the plain <div> wrapping it have the
   // same bounding box and both used to read just "div".
   await page.getByRole('button', { name: 'Continue to checkout' }).hover();
-  await expect(label).toHaveText('button (div) "Continue to checkout"');
+  await expect(label).toHaveText(/› button \(div\) "Continue to checkout"$/);
 
   // The wrapper is now plainly distinguishable from the control inside it.
   await page.locator('.cta-wrapper').hover({ position: { x: 2, y: 2 } });
-  await expect(label).toHaveText('div');
+  await expect(label).toHaveText(/› div$/);
 
   // Formatting details — truncation, role="none", missing names — are covered
   // by tests/unit/describe.test.ts against the same function. This test exists
   // for the thing only a real browser can show: that hovering two elements with
   // identical bounding boxes now tells them apart.
+});
+
+test('arrow keys walk the target up and down the DOM', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'arrows', 'widgets.html');
+
+  await sw.evaluate(() => {
+    const g = globalThis as unknown as { __picks: unknown[]; __collecting?: boolean };
+    g.__picks = [];
+    if (g.__collecting) return;
+    g.__collecting = true;
+    chrome.runtime.onMessage.addListener((m) => g.__picks.push(m));
+  });
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
+
+  const label = page.locator('[data-page-modeller="label"]');
+  await page.getByRole('button', { name: 'Continue to checkout' }).hover();
+  // Ancestors are role-or-tag only; the target carries its accessible name.
+  await expect(label).toHaveText('body › main › div › button (div) "Continue to checkout"');
+
+  // Up moves to the wrapper — the element that needed a 2px sliver of padding
+  // to hit with the mouse.
+  await page.keyboard.press('ArrowUp');
+  await expect(label).toHaveText('body › main › div');
+
+  // Down walks back towards the element under the cursor.
+  await page.keyboard.press('ArrowDown');
+  await expect(label).toHaveText('body › main › div › button (div) "Continue to checkout"');
+
+  // Clicking picks the walked-to target, not what is under the pointer.
+  await page.keyboard.press('ArrowUp');
+  await page.getByRole('button', { name: 'Continue to checkout' }).click();
+
+  await expect
+    .poll(async () => (await sw.evaluate(() => (globalThis as unknown as { __picks: { type: string }[] }).__picks)).length)
+    .toBe(1);
+  const picks = await sw.evaluate(() => (globalThis as unknown as { __picks: Record<string, unknown>[] }).__picks);
+  const result = picks[0].result as { tag: string; role: string | null };
+  expect(result.tag, 'picked the wrapper, not the button under the cursor').toBe('div');
+  expect(result.role).toBeNull();
 });

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -573,6 +573,13 @@ test('arrow keys walk the target up and down the DOM', async () => {
   await page.keyboard.press('ArrowDown');
   await expect(label).toHaveText('body › main › div › button (div) "Continue to checkout"');
 
+  // The panel drives the same move over a message, because after clicking Add
+  // Element focus is in the panel and the page never sees the keydown.
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'MOVE_TARGET', direction: 'up' }), tabId);
+  await expect(label).toHaveText('body › main › div');
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'MOVE_TARGET', direction: 'down' }), tabId);
+  await expect(label).toHaveText('body › main › div › button (div) "Continue to checkout"');
+
   // Clicking picks the walked-to target, not what is under the pointer.
   await page.keyboard.press('ArrowUp');
   await page.getByRole('button', { name: 'Continue to checkout' }).click();

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -594,3 +594,46 @@ test('arrow keys walk the target up and down the DOM', async () => {
   expect(result.tag, 'picked the wrapper, not the button under the cursor').toBe('div');
   expect(result.role).toBeNull();
 });
+
+test('the model lives outside the service worker, not in it', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  for (const open of context.pages()) {
+    if (open.url().startsWith('chrome-extension://')) await open.close();
+  }
+
+  const { page, tabId } = await openFixture(sw as never, 'session-storage');
+
+  const panel = await context.newPage();
+  await panel.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await panel.evaluate(
+    ([name, id]) => {
+      chrome.runtime.connect({ name: name as string }).postMessage({ tabId: id as number });
+    },
+    ['page-modeller-panel', tabId] as [string, number]
+  );
+
+  await panel.evaluate(
+    (id) => chrome.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: id, message: { type: 'START_PICKING', mode: 'add' } }),
+    tabId
+  );
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Chrome terminates the worker after 30s of inactivity, and since Chrome 114
+  // an open port does not hold it open. A model in worker memory simply
+  // vanished — which is why it "came back" after restarting the browser.
+  // storage.session survives that: in memory, cleared when the browser closes,
+  // never written to disk, so SPEC §5 still holds.
+  await expect
+    .poll(async () =>
+      panel.evaluate(async (id) => {
+        const stored = (await chrome.storage.session.get('models')) as {
+          models?: Record<string, { elements: { name: string }[] }>;
+        };
+        return stored.models?.[id]?.elements.map((e) => e.name);
+      }, tabId)
+    )
+    .toEqual(['SignIn']);
+});

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -580,9 +580,11 @@ test('arrow keys walk the target up and down the DOM', async () => {
   await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'MOVE_TARGET', direction: 'down' }), tabId);
   await expect(label).toHaveText('body › main › div › button (div) "Continue to checkout"');
 
-  // Clicking picks the walked-to target, not what is under the pointer.
+  // Enter commits the walked-to target: hands are already on the arrows, and
+  // the Add Element button still has focus, so an unhandled Enter would
+  // re-activate it and cancel the pick.
   await page.keyboard.press('ArrowUp');
-  await page.getByRole('button', { name: 'Continue to checkout' }).click();
+  await page.keyboard.press('Enter');
 
   await expect
     .poll(async () => (await sw.evaluate(() => (globalThis as unknown as { __picks: { type: string }[] }).__picks)).length)

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -160,6 +160,15 @@ function onPanelKey(e: KeyboardEvent) {
     // Swallowed even at the ends of the chain, so the panel does not scroll.
     e.preventDefault();
     send(tabId.value, { type: 'MOVE_TARGET', direction: e.key === 'ArrowUp' ? 'up' : 'down' });
+    return;
+  }
+
+  if (e.key === 'Enter') {
+    // Must be intercepted, not merely forwarded: the Add Element button still
+    // has focus after being clicked, so an unhandled Enter would re-activate it
+    // and cancel the pick instead of committing it.
+    e.preventDefault();
+    send(tabId.value, { type: 'PICK_TARGET' });
   }
 }
 

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -136,10 +136,31 @@ function stopPicking() {
   isAdding.value = isScanning.value = false;
 }
 
+/**
+ * Keys that belong to picking, handled here as well as in the page. After
+ * clicking Add Element focus is in the panel, so the page never sees them —
+ * which is why the arrows did nothing at first.
+ */
 function onPanelKey(e: KeyboardEvent) {
-  if (e.key !== 'Escape' || !isPicking()) return;
-  e.preventDefault();
-  stopPicking();
+  if (!isPicking() || tabId.value == null) return;
+
+  // Only when the keystroke is not meant for something else. The listener is on
+  // the capture phase, so without this it would swallow the arrows used to move
+  // through the framework dropdown — which is reachable while picking, since
+  // the model is still empty.
+  const target = e.target as HTMLElement | null;
+  if (target?.closest('input, textarea, select, [contenteditable="true"], [role="listbox"], [role="menu"], .q-menu')) return;
+
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    stopPicking();
+    return;
+  }
+  if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+    // Swallowed even at the ends of the chain, so the panel does not scroll.
+    e.preventDefault();
+    send(tabId.value, { type: 'MOVE_TARGET', direction: e.key === 'ArrowUp' ? 'up' : 'down' });
+  }
 }
 
 /**

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -299,25 +299,35 @@ function showMatchCount(count: number) {
   });
 }
 
+/**
+ * Both confirms are destructive, so the affirmative action reads as such.
+ *
+ * The colours are explicit because Quasar's dialog plugin defaults to
+ * `isDark() ? 'amber' : 'primary'` — which made both buttons yellow against the
+ * dark panel, and gave a delete confirm the same weight as any other dialog.
+ */
+function confirmDestructive(title: string, message: string) {
+  return $q.dialog({
+    title,
+    message,
+    cancel: { label: 'Cancel', flat: true, color: 'grey' },
+    ok: { label: 'Yes', flat: true, color: 'negative' },
+  });
+}
+
 function removeElement(id: string) {
   const el = model.value.elements.find((e) => e.id === id);
   if (!el || tabId.value == null) return;
-  $q.dialog({
-    title: 'Delete Element',
-    message: `Really delete ${el.name}?`,
-    cancel: true,
-    ok: { label: 'Yes', flat: true },
-  }).onOk(() => toBackground({ type: 'DELETE_ELEMENT', tabId: tabId.value!, id }));
+  confirmDestructive('Delete Element', `Really delete ${el.name}?`).onOk(() =>
+    toBackground({ type: 'DELETE_ELEMENT', tabId: tabId.value!, id })
+  );
 }
 
 function deleteModel() {
   if (tabId.value == null) return;
-  $q.dialog({
-    title: 'Delete Model',
-    message: 'Really delete the model?',
-    cancel: true,
-    ok: { label: 'Yes', flat: true },
-  }).onOk(() => toBackground({ type: 'DELETE_MODEL', tabId: tabId.value! }));
+  confirmDestructive('Delete Model', 'Really delete the model?').onOk(() =>
+    toBackground({ type: 'DELETE_MODEL', tabId: tabId.value! })
+  );
 }
 
 function notYet(what: string) {

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -204,6 +204,24 @@ function onRuntimeMessage(msg: unknown) {
 // go (SPEC §5). Disconnect happens on its own when the page unloads, which is
 // what covers closing the sidebar or closing DevTools.
 let port: { disconnect(): void; postMessage(msg: unknown): void } | undefined;
+let closing = false;
+
+/**
+ * The port also drops when Chrome terminates the service worker, which it does
+ * after 30 seconds of inactivity — and since Chrome 114 an open port does not
+ * hold it open. Reconnect, or the panel stops being counted and the background
+ * never learns which tab it is on.
+ */
+function connectToBackground() {
+  const opened = browser.runtime.connect({ name: PANEL_PORT });
+  port = opened;
+  opened.onDisconnect.addListener(() => {
+    port = undefined;
+    if (closing) return;
+    connectToBackground();
+  });
+  reportViewing();
+}
 
 /** Tell the background which tab this panel is showing (SPEC §5). */
 function reportViewing() {
@@ -211,9 +229,8 @@ function reportViewing() {
 }
 
 onMounted(async () => {
-  port = browser.runtime.connect({ name: PANEL_PORT });
   tabId.value = await host.getTabId();
-  reportViewing();
+  connectToBackground();
   if (tabId.value != null) toBackground({ type: 'GET_MODEL', tabId: tabId.value });
   // The content script listens for Escape too, but after clicking Add Element
   // focus is in the panel, so the page never sees the keydown. Cover both.
@@ -222,6 +239,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
+  closing = true;
   window.removeEventListener('keydown', onPanelKey, true);
   browser.runtime.onMessage.removeListener(onRuntimeMessage);
   port?.disconnect();

--- a/v3/wxt.config.ts
+++ b/v3/wxt.config.ts
@@ -14,7 +14,10 @@ export default defineConfig({
     description: 'Pick a DOM element and generate a verified Playwright Page Object Model.',
     // `sidePanel` is Chromium-only and is rejected by Firefox; WXT adds it to
     // the Chrome build itself when it sees the sidepanel entrypoint.
-    permissions: ['activeTab', 'tabs'],
+    // `storage` covers storage.session, where the per-tab models live (SPEC §5)
+    // — the service worker is terminated after 30s idle and cannot hold them —
+    // and storage.sync for settings (SPEC §14).
+    permissions: ['activeTab', 'tabs', 'storage'],
     // No popup — the click is handled in the background so it can open the
     // side panel (Chrome) or toggle the sidebar (Firefox). Without an `action`
     // key there is no toolbar button at all.


### PR DESCRIPTION
`REWRITE-PLAN.md` §12 step 9. The mouse alone can't reliably hit a nested element — a wrapper `<div>` and the `<div role="button">` inside it share a bounding box, so selecting the wrapper meant finding a 2px sliver of padding.

## Behaviour

| | |
|---|---|
| **↑** | move the target to the parent (stops at `<body>`) |
| **↓** | walk back towards the element under the cursor |
| **mouse move** | start again from whatever is under the cursor |
| **click** | picks the *currently targeted* element, not what's under the pointer |

Arrows are swallowed while picking even at the ends of the chain, so the page can't scroll out from under a pick in progress.

## The label becomes a breadcrumb

```
body › main › div › button (div) "Continue to checkout"
```

Ancestors are role-or-tag only; the target keeps its full description. Capped at three ancestors, elided with `…` beyond that.

Two jobs: say where you are in the nesting, and **make wrappers visible at all**. Before this there was no way to know a same-sized parent existed until you accidentally hit it.

Built from elements rather than `innerHTML`, since the text comes from the page.

## Why this came before Scan

Scan's whole job is picking a **container**, and containers are exactly the nested, same-box elements this fixes. Building Scan first would have shipped a feature whose primary interaction we already knew was broken.

## One test-isolation fix

Two E2E tests using `widgets.html` both opened the same URL, so `tabs.query(...)[0]` returned whichever tab the earlier one had left open — the same collision the login fixture already guarded against. `openFixture` now takes a file name, so every test gets its own tab. It passed in isolation and failed in the suite, which is exactly the failure mode worth removing.

## Hand-test

On a deeply nested control (the Facebook login button is the case that prompted this): hover roughly, press ↑ to reach the wrapper, ↓ to come back, and check a click takes the walked-to element. Worth confirming on both browsers that the page doesn't scroll while arrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)