### PR TITLE
v3: settings, an options page, and an optional type suffix on names

### DIFF
--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -361,7 +361,12 @@ before starting the next.
 
 13. **Remaining generators** — Selenium C#/Python, Puppeteer, Playwright Python.
 
-14. **Frames** (SPEC §16), **settings** (SPEC §14), **page-object wrapper** (SPEC §17).
+14. **Frames** (SPEC §16) and the **page-object wrapper** (SPEC §17).
+
+**Settings** (SPEC §14) ✅ **done, pulled forward** — `src/settings.ts` over `storage.sync`, an options
+page at `entrypoints/options/`, and all five toggles wired. Brought forward because `appendTypeToName`
+was requested, and a setting nobody can change is not a feature; building the mechanism twice would have
+been the alternative.
 
 **Release blocker:** `browser_specific_settings.gecko.id` is a placeholder. The real AMO id must replace
 it or an upload creates a second listing instead of updating the existing one (NFR-6).

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -449,8 +449,8 @@ Four agreed changes: **[settled]**
 Keep v2.5.1's **plain names** by default — `About`, not `AboutLink`. The user can rename before
 exporting.
 
-**`appendTypeToName`** (§14, off by default) turns the suffix on: `DiscoverTheDifference` becomes
-`DiscoverTheDifferenceLink`. The vocabulary is the one test authors use rather than raw ARIA — `textbox`
+**`appendTypeToName`** (§14, off by default) turns the suffix on: `FeelTheMagic` becomes
+`FeelTheMagicLink`. The vocabulary is the one test authors use rather than raw ARIA — `textbox`
 and `searchbox` become `Input`, `combobox` and `listbox` become `Select`, `img` becomes `Image` — since
 these names are read by people writing page objects. A role with no entry falls back to the role itself,
 so an unmapped one still produces something sensible, and a name already ending in its type is left

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -446,8 +446,16 @@ Four agreed changes: **[settled]**
    "Submit" is named `Btn1`; what a human calls the element should win.
 4. **Drop the ng-model and ng-binding rules.**
 
-Keep v2.5.1's **plain names** — `About`, not `AboutLink`. No role suffix; the user can rename before
+Keep v2.5.1's **plain names** by default — `About`, not `AboutLink`. The user can rename before
 exporting.
+
+**`appendTypeToName`** (§14, off by default) turns the suffix on: `DiscoverTheDifference` becomes
+`DiscoverTheDifferenceLink`. The vocabulary is the one test authors use rather than raw ARIA — `textbox`
+and `searchbox` become `Input`, `combobox` and `listbox` become `Select`, `img` becomes `Image` — since
+these names are read by people writing page objects. A role with no entry falls back to the role itself,
+so an unmapped one still produces something sensible, and a name already ending in its type is left
+alone rather than becoming `SubmitButtonButton`. Read per pick, so the setting takes effect at once.
+**[settled]**
 
 **Build-generated identifiers are skipped**, in both the class-name and `id` rules. `Xtvsq51` is not a
 name anyone would choose, and it changes on the next build of the site under test. Detected by known
@@ -470,9 +478,20 @@ Stored in `chrome.storage.sync` under the key `options`. Defaults as shipped: **
 | Key | Default | Effect |
 |---|---|---|
 | `showTooltips` | `true` | Tooltips on toolbar and row action buttons |
-| `darkMode` | `false` | Dark theme for the panel |
+| `theme` | `system` | Panel theme; `system` follows the browser and DevTools |
 | `modelHiddenElements` | `false` | Include non-visible elements when scanning |
 | `clickTableRowsToViewMatchedElements` | `false` | Single-click a row highlights matches |
+| `appendTypeToName` | `false` | Append the element's type to its derived name |
+
+v2.5.1's `darkMode` boolean is replaced by `theme`; the rest keep their keys so an in-place upgrade
+keeps the user's choices (NFR-6).
+
+**Applying the theme moves two things**, and both surfaces go through one function: our CSS tokens,
+stamped on the root, and Quasar's own dark mode, which paints its dialogs, notifications and the body
+background. Setting only the first gives dark text on Quasar's dark ground.
+
+Settings are read live — the options page is a separate tab, so a change reaches an open panel only
+through `storage.onChanged`.
 
 ### v3 changes **[settled]**
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -516,8 +516,12 @@ platform-aware shortcut (`Command+Option+I` on Mac, `Control+Shift+I` elsewhere)
 the GitHub repo, **OPTIONS** → `runtime.openOptionsPage()`.
 
 Its reason for existing — DevTools being the only surface — is gone in v3. **The popup is dropped: the
-toolbar click opens the panel** (side panel on Chrome, sidebar toggle on Firefox). Support moves into the
-panel; Options stays reachable via the browser's own extension menu. **[settled]**
+toolbar click opens the panel** (side panel on Chrome, sidebar toggle on Firefox), because a click
+should get you working rather than show you a menu. **[settled]**
+
+**Right-clicking the toolbar icon carries what the popup did** — **Options** and **Support** — via
+`contextMenus` with `contexts: ['action']`. The items are created on install rather than on every worker
+start: the browser keeps them, and the worker is restarted constantly. **[settled]**
 
 ## 16. Frames
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -519,9 +519,14 @@ Its reason for existing — DevTools being the only surface — is gone in v3. *
 toolbar click opens the panel** (side panel on Chrome, sidebar toggle on Firefox), because a click
 should get you working rather than show you a menu. **[settled]**
 
-**Right-clicking the toolbar icon carries what the popup did** — **Options** and **Support** — via
-`contextMenus` with `contexts: ['action']`. The items are created on install rather than on every worker
-start: the browser keeps them, and the worker is restarted constantly. **[settled]**
+**Right-clicking the toolbar icon carries what the popup did**, via `contextMenus` with
+`contexts: ['action']` — but only what the browser does not already offer. Chrome puts **Options** on
+that menu itself (along with *Open side panel*), so adding our own would show it twice; Firefox offers
+*Manage Extension*, which goes to `about:addons` rather than the options page. So **Support** on both,
+**Options** on Firefox only. **[settled]**
+
+Created on every worker start, not on install: `onInstalled` does not reliably fire when an unpacked
+extension is reloaded — which is every rebuild in dev — and the menu is then simply absent.
 
 ## 16. Frames
 

--- a/v3/README.md
+++ b/v3/README.md
@@ -44,6 +44,7 @@ MV3 on both browsers. One `sidepanel` entrypoint gives Chrome `side_panel` and F
 | | Chrome | Firefox |
 |---|---|---|
 | Side panel / sidebar | toolbar icon | toolbar icon (or View → Sidebar → Page Modeller) |
+| Options / Support | right-click the toolbar icon | right-click the toolbar icon |
 | DevTools panel | F12 → **Page Modeller** | F12 → **Page Modeller** |
 
 ## Load it

--- a/v3/README.md
+++ b/v3/README.md
@@ -44,7 +44,8 @@ MV3 on both browsers. One `sidepanel` entrypoint gives Chrome `side_panel` and F
 | | Chrome | Firefox |
 |---|---|---|
 | Side panel / sidebar | toolbar icon | toolbar icon (or View → Sidebar → Page Modeller) |
-| Options / Support | right-click the toolbar icon | right-click the toolbar icon |
+| Support | right-click the toolbar icon | right-click the toolbar icon |
+| Options | right-click the toolbar icon (Chrome's own item) | right-click the toolbar icon |
 | DevTools panel | F12 → **Page Modeller** | F12 → **Page Modeller** |
 
 ## Load it

--- a/v3/README.md
+++ b/v3/README.md
@@ -13,6 +13,8 @@ the stack validated in the feasibility study (WXT + Vue 3 + Quasar + TypeScript,
 - **Panel UI** (`ui/`) — Quasar: `AppToolbar` (SPEC §3) over `ModelTable` (SPEC §6). One app, three
   surfaces. Shell only so far — capture, generation and the dialogs are the next increments.
 - **Frameworks** (`src/frameworks.ts`) — the targets and the locator types each can express (SPEC §7).
+- **Settings** (`src/settings.ts`, `ui/OptionsPage.vue`) — `storage.sync`, read live by every surface
+  (SPEC §14).
 - **Session model** (`src/model.ts`) — one model per tab, owned by the background; panels are views
   (SPEC §5).
 - **Naming** (`src/engine/naming.ts`) — split across the message boundary: `baseName` runs in the page,

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -4,6 +4,8 @@ import { ModelStore, usedNames, type TabModel } from '@/src/model';
 import { uniqueName } from '@/src/engine/naming';
 import { defaultFrameworkId } from '@/src/frameworks';
 import { chooseCandidate } from '@/src/locators/select';
+import { withTypeSuffix } from '@/src/locators/type-name';
+import { loadSettings } from '@/src/settings';
 
 // Background service worker / event page.
 //
@@ -41,11 +43,13 @@ export default defineBackground(() => {
   browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
     if (!changeInfo.url) return;
     const url = changeInfo.url;
-    void store.mutate(tabId, (model) => {
-      if (model.url == null) return;
-      // Navigating back to where it was built makes it current again.
-      model.stale = model.url !== url;
-    }).then((model) => publish(tabId, model));
+    void store
+      .mutate(tabId, (model) => {
+        if (model.url == null) return;
+        // Navigating back to where it was built makes it current again.
+        model.stale = model.url !== url;
+      })
+      .then((model) => publish(tabId, model));
   });
 
   // A model with no panel watching it is abandoned work (SPEC §5). Each panel
@@ -95,20 +99,25 @@ export default defineBackground(() => {
         const tabId = sender.tab?.id;
         if (tabId == null) return;
         const url = sender.tab?.url ?? null;
-        void change(tabId, (model) => {
-          // The page the model belongs to, recorded when the first element lands.
-          if (model.url == null) model.url = url;
-          model.elements.push({
-            ...m.result,
-            // Unique within the model rather than a worker-lifetime counter:
-            // the worker restarts, and the counter would restart with it.
-            id: `el-${Date.now().toString(36)}-${model.elements.length}`,
-            name: uniqueName(m.result.suggestedName, usedNames(model)),
-            // Not the engine's preferredIndex: that is framework-agnostic, and
-            // would hand a Selenium model a Playwright-only locator.
-            selectedIndex: chooseCandidate(m.result.candidates, model.frameworkId),
-          });
-        });
+        // Read before mutating: the change callback is synchronous, and naming
+        // depends on a setting the user can change at any time (SPEC §13).
+        void loadSettings().then((settings) =>
+          change(tabId, (model) => {
+            // The page the model belongs to, recorded when the first element
+            // lands.
+            if (model.url == null) model.url = url;
+            model.elements.push({
+              ...m.result,
+              // Unique within the model rather than a worker-lifetime counter:
+              // the worker restarts, and the counter would restart with it.
+              id: `el-${Date.now().toString(36)}-${model.elements.length}`,
+              name: uniqueName(settings.appendTypeToName ? withTypeSuffix(m.result.suggestedName, m.result.role) : m.result.suggestedName, usedNames(model)),
+              // Not the engine's preferredIndex: that is framework-agnostic,
+              // and would hand a Selenium model a Playwright-only locator.
+              selectedIndex: chooseCandidate(m.result.candidates, model.frameworkId),
+            });
+          })
+        );
         // Picking is one-shot (SPEC §4); tell the panels so they can un-arm.
         browser.runtime.sendMessage({ type: 'FROM_TAB', tabId, message: { type: 'PICKING_STOPPED' } }).catch(() => {});
         return;
@@ -153,7 +162,10 @@ export default defineBackground(() => {
         });
         return;
       case 'DELETE_MODEL':
-        void store.clear(m.tabId).then(() => store.get(m.tabId)).then((model) => publish(m.tabId, model));
+        void store
+          .clear(m.tabId)
+          .then(() => store.get(m.tabId))
+          .then((model) => publish(m.tabId, model));
         return;
       case 'SET_FRAMEWORK':
         void change(m.tabId, (model) => {

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -20,6 +20,9 @@ import { loadSettings } from '@/src/settings';
 //     background always sees the sender, and stamps it.
 //   * A model held in a panel is one model per *panel*: a sidebar and a
 //     DevTools panel on the same tab showed different rows.
+/** Where Support goes — the repository, as in v2.5.1. */
+const SUPPORT_URL = 'https://github.com/danhumphrey/page-modeller';
+
 export default defineBackground(() => {
   console.log('[Page Modeller] background ready', import.meta.env.MODE, import.meta.env.BROWSER);
 
@@ -173,6 +176,31 @@ export default defineBackground(() => {
         });
         return;
     }
+  });
+
+  // Right-clicking the toolbar icon (SPEC §15). v2.5.1 carried Support and
+  // Options in a popup; the popup is gone, because a click should open the
+  // panel rather than a menu, and this is where those links belong instead.
+  //
+  // Created on install rather than on every worker start: menu items are kept
+  // by the browser, and the worker is restarted constantly.
+  const MENU = {
+    options: 'Options',
+    support: 'Support',
+  };
+
+  browser.runtime.onInstalled.addListener(() => {
+    // removeAll first, or re-creating a known id throws on update.
+    browser.contextMenus.removeAll(() => {
+      for (const [id, title] of Object.entries(MENU)) {
+        browser.contextMenus.create({ id, title, contexts: ['action'] });
+      }
+    });
+  });
+
+  browser.contextMenus.onClicked.addListener((info) => {
+    if (info.menuItemId === 'options') void browser.runtime.openOptionsPage();
+    else if (info.menuItemId === 'support') void browser.tabs.create({ url: SUPPORT_URL });
   });
 
   if (import.meta.env.FIREFOX) {

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -182,20 +182,21 @@ export default defineBackground(() => {
   // Options in a popup; the popup is gone, because a click should open the
   // panel rather than a menu, and this is where those links belong instead.
   //
-  // Created on install rather than on every worker start: menu items are kept
-  // by the browser, and the worker is restarted constantly.
-  const MENU = {
-    options: 'Options',
-    support: 'Support',
-  };
+  // Only what the browser does not already offer. Chrome puts Options on this
+  // menu itself, so adding our own would show it twice; Firefox offers
+  // "Manage Extension", which goes to about:addons rather than the options
+  // page, so there it earns its place.
+  const items: Array<{ id: string; title: string }> = [{ id: 'support', title: 'Support' }];
+  if (import.meta.env.FIREFOX) items.unshift({ id: 'options', title: 'Options' });
 
-  browser.runtime.onInstalled.addListener(() => {
-    // removeAll first, or re-creating a known id throws on update.
-    browser.contextMenus.removeAll(() => {
-      for (const [id, title] of Object.entries(MENU)) {
-        browser.contextMenus.create({ id, title, contexts: ['action'] });
-      }
-    });
+  // On every worker start, not on install: onInstalled does not reliably fire
+  // when an unpacked extension is reloaded, which is every rebuild in dev, and
+  // the menu would then be missing. removeAll first, or re-creating a known id
+  // throws.
+  browser.contextMenus.removeAll(() => {
+    for (const { id, title } of items) {
+      browser.contextMenus.create({ id, title, contexts: ['action'] });
+    }
   });
 
   browser.contextMenus.onClicked.addListener((info) => {

--- a/v3/entrypoints/options/index.html
+++ b/v3/entrypoints/options/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page Modeller Options</title>
+    <!-- A full tab, as in v2.5.1 (SPEC §14) — the cramped popup that Chrome
+         shows otherwise is not enough room for the hints. -->
+    <meta name="manifest.open_in_tab" content="true" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/v3/entrypoints/options/main.ts
+++ b/v3/entrypoints/options/main.ts
@@ -1,0 +1,8 @@
+import { createApp } from 'vue';
+import { Quasar } from 'quasar';
+import 'quasar/src/css/index.sass';
+import '@quasar/extras/material-icons/material-icons.css';
+import '@/ui/theme.css';
+import OptionsPage from '@/ui/OptionsPage.vue';
+
+createApp(OptionsPage).use(Quasar, { config: { dark: 'auto' } }).mount('#app');

--- a/v3/scripts/check-manifests.mjs
+++ b/v3/scripts/check-manifests.mjs
@@ -7,6 +7,9 @@ const EXPECT = {
   'chrome-mv3': {
     'manifest_version': (m) => m.manifest_version === 3,
     'action (toolbar button exists)': (m) => m.action != null,
+    'contextMenus permission': (m) => m.permissions?.includes('contextMenus'),
+    'storage permission': (m) => m.permissions?.includes('storage'),
+    'options_ui opens in a tab': (m) => m.options_ui?.open_in_tab === true,
     'icons': (m) => m.icons?.['128'] != null,
     'side_panel.default_path': (m) => m.side_panel?.default_path === 'sidepanel.html',
     'sidePanel permission': (m) => m.permissions?.includes('sidePanel'),
@@ -17,6 +20,9 @@ const EXPECT = {
   'firefox-mv3': {
     'manifest_version': (m) => m.manifest_version === 3,
     'action (toolbar button exists)': (m) => m.action != null,
+    'contextMenus permission': (m) => m.permissions?.includes('contextMenus'),
+    'storage permission': (m) => m.permissions?.includes('storage'),
+    'options_ui opens in a tab': (m) => m.options_ui?.open_in_tab === true,
     'icons': (m) => m.icons?.['128'] != null,
     'sidebar_action.default_panel': (m) => m.sidebar_action?.default_panel === 'sidepanel.html',
     'no sidePanel permission': (m) => !m.permissions?.includes('sidePanel'),

--- a/v3/src/locators/type-name.ts
+++ b/v3/src/locators/type-name.ts
@@ -1,0 +1,46 @@
+// The type suffix appended to a derived name when `appendTypeToName` is on
+// (SPEC §13): `DiscoverTheDifference` → `DiscoverTheDifferenceLink`.
+//
+// Test-author vocabulary rather than raw ARIA: `textbox` becomes `Input` and
+// `combobox` becomes `Select`, because those are the words people use when
+// naming page-object members, and the names are read by testers rather than
+// accessibility folk. Roles with no entry fall back to the role itself, so an
+// unmapped role still produces something sensible.
+const SUFFIX: Record<string, string> = {
+  link: 'Link',
+  button: 'Button',
+  textbox: 'Input',
+  searchbox: 'Input',
+  spinbutton: 'Input',
+  combobox: 'Select',
+  listbox: 'Select',
+  checkbox: 'Checkbox',
+  radio: 'Radio',
+  switch: 'Switch',
+  img: 'Image',
+  heading: 'Heading',
+  tab: 'Tab',
+  menuitem: 'MenuItem',
+  option: 'Option',
+};
+
+function pascal(role: string): string {
+  return role
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join('');
+}
+
+/** The suffix for a role, or '' when there is no role to describe. */
+export function typeSuffix(role: string | null): string {
+  if (!role) return '';
+  return SUFFIX[role] ?? pascal(role);
+}
+
+/** `About` + link → `AboutLink`. Already-suffixed names are left alone. */
+export function withTypeSuffix(name: string, role: string | null): string {
+  const suffix = typeSuffix(role);
+  if (!suffix || name.toLowerCase().endsWith(suffix.toLowerCase())) return name;
+  return `${name}${suffix}`;
+}

--- a/v3/src/settings.ts
+++ b/v3/src/settings.ts
@@ -1,9 +1,9 @@
 // User settings (SPEC §14).
 //
 // Stored in chrome.storage.sync under the key `options`, preserving v2.5.1's
-// keys so an in-place upgrade keeps the user's choices. Storage and the options
-// page land with REWRITE-PLAN §12 step 13; until then these defaults are what
-// the panel runs on.
+// key and names so an in-place upgrade keeps the user's choices (NFR-6).
+import { browser } from 'wxt/browser';
+
 export type ThemePreference = 'system' | 'light' | 'dark';
 
 export interface Settings {
@@ -14,6 +14,8 @@ export interface Settings {
   modelHiddenElements: boolean;
   /** Single-click a row runs View Matched Elements (SPEC §6). */
   clickTableRowsToViewMatchedElements: boolean;
+  /** Append the element's type to its derived name: `About` → `AboutLink`. */
+  appendTypeToName: boolean;
 }
 
 export const defaultSettings: Settings = {
@@ -21,4 +23,36 @@ export const defaultSettings: Settings = {
   theme: 'system',
   modelHiddenElements: false,
   clickTableRowsToViewMatchedElements: false,
+  appendTypeToName: false,
 };
+
+const KEY = 'options';
+
+/** Stored settings merged over the defaults, so a new setting has a value. */
+export async function loadSettings(): Promise<Settings> {
+  try {
+    const stored = (await browser.storage.sync.get(KEY)) as { options?: Partial<Settings> };
+    return { ...defaultSettings, ...stored.options };
+  } catch {
+    // Sync storage can be unavailable or over quota; defaults still work.
+    return { ...defaultSettings };
+  }
+}
+
+export async function saveSettings(settings: Settings): Promise<void> {
+  await browser.storage.sync.set({ [KEY]: settings });
+}
+
+/**
+ * Call `onChange` whenever settings change anywhere — the options page is a
+ * separate tab, so a panel cannot learn about a change any other way.
+ * Returns an unsubscribe.
+ */
+export function watchSettings(onChange: (settings: Settings) => void): () => void {
+  const listener = (changes: Record<string, { newValue?: unknown }>, area: string) => {
+    if (area !== 'sync' || !changes[KEY]) return;
+    onChange({ ...defaultSettings, ...(changes[KEY].newValue as Partial<Settings> | undefined) });
+  };
+  browser.storage.onChanged.addListener(listener);
+  return () => browser.storage.onChanged.removeListener(listener);
+}

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -637,3 +637,50 @@ test('the model lives outside the service worker, not in it', async () => {
     )
     .toEqual(['SignIn']);
 });
+
+test('appendTypeToName changes how a pick is named (SPEC §13)', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  for (const open of context.pages()) {
+    if (open.url().startsWith('chrome-extension://')) await open.close();
+  }
+
+  const panel = await context.newPage();
+  await panel.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await panel.evaluate(() => {
+    (window as unknown as { __msgs: unknown[] }).__msgs = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+    });
+  });
+
+  const namesFor = async (id: number) =>
+    (await panel.evaluate(() => (window as unknown as { __msgs: { type: string; tabId?: number; model?: { elements: { name: string }[] } }[] }).__msgs))
+      .filter((m) => m.type === 'MODEL' && m.tabId === id)
+      .at(-1)
+      ?.model?.elements.map((e) => e.name);
+
+  async function pickSignIn(caseName: string) {
+    const fixture = await openFixture(sw as never, caseName);
+    await panel.evaluate(
+      (id) => chrome.runtime.sendMessage({ type: 'RELAY_TO_TAB', tabId: id, message: { type: 'START_PICKING', mode: 'add' } }),
+      fixture.tabId
+    );
+    await fixture.page.getByRole('button', { name: 'Sign in' }).click();
+    return fixture.tabId;
+  }
+
+  // Off by default — v2.5.1's plain names.
+  const plain = await pickSignIn('suffix-off');
+  await expect.poll(() => namesFor(plain)).toEqual(['SignIn']);
+
+  // The setting is read per pick, so turning it on takes effect immediately
+  // rather than only for a new session.
+  await panel.evaluate(() => chrome.storage.sync.set({ options: { appendTypeToName: true } }));
+  const suffixed = await pickSignIn('suffix-on');
+  await expect.poll(() => namesFor(suffixed)).toEqual(['SignInButton']);
+
+  await panel.evaluate(() => chrome.storage.sync.remove('options'));
+});

--- a/v3/tests/extension.e2e.spec.ts
+++ b/v3/tests/extension.e2e.spec.ts
@@ -16,6 +16,51 @@ const SURFACES = [
   { name: 'DevTools panel', page: 'devtools-panel.html' },
 ];
 
+test('the options page renders every setting', async () => {
+  const context: BrowserContext = await chromium.launchPersistentContext('', {
+    headless: false,
+    // A DARK browser, so that "auto" genuinely means dark. Under the default
+    // light scheme the theme assertion below passes whether or not Quasar was
+    // switched, which makes it worthless.
+    colorScheme: 'dark',
+    args: [`--headless=new`, `--disable-extensions-except=${EXT_PATH}`, `--load-extension=${EXT_PATH}`],
+  });
+
+  try {
+    let [sw] = context.serviceWorkers();
+    if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+    const page = await context.newPage();
+    await page.goto(`chrome-extension://${new URL(sw.url()).host}/options.html`);
+
+    // A setting nobody can reach is not a setting (SPEC §14).
+    for (const key of ['showTooltips', 'appendTypeToName', 'modelHiddenElements', 'clickTableRowsToViewMatchedElements']) {
+      await expect(page.getByTestId(`option-${key}`)).toBeVisible();
+    }
+    await expect(page.getByTestId('option-theme')).toBeVisible();
+
+    // Choosing Light must move BOTH our tokens and Quasar's dark mode. Setting
+    // only the tokens left dark text on Quasar's dark body.
+    await page.getByTestId('option-theme').click();
+    await page.getByRole('option', { name: 'Light' }).click();
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.getAttribute('data-pm-theme')))
+      .toBe('light');
+    await expect
+      .poll(() => page.evaluate(() => document.body.classList.contains('body--dark')))
+      .toBe(false);
+
+    // Toggling writes through to sync storage, which is what the panel reads.
+    await page.getByTestId('option-appendTypeToName').click();
+    await expect
+      .poll(async () =>
+        page.evaluate(async () => ((await chrome.storage.sync.get('options')) as { options?: { appendTypeToName?: boolean } }).options?.appendTypeToName)
+      )
+      .toBe(true);
+  } finally {
+    await context.close();
+  }
+});
+
 test('built extension loads and every panel surface renders', async () => {
   const context: BrowserContext = await chromium.launchPersistentContext('', {
     headless: false,

--- a/v3/tests/unit/ModelTable.test.ts
+++ b/v3/tests/unit/ModelTable.test.ts
@@ -9,9 +9,9 @@ const rows: ModelRow[] = [
   { id: 'b', name: 'About', locator: "getByRole('link', { name: 'About', exact: true })" },
 ];
 
-function render(props: Partial<{ elements: ModelRow[]; clickToHighlight: boolean }> = {}) {
+function render(props: Partial<{ elements: ModelRow[]; clickToHighlight: boolean; showTooltips: boolean }> = {}) {
   return mount(ModelTable, {
-    props: { elements: rows, clickToHighlight: false, ...props },
+    props: { elements: rows, clickToHighlight: false, showTooltips: true, ...props },
     // @quasar/vite-plugin auto-imports Quasar components when building; in a
     // test they have to be registered by hand or they render as unknown
     // elements and every query for a real <button> misses.

--- a/v3/tests/unit/type-name.test.ts
+++ b/v3/tests/unit/type-name.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { typeSuffix, withTypeSuffix } from '../../src/locators/type-name';
+
+describe('typeSuffix', () => {
+  it('uses test-author vocabulary, not raw ARIA', () => {
+    // These names are read by testers writing page objects, not by people
+    // working on accessibility.
+    expect(typeSuffix('textbox')).toBe('Input');
+    expect(typeSuffix('searchbox')).toBe('Input');
+    expect(typeSuffix('combobox')).toBe('Select');
+    expect(typeSuffix('listbox')).toBe('Select');
+    expect(typeSuffix('img')).toBe('Image');
+  });
+
+  it('passes through roles that already read well', () => {
+    expect(typeSuffix('link')).toBe('Link');
+    expect(typeSuffix('button')).toBe('Button');
+    expect(typeSuffix('checkbox')).toBe('Checkbox');
+  });
+
+  it('falls back to the role itself when unmapped', () => {
+    // An unmapped role still produces something sensible rather than nothing.
+    expect(typeSuffix('treeitem')).toBe('Treeitem');
+    expect(typeSuffix('menuitemcheckbox')).toBe('Menuitemcheckbox');
+  });
+
+  it('has nothing to say about an element with no role', () => {
+    expect(typeSuffix(null)).toBe('');
+  });
+});
+
+describe('withTypeSuffix', () => {
+  it('appends the type', () => {
+    expect(withTypeSuffix('DiscoverTheDifference', 'link')).toBe('DiscoverTheDifferenceLink');
+    expect(withTypeSuffix('Search', 'textbox')).toBe('SearchInput');
+  });
+
+  it('leaves a name that already ends in its type alone', () => {
+    // Otherwise "Log in" on a button becomes LogInButtonButton.
+    expect(withTypeSuffix('SubmitButton', 'button')).toBe('SubmitButton');
+    expect(withTypeSuffix('Submitbutton', 'button')).toBe('Submitbutton');
+  });
+
+  it('leaves a name alone when there is no role', () => {
+    expect(withTypeSuffix('Div1', null)).toBe('Div1');
+  });
+});

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -6,6 +6,7 @@
         :has-model="model.elements.length > 0"
         :is-scanning="isScanning"
         :is-adding="isAdding"
+        :show-tooltips="settings.showTooltips"
         @update:framework-id="setFramework"
         @scan="notYet('Scan')"
         @add="toggleAdd"
@@ -31,6 +32,7 @@
         <ModelTable
           :elements="rows"
           :click-to-highlight="settings.clickTableRowsToViewMatchedElements"
+          :show-tooltips="settings.showTooltips"
           @highlight="highlight"
           @edit="openEditor"
           @remove="removeElement"
@@ -63,8 +65,9 @@ import { displayLocator } from '@/src/locators/display';
 import { activeCandidate, emptyModel, type ModelElement, type TabModel } from '@/src/model';
 import { isMessage, PANEL_PORT, type BackgroundToPanel, type PanelToBackground, type PanelToContent } from '@/src/messaging';
 import { hostKey } from '@/host/types';
+import { applyTheme } from './theme';
 import type { LocatorCandidate } from '@/src/engine/types';
-import { defaultSettings } from '@/src/settings';
+import { defaultSettings, loadSettings, watchSettings } from '@/src/settings';
 
 // The panel is a VIEW. The background owns the model, one per tab (SPEC §5), so
 // a sidebar and a DevTools panel on the same tab show the same rows and a pick
@@ -72,9 +75,12 @@ import { defaultSettings } from '@/src/settings';
 const $q = useQuasar();
 const host = inject(hostKey)!;
 
-// Storage and the options page arrive with REWRITE-PLAN §12 step 13; until then
-// the panel runs on the defaults.
+// Loaded on mount and kept current: the options page is a separate tab, so a
+// change there reaches the panel only through storage (SPEC §14).
 const settings = ref({ ...defaultSettings });
+let unwatchSettings: (() => void) | undefined;
+
+
 const tabId = ref<number | undefined>();
 const model = ref<TabModel>(emptyModel(defaultFrameworkId));
 const isScanning = ref(false);
@@ -229,6 +235,13 @@ function reportViewing() {
 }
 
 onMounted(async () => {
+  settings.value = await loadSettings();
+  applyTheme($q, settings.value.theme);
+  unwatchSettings = watchSettings((next) => {
+    settings.value = next;
+    applyTheme($q, next.theme);
+  });
+
   tabId.value = await host.getTabId();
   connectToBackground();
   if (tabId.value != null) toBackground({ type: 'GET_MODEL', tabId: tabId.value });
@@ -240,6 +253,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   closing = true;
+  unwatchSettings?.();
   window.removeEventListener('keydown', onPanelKey, true);
   browser.runtime.onMessage.removeListener(onRuntimeMessage);
   port?.disconnect();

--- a/v3/ui/AppToolbar.vue
+++ b/v3/ui/AppToolbar.vue
@@ -4,17 +4,17 @@
          a model exists; the framework is chosen up front because locator types
          are framework-specific. -->
     <q-btn flat dense round icon="manage_search" :disable="hasModel || isAdding" data-testid="btn-scan" @click="$emit('scan')">
-      <q-tooltip>Scan Page</q-tooltip>
+      <q-tooltip v-if="showTooltips">Scan Page</q-tooltip>
     </q-btn>
 
     <q-btn flat dense round icon="delete_sweep" :disable="!hasModel || isPicking" data-testid="btn-delete-model" @click="$emit('deleteModel')">
-      <q-tooltip>Delete Model</q-tooltip>
+      <q-tooltip v-if="showTooltips">Delete Model</q-tooltip>
     </q-btn>
 
     <q-btn flat dense no-caps :disable="hasModel || isPicking" class="framework" data-testid="framework-selector">
       <span class="ellipsis">{{ framework.label }}</span>
       <q-icon name="arrow_drop_down" />
-      <q-tooltip>Select Target Framework</q-tooltip>
+      <q-tooltip v-if="showTooltips">Select Target Framework</q-tooltip>
       <q-menu auto-close>
         <q-list dense style="min-width: 200px">
           <q-item
@@ -34,11 +34,11 @@
     <q-space />
 
     <q-btn flat dense round icon="playlist_add" :disable="isScanning" data-testid="btn-add" @click="$emit('add')">
-      <q-tooltip>Add Element</q-tooltip>
+      <q-tooltip v-if="showTooltips">Add Element</q-tooltip>
     </q-btn>
 
     <q-btn flat dense round icon="code" :disable="!hasModel || isPicking" data-testid="btn-generate" @click="$emit('generate')">
-      <q-tooltip>Generate Code</q-tooltip>
+      <q-tooltip v-if="showTooltips">Generate Code</q-tooltip>
     </q-btn>
   </q-toolbar>
 </template>
@@ -52,6 +52,7 @@ const props = defineProps<{
   hasModel: boolean;
   isScanning: boolean;
   isAdding: boolean;
+  showTooltips: boolean;
 }>();
 
 defineEmits<{

--- a/v3/ui/ModelTable.vue
+++ b/v3/ui/ModelTable.vue
@@ -26,13 +26,13 @@
           <td class="col-locator"><span :title="el.locator">{{ el.locator }}</span></td>
           <td class="col-actions">
             <q-btn flat dense round size="sm" icon="visibility" @click.stop="$emit('highlight', el.id)">
-              <q-tooltip>View Matched Elements</q-tooltip>
+              <q-tooltip v-if="showTooltips">View Matched Elements</q-tooltip>
             </q-btn>
             <q-btn flat dense round size="sm" icon="edit" @click.stop="$emit('edit', el.id)">
-              <q-tooltip>Edit</q-tooltip>
+              <q-tooltip v-if="showTooltips">Edit</q-tooltip>
             </q-btn>
             <q-btn flat dense round size="sm" icon="delete" @click.stop="$emit('remove', el.id)">
-              <q-tooltip>Delete</q-tooltip>
+              <q-tooltip v-if="showTooltips">Delete</q-tooltip>
             </q-btn>
           </td>
         </tr>
@@ -54,6 +54,7 @@ defineProps<{
   elements: ModelRow[];
   /** Single-click a row runs View Matched Elements — off by default (SPEC §6). */
   clickToHighlight: boolean;
+  showTooltips: boolean;
 }>();
 
 defineEmits<{

--- a/v3/ui/OptionsPage.vue
+++ b/v3/ui/OptionsPage.vue
@@ -1,0 +1,141 @@
+<template>
+  <main class="options">
+    <h1 class="title">Page Modeller Options</h1>
+
+    <div v-for="option in options" :key="option.key" class="option">
+      <q-toggle
+        :model-value="settings[option.key] as boolean"
+        :data-testid="`option-${option.key}`"
+        @update:model-value="set(option.key, $event)"
+      />
+      <div class="option-text">
+        <div class="option-label">{{ option.label }}</div>
+        <div class="option-hint">{{ option.hint }}</div>
+      </div>
+    </div>
+
+    <div class="option">
+      <q-select
+        v-model="theme"
+        dense
+        outlined
+        emit-value
+        map-options
+        class="theme-select"
+        :options="themeOptions"
+        data-testid="option-theme"
+      />
+      <div class="option-text">
+        <div class="option-label">Theme</div>
+        <div class="option-hint">System follows the browser, and DevTools when the panel is docked there.</div>
+      </div>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+import { useQuasar } from 'quasar';
+import { applyTheme } from './theme';
+import { defaultSettings, loadSettings, saveSettings, watchSettings, type Settings, type ThemePreference } from '@/src/settings';
+
+type BooleanKey = { [K in keyof Settings]: Settings[K] extends boolean ? K : never }[keyof Settings];
+
+// Hints say what the setting does, not what it is called — the label already
+// does that.
+const options: Array<{ key: BooleanKey; label: string; hint: string }> = [
+  { key: 'showTooltips', label: 'Show tooltips', hint: 'Tooltips on the toolbar and row buttons.' },
+  {
+    key: 'appendTypeToName',
+    label: 'Append the element type to names',
+    hint: '“DiscoverTheDifference” becomes “DiscoverTheDifferenceLink”.',
+  },
+  {
+    key: 'modelHiddenElements',
+    label: 'Model hidden elements',
+    hint: 'Scan includes elements hidden from the accessibility tree — a validation message, or a modal not yet opened.',
+  },
+  {
+    key: 'clickTableRowsToViewMatchedElements',
+    label: 'Click a row to view matched elements',
+    hint: 'Otherwise only the eye does it. Double-click always opens the editor.',
+  },
+];
+
+const themeOptions: Array<{ label: string; value: ThemePreference }> = [
+  { label: 'System', value: 'system' },
+  { label: 'Light', value: 'light' },
+  { label: 'Dark', value: 'dark' },
+];
+
+const $q = useQuasar();
+const settings = ref<Settings>({ ...defaultSettings });
+let unwatch: (() => void) | undefined;
+
+const theme = computed({
+  get: () => settings.value.theme,
+  set: (value: ThemePreference) => set('theme', value),
+});
+
+onMounted(async () => {
+  settings.value = await loadSettings();
+  applyTheme($q, settings.value.theme);
+  // Another surface may change these; the page should not go stale.
+  unwatch = watchSettings((next) => {
+    settings.value = next;
+    applyTheme($q, next.theme);
+  });
+});
+
+onBeforeUnmount(() => unwatch?.());
+
+async function set<K extends keyof Settings>(key: K, value: Settings[K]) {
+  settings.value = { ...settings.value, [key]: value };
+  // This page follows its own setting, so the choice is visible here rather
+  // than only after opening the panel.
+  applyTheme($q, settings.value.theme);
+  await saveSettings(settings.value);
+}
+</script>
+
+<style scoped>
+.options {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  color: var(--pm-text);
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0 0 24px;
+}
+
+.option {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 0;
+  border-top: 1px solid var(--pm-rule);
+}
+
+.option-text {
+  min-width: 0;
+}
+
+.option-label {
+  font-size: 14px;
+}
+
+.option-hint {
+  font-size: 12px;
+  color: var(--pm-text-muted);
+  margin-top: 2px;
+}
+
+.theme-select {
+  width: 140px;
+  flex: 0 0 auto;
+}
+</style>

--- a/v3/ui/OptionsPage.vue
+++ b/v3/ui/OptionsPage.vue
@@ -48,7 +48,7 @@ const options: Array<{ key: BooleanKey; label: string; hint: string }> = [
   {
     key: 'appendTypeToName',
     label: 'Append the element type to names',
-    hint: '“DiscoverTheDifference” becomes “DiscoverTheDifferenceLink”.',
+    hint: '“FeelTheMagic” becomes “FeelTheMagicLink”.',
   },
   {
     key: 'modelHiddenElements',

--- a/v3/ui/theme.ts
+++ b/v3/ui/theme.ts
@@ -1,0 +1,17 @@
+// Applying the theme preference (SPEC §14).
+//
+// Two things have to move together, which is why this is shared rather than
+// written out in each surface: our CSS tokens, stamped on the root, and
+// Quasar's own dark mode, which paints its dialogs, notifications and the body
+// background. Setting only the first gives dark text on Quasar's dark ground.
+import type { QVueGlobals } from 'quasar';
+import type { ThemePreference } from '@/src/settings';
+
+export function applyTheme(quasar: QVueGlobals, theme: ThemePreference): void {
+  const root = document.documentElement;
+  // Absent means "system", which the CSS resolves through prefers-color-scheme.
+  if (theme === 'system') root.removeAttribute('data-pm-theme');
+  else root.setAttribute('data-pm-theme', theme);
+
+  quasar.dark.set(theme === 'system' ? 'auto' : theme === 'dark');
+}

--- a/v3/wxt.config.ts
+++ b/v3/wxt.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     // `storage` covers storage.session, where the per-tab models live (SPEC §5)
     // — the service worker is terminated after 30s idle and cannot hold them —
     // and storage.sync for settings (SPEC §14).
-    permissions: ['activeTab', 'tabs', 'storage'],
+    permissions: ['activeTab', 'tabs', 'storage', 'contextMenus'],
     // No popup — the click is handled in the background so it can open the
     // side panel (Chrome) or toggle the sidebar (Firefox). Without an `action`
     // key there is no toolbar button at all.


### PR DESCRIPTION
Adds `appendTypeToName` (SPEC §13, **off by default**): `DiscoverTheDifference` becomes `DiscoverTheDifferenceLink`.

## The vocabulary

Test-author words rather than raw ARIA, because these names are read by people writing page objects:

| role | suffix | |
|---|---|---|
| `link` | `Link` | `DiscoverTheDifferenceLink` |
| `textbox`, `searchbox` | `Input` | `SearchInput` |
| `combobox`, `listbox` | `Select` | `CountrySelect` |
| `img` | `Image` | `AcmeLogoImage` |

Unmapped roles fall back to the role itself, so a `treeitem` still gets something sensible. A name already ending in its type is left alone rather than becoming `SubmitButtonButton`. Read per pick, so the setting takes effect immediately.

## This pulled step 13 forward, deliberately

**A setting nobody can change isn't a feature**, and there was no settings mechanism — `src/settings.ts` held defaults and nothing read storage. Building it now lands all five toggles at once rather than building the mechanism twice.

- **`src/settings.ts`** loads and saves under v2.5.1's `options` key in `storage.sync`, so an in-place upgrade keeps the user's choices (NFR-6), and merges over defaults so a newly added setting has a value.
- **`entrypoints/options/`** is a full tab, as v2.5.1 was — Chrome's embedded popup isn't enough room for the hints.
- **Every surface watches `storage.onChanged`.** The options page is a separate tab, so that's the only way a change reaches an open panel.
- **`showTooltips`** and **`clickTableRowsToViewMatchedElements`** now read the real setting rather than a hardcoded default.

## One bug found while testing

Choosing **Light** left dark text on a dark ground. The page stamped our CSS tokens but never told Quasar, whose dark mode paints the body and its dialogs — so our tokens went light while Quasar kept painting black. Both surfaces now share one `applyTheme()` that moves both, since the two copies had already drifted once.

The test for that was **vacuous at first**: headless Chrome defaults to light, so "not dark" passed whether or not Quasar had been switched. It now runs the context with `colorScheme: 'dark'`, and fails if the Quasar half is removed.

## Hand-test

The options page opens from the browser's extension menu. Worth checking each toggle takes effect in an **already-open** panel without reopening it, and the theme on both surfaces in both browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)