### PR TITLE
v3: Scan Page

### DIFF
--- a/docs/v3/PRD.md
+++ b/docs/v3/PRD.md
@@ -89,6 +89,12 @@ Models — with first-class modern **Playwright accessibility locators**. Determ
 - NFR-3 Per-pick latency interactive (<~100ms typical DOM).
 - NFR-4 Test pyramid: unit (generators) + engine-fidelity vs real Playwright + extension E2E.
 - NFR-5 Automated build → zip → multi-store submit.
+- NFR-7 **Browser floors, declared in the manifest and guarded by
+  `v3/scripts/check-manifests.mjs`.** Chrome **114** (`minimum_chrome_version`), set by the side panel
+  API; Firefox **115** (`gecko.strict_min_version`), set by `storage.session`, where the per-tab models
+  live. Both are the highest floor anything in v3 needs — MV3 itself is Chrome 88 / Firefox 109, and
+  `menus` with `contexts: ['action']` is Chrome 85 / Firefox 109. Shipped source uses no JavaScript newer
+  than `??=` and `replaceChildren` (2020).
 - NFR-6 Ship as in-place update to existing CWS + AMO listings; preserve extension IDs (CWS item `ejgkdhekcepfgdghejpkmbfjgnioejak`, AMO `gecko.id` — **not yet recorded, read it off the AMO Developer Hub**; `v3/wxt.config.ts` carries a placeholder). MV3 on both browsers, as v2.5.1 already ships. User storage persists across upgrade.
 
 ## 6. Out of scope (v1)

--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -352,7 +352,8 @@ before starting the next.
    Scan deliberately: Scan's job is picking a *container*, and containers are exactly the nested,
    same-box elements this fixes.
 
-10. **Scan** (SPEC §4). Container pick, interactive-role descendants, a11y-tree filtered.
+10. **Scan** (SPEC §4). ✅ **Done** — container pick, interactive descendants, a11y-tree filtered,
+    honouring `modelHiddenElements`. Awaiting hand-test.
 
 11. **Generate Code** (SPEC §11). Selenium Java first — the reference template — with the six fixes.
 

--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -364,6 +364,21 @@ before starting the next.
 
 14. **Frames** (SPEC §16) and the **page-object wrapper** (SPEC §17).
 
+**Considered, not scheduled — capture from the Elements tree.** `devtools.panels.elements
+.onSelectionChanged` plus `inspectedWindow.eval` with `$0` would let a button add whatever is selected
+in DevTools' own DOM tree (Chrome 18 / Firefox 56, so no compatibility concern). Attractive because that
+tree already solves nesting, shadow DOM and collapsed subtrees — the things the overlay struggles with.
+
+Two reasons it is not scheduled. `devtools.*` exists only in the DevTools panel, so it would be a button
+the sidebar cannot have; and `inspectedWindow.eval` runs in the page world while the engine lives in the
+content script's, with `useContentScriptContext` being Chrome-only — the portable bridge is to tag `$0`
+with a temporary attribute and have the content script find it.
+
+A sidebar pane in the Elements panel (`createSidebarPane`) was rejected outright: it would be a second
+copy of the table we already have, somewhere worse. There is no way to add an item to the Elements
+context menu — the menu contexts are `action, bookmark, browser_action, launcher, page_action, password,
+tab, tools_menu`, and none of them are DevTools.
+
 **Settings** (SPEC §14) ✅ **done, pulled forward** — `src/settings.ts` over `storage.sync`, an options
 page at `entrypoints/options/`, and all five toggles wired. Brought forward because `appendTypeToName`
 was requested, and a setting nobody can change is not a feature; building the mechanism twice would have

--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -369,10 +369,18 @@ before starting the next.
 in DevTools' own DOM tree (Chrome 18 / Firefox 56, so no compatibility concern). Attractive because that
 tree already solves nesting, shadow DOM and collapsed subtrees — the things the overlay struggles with.
 
-Two reasons it is not scheduled. `devtools.*` exists only in the DevTools panel, so it would be a button
-the sidebar cannot have; and `inspectedWindow.eval` runs in the page world while the engine lives in the
-content script's, with `useContentScriptContext` being Chrome-only — the portable bridge is to tag `$0`
-with a temporary attribute and have the content script find it.
+**It only makes sense feeding the sidebar, not a DevTools panel.** DevTools panels are mutually
+exclusive tabs: you are on Elements or on Page Modeller, never both, so selecting in the tree and then
+switching tabs to press Add is worse than the overlay.
+
+The `devtools` page is not a panel, though — `devtools.html` runs the whole time DevTools is open,
+whichever tab is showing. So it can listen for `onSelectionChanged` while Elements is active and feed
+the **sidebar**, which is visible alongside it. That is the one arrangement where this beats the
+overlay, and it needs DevTools and the sidebar open together.
+
+Remaining wrinkle: `inspectedWindow.eval` runs in the page world while the engine lives in the content
+script's, and `useContentScriptContext` is Chrome-only — the portable bridge is to tag `$0` with a
+temporary attribute and have the content script find it.
 
 A sidebar pane in the Elements panel (`createSidebarPane`) was rejected outright: it would be a second
 copy of the table we already have, somewhere worse. There is no way to add an item to the Elements

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -74,8 +74,7 @@ non-interactive elements get into the model.
 
 Both modes are **one-shot**: selecting an element stops picking. No continuous capture. **[settled]**
 
-**What scan includes.** Descendants with an **interactive role**, filtered by
-`modelHiddenElements` (§14): **[settled]**
+**What scan includes.** Descendants that are **interactive**, filtered by `modelHiddenElements` (§14): **[settled]**
 
 | `modelHiddenElements` | Scan includes |
 |---|---|
@@ -83,8 +82,16 @@ Both modes are **one-shot**: selecting an element stops picking. No continuous c
 | **on** | every interactive-role descendant, regardless of a11y-tree exposure |
 
 Off is the same rule Playwright's `getByRole` applies by default (`includeHidden: false`), so the scan
-filter and the locator semantics agree by construction. Interactive-ness is already role-derived, so one
-rule covers both concerns.
+filter and the locator semantics agree by construction.
+
+**Interactive means the four buckets of §11** — actionable, text, toggle, select — so anything a scan
+collects is something the generator can write methods for. `static` is deliberately excluded, or a scan
+of a page would return every heading, paragraph and image on it; those go in one at a time with Add.
+
+**Plus form controls that HTML-AAM gives no role at all.** `input[type=password]` is the one that
+matters: it has no ARIA role, so a role-only rule skips it, and a scan of a login form that misses the
+password field is plainly broken. The date and time family, colour and file pickers are in the same
+position. `type=hidden` is excluded — never rendered, never interactive.
 
 **Note that "what Playwright includes" is two rules, not one.** `getByRole` uses ARIA tree exclusion;
 `:visible` and actionability use *"non-empty bounding box and does not have `visibility:hidden`"*. They

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -222,6 +222,13 @@ locator can be tested before saving. **[settled]**
 | 0 | red error | *0 elements match that locator* |
 | >1 | amber warning | *N elements match that locator* |
 
+**A hidden match is still shown, and said.** With `modelHiddenElements` on (§14) a locator can resolve to
+something with no box to outline, and the eye then reported *1 element matches* while drawing nothing —
+a true count that reads as a failure. Such a match is marked on its **nearest visible ancestor**, dashed
+rather than solid and captioned *hidden element*, so it says where on the page the thing lives without
+pretending to be it. With no visible ancestor at all, a banner says how many matches have no position.
+The count appends *— it is hidden* / *— N hidden*. **[settled]**
+
 **Every candidate must find the element it was generated from.** A locator can be well-formed, resolve
 to something, and still be useless: `getByRole` excludes a11y-hidden elements, so a hidden button's role
 candidate finds the *other* buttons; `getByText` matches the innermost element, so a `<fieldset>`'s text

--- a/v3/README.md
+++ b/v3/README.md
@@ -92,20 +92,22 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    the count — green for 1, red for 0, amber for more. Highlight clears after ~3s, or at once on
    **Close**. Clicking it repeatedly replaces the message rather than stacking a counter badge, and the
    new highlight survives the replacement.
-10. **Edit** (pencil or double-click): name validation rejects blank, spaced and duplicate names;
+10. With **Model hidden elements** on, the eye on a hidden row marks its nearest visible ancestor
+    with a dashed outline captioned *hidden element*, and the count says so.
+11. **Edit** (pencil or double-click): name validation rejects blank, spaced and duplicate names;
    switching type fills the fields from a generated locator or blanks them; the eye tests what is
    typed; Save updates the row in **both** surfaces.
-11. **Clicking a row** does nothing — that is setting-gated and off by default (SPEC §6). Double-click
+12. **Clicking a row** does nothing — that is setting-gated and off by default (SPEC §6). Double-click
    still opens the editor.
-12. **Both surfaces at once**: open the sidebar and the DevTools panel on one tab — they show the same
+13. **Both surfaces at once**: open the sidebar and the DevTools panel on one tab — they show the same
     rows, and a pick in either appears in both. Close one; the model survives in the other. Close them
     all and reopen; that tab's model is gone. Check this with a second tab modelled too — closing one
     tab's panels must not touch the other's.
-13. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
+14. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
    switch to B, add something different, switch back — A must be intact.
-14. **Navigate within a tab** with a model built: a banner names the page it was built on and offers
+15. **Navigate within a tab** with a model built: a banner names the page it was built on and offers
     Delete Model. Navigate back and the banner clears.
-15. Table headers stay visible at the narrowest side-panel width.
+16. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the
 engine was validated on — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a

--- a/v3/README.md
+++ b/v3/README.md
@@ -53,6 +53,11 @@ MV3 on both browsers. One `sidepanel` entrypoint gives Chrome `side_panel` and F
 `npm run dev` (Chrome) or `npm run dev:firefox` — WXT launches the browser with the extension loaded.
 Navigate wherever you want to test.
 
+The dev browser reuses a profile under `.wxt/` rather than a throwaway one, so settings, logins and
+history survive a restart. `web-ext` uses a temporary profile by default, which meant `storage.sync`
+started empty every run and no setting ever appeared to persist. Delete `.wxt/chrome-profile` or
+`.wxt/firefox-profile` to start clean.
+
 Manually, from a production build:
 
 - **Chrome** — `npm run build`, then `chrome://extensions` → Developer mode → Load unpacked →

--- a/v3/README.md
+++ b/v3/README.md
@@ -53,8 +53,10 @@ MV3 on both browsers. One `sidepanel` entrypoint gives Chrome `side_panel` and F
 `npm run dev` (Chrome) or `npm run dev:firefox` — WXT launches the browser with the extension loaded.
 Navigate wherever you want to test.
 
-The dev browser reuses a profile under `.wxt/` rather than a throwaway one, so settings, logins and
-history survive a restart. `web-ext` uses a temporary profile by default, which meant `storage.sync`
+The dev browser is Chrome **stable**, and reuses a profile under `.wxt/` rather than a throwaway one, so
+settings, logins and history survive a restart. `chrome-launcher` otherwise picks the newest install it
+finds — Canary, on a machine that has it — which would hide exactly the version problems
+`minimum_chrome_version` exists to catch. Set `CHROME_PATH` to override. `web-ext` uses a temporary profile by default, which meant `storage.sync`
 started empty every run and no setting ever appeared to persist. Delete `.wxt/chrome-profile` or
 `.wxt/firefox-profile` to start clean.
 

--- a/v3/README.md
+++ b/v3/README.md
@@ -81,28 +81,30 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    - **↑ / ↓** walk the target up and down the nesting; moving the mouse starts again from the cursor.
      **Enter** or a click picks the walked-to element, not what is under the pointer. The page must not
      scroll, and Enter must not re-trigger the Add Element button.
-5. **Escape** cancels Add Element — both with focus in the panel and with focus in the page.
-6. The row's name and locator look right, **on one line** — Name, Locator and Actions across, not
+5. **Scan Page** → pick a container (arrow keys help: clicking the middle of a form lands on an input)
+   → its interactive descendants arrive as rows, the container itself does not, and Scan then greys out
+   because it is once per model.
+6. **Escape** cancels Add Element — both with focus in the panel and with focus in the page.
+7. The row's name and locator look right, **on one line** — Name, Locator and Actions across, not
    stacked; a second element with the same name becomes `About2`.
-7. Row trash and Delete Model both confirm, and the dialog follows the light/dark theme.
-8. **Eye** highlights every match in yellow with a red outline, scrolls the first into view, and reports
+8. Row trash and Delete Model both confirm, and the dialog follows the light/dark theme.
+9. **Eye** highlights every match in yellow with a red outline, scrolls the first into view, and reports
    the count — green for 1, red for 0, amber for more. Highlight clears after ~3s, or at once on
    **Close**. Clicking it repeatedly replaces the message rather than stacking a counter badge, and the
    new highlight survives the replacement.
-9. **Edit** (pencil or double-click): name validation rejects blank, spaced and duplicate names;
+10. **Edit** (pencil or double-click): name validation rejects blank, spaced and duplicate names;
    switching type fills the fields from a generated locator or blanks them; the eye tests what is
    typed; Save updates the row in **both** surfaces.
-10. **Clicking a row** does nothing — that is setting-gated and off by default (SPEC §6). Double-click
+11. **Clicking a row** does nothing — that is setting-gated and off by default (SPEC §6). Double-click
    still opens the editor.
-11. **Both surfaces at once**: open the sidebar and the DevTools panel on one tab — they show the same
+12. **Both surfaces at once**: open the sidebar and the DevTools panel on one tab — they show the same
     rows, and a pick in either appears in both. Close one; the model survives in the other. Close them
     all and reopen; that tab's model is gone. Check this with a second tab modelled too — closing one
     tab's panels must not touch the other's.
-12. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
+13. **Switch tabs**: the table swaps to that tab's model and swaps back (SPEC §5). Build a model in tab A,
    switch to B, add something different, switch back — A must be intact.
-13. **Navigate within a tab** with a model built: a banner names the page it was built on and offers
+14. **Navigate within a tab** with a model built: a banner names the page it was built on and offers
     Delete Model. Navigate back and the banner clears.
-14. Navigate within a tab: the model stays (it may be stale; the banner for that is not built yet).
 15. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -98,10 +98,14 @@ export default defineBackground(() => {
 
     switch (m.type) {
       // ---- from a content script ----
-      case 'ELEMENT_PICKED': {
+      case 'ELEMENT_PICKED':
+      case 'ELEMENTS_PICKED': {
         const tabId = sender.tab?.id;
         if (tabId == null) return;
         const url = sender.tab?.url ?? null;
+        // One path for a single pick and a scan's haul, so both name and rank
+        // identically — a scan is just Add, many times over.
+        const results = m.type === 'ELEMENTS_PICKED' ? m.results : [m.result];
         // Read before mutating: the change callback is synchronous, and naming
         // depends on a setting the user can change at any time (SPEC §13).
         void loadSettings().then((settings) =>
@@ -109,16 +113,24 @@ export default defineBackground(() => {
             // The page the model belongs to, recorded when the first element
             // lands.
             if (model.url == null) model.url = url;
-            model.elements.push({
-              ...m.result,
-              // Unique within the model rather than a worker-lifetime counter:
-              // the worker restarts, and the counter would restart with it.
-              id: `el-${Date.now().toString(36)}-${model.elements.length}`,
-              name: uniqueName(settings.appendTypeToName ? withTypeSuffix(m.result.suggestedName, m.result.role) : m.result.suggestedName, usedNames(model)),
-              // Not the engine's preferredIndex: that is framework-agnostic,
-              // and would hand a Selenium model a Playwright-only locator.
-              selectedIndex: chooseCandidate(m.result.candidates, model.frameworkId),
-            });
+            // usedNames is derived from the model, so it is recomputed as each
+            // element lands — otherwise a scan of ten "Delete" buttons would
+            // name them all the same.
+            for (const result of results) {
+              model.elements.push({
+                ...result,
+                // Unique within the model rather than a worker-lifetime
+                // counter: the worker restarts, and so would the counter.
+                id: `el-${Date.now().toString(36)}-${model.elements.length}`,
+                name: uniqueName(
+                  settings.appendTypeToName ? withTypeSuffix(result.suggestedName, result.role) : result.suggestedName,
+                  usedNames(model)
+                ),
+                // Not the engine's preferredIndex: that is framework-agnostic,
+                // and would hand a Selenium model a Playwright-only locator.
+                selectedIndex: chooseCandidate(result.candidates, model.frameworkId),
+              });
+            }
           })
         );
         // Picking is one-shot (SPEC §4); tell the panels so they can un-arm.

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -1,6 +1,7 @@
 import { generate, resolveCandidate } from '@/src/engine/candidates';
 import { describeBrief, describeElement } from '@/src/engine/describe';
-import { isMessage, type Message } from '@/src/messaging';
+import { collectInteractive } from '@/src/engine/interactive';
+import { isMessage, type Message, type PickMode } from '@/src/messaging';
 
 // Inspector overlay: highlight the element under the cursor (like DevTools) and,
 // on click, run the locator engine and report the result to the side panel.
@@ -9,6 +10,9 @@ export default defineContentScript({
   allFrames: true,
   main() {
     let active = false;
+    /** 'add' takes the element itself; 'scan' takes its interactive children. */
+    let mode: PickMode = 'add';
+    let includeHidden = false;
     let box: HTMLDivElement | null = null;
     let label: HTMLDivElement | null = null;
     let current: Element | null = null;
@@ -165,12 +169,20 @@ export default defineContentScript({
     /** Commit the current target. Shared by clicking and by Enter. */
     function pickCurrent() {
       if (!active || !current) return;
-      const result = generate(current);
+      const target = current;
       // Both modes are one-shot (SPEC §4) — stop before reporting, so the
       // overlay is gone by the time the panel re-renders.
       stop({ notify: false });
+
+      // Scan takes the container's interactive descendants, never the container
+      // itself: you are modelling what is inside the section you chose.
+      const message =
+        mode === 'scan'
+          ? { type: 'ELEMENTS_PICKED', results: collectInteractive(target, includeHidden).map(generate) }
+          : { type: 'ELEMENT_PICKED', result: generate(target) };
+
       // Rejects when no panel is open; that's fine, drop it.
-      browser.runtime.sendMessage({ type: 'ELEMENT_PICKED', result }).catch(() => {});
+      browser.runtime.sendMessage(message).catch(() => {});
     }
 
     const onClick = (e: MouseEvent) => {
@@ -256,7 +268,11 @@ export default defineContentScript({
     browser.runtime.onMessage.addListener((msg: unknown) => {
       if (!isMessage(msg)) return;
       const m = msg as Message;
-      if (m.type === 'START_PICKING') start();
+      if (m.type === 'START_PICKING') {
+        mode = m.mode;
+        includeHidden = m.includeHidden;
+        start();
+      }
       else if (m.type === 'STOP_PICKING') stop();
       else if (m.type === 'CLEAR_HIGHLIGHT') clearMarks();
       else if (m.type === 'MOVE_TARGET') moveTarget(m.direction);

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -124,35 +124,102 @@ export default defineContentScript({
       markTimer = undefined;
     }
 
-    function highlightAll(targets: Element[]) {
+    const hasBox = (el: Element) => {
+      const r = el.getBoundingClientRect();
+      return r.width > 0 || r.height > 0;
+    };
+
+    /**
+     * Where to draw a match, and whether it is really there.
+     *
+     * A hidden element has no box to outline, so with `modelHiddenElements` on
+     * the eye reported "1 element matches" and drew nothing at all — a true
+     * count that looked like a failure. Fall back to the nearest ancestor that
+     * does have a box, which at least says *where* on the page the hidden thing
+     * lives.
+     */
+    function markTarget(el: Element): { anchor: Element | null; hidden: boolean } {
+      if (hasBox(el)) return { anchor: el, hidden: false };
+      for (let cur = el.parentElement; cur; cur = cur.parentElement) {
+        if (hasBox(cur)) return { anchor: cur, hidden: true };
+      }
+      return { anchor: null, hidden: true };
+    }
+
+    function drawMark(rect: DOMRect, hidden: boolean, caption?: string) {
+      const mark = document.createElement('div');
+      // Identifies our overlay to tests and to anyone inspecting the page.
+      mark.dataset.pageModeller = 'highlight';
+      if (hidden) mark.dataset.hidden = 'true';
+      Object.assign(mark.style, {
+        position: 'fixed',
+        pointerEvents: 'none',
+        zIndex: Z,
+        left: `${rect.left}px`,
+        top: `${rect.top}px`,
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+        background: 'rgba(255, 235, 59, 0.45)',
+        // Dashed, so a stand-in for something you cannot see does not look like
+        // the thing itself.
+        outline: hidden ? '2px dashed #d32f2f' : '2px solid #d32f2f',
+        outlineOffset: '-1px',
+      } as CSSStyleDeclaration);
+
+      if (caption) {
+        const tag = document.createElement('div');
+        tag.textContent = caption;
+        Object.assign(tag.style, {
+          position: 'absolute',
+          left: '0',
+          top: '0',
+          font: '11px/1.4 ui-monospace, monospace',
+          color: '#fff',
+          background: '#d32f2f',
+          padding: '1px 6px',
+          borderRadius: '0 0 3px 0',
+          whiteSpace: 'nowrap',
+        } as CSSStyleDeclaration);
+        mark.appendChild(tag);
+      }
+
+      document.documentElement.appendChild(mark);
+      marks.push(mark);
+      return mark;
+    }
+
+    function highlightAll(targets: Element[]): { hidden: number } {
       clearMarks();
-      if (targets.length === 0) return;
+      if (targets.length === 0) return { hidden: 0 };
+
+      const placed = targets.map((t) => ({ target: t, ...markTarget(t) }));
 
       // Scroll the FIRST match into view before measuring, or every box after
-      // it would be positioned against the pre-scroll viewport.
-      targets[0].scrollIntoView({ block: 'center', inline: 'nearest' });
+      // it would be positioned against the pre-scroll viewport. A hidden
+      // element cannot be scrolled to, so scroll to its stand-in.
+      placed.find((p) => p.anchor)?.anchor?.scrollIntoView({ block: 'center', inline: 'nearest' });
 
-      for (const t of targets) {
-        const r = t.getBoundingClientRect();
-        const mark = document.createElement('div');
-        // Identifies our overlay to tests and to anyone inspecting the page.
-        mark.dataset.pageModeller = 'highlight';
-        Object.assign(mark.style, {
-          position: 'fixed',
-          pointerEvents: 'none',
-          zIndex: Z,
-          left: `${r.left}px`,
-          top: `${r.top}px`,
-          width: `${r.width}px`,
-          height: `${r.height}px`,
-          background: 'rgba(255, 235, 59, 0.45)',
-          outline: '2px solid #d32f2f',
-          outlineOffset: '-1px',
-        } as CSSStyleDeclaration);
-        document.documentElement.appendChild(mark);
-        marks.push(mark);
+      let unplaceable = 0;
+      for (const { anchor, hidden } of placed) {
+        if (!anchor) {
+          unplaceable++;
+          continue;
+        }
+        drawMark(anchor.getBoundingClientRect(), hidden, hidden ? 'hidden element' : undefined);
       }
+
+      // Nothing on the page to point at — say so rather than drawing nothing.
+      if (unplaceable > 0) {
+        const banner = drawMark(new DOMRect(16, 16, 260, 0), true);
+        banner.style.height = 'auto';
+        banner.style.padding = '8px 10px';
+        banner.style.font = '12px/1.4 ui-monospace, monospace';
+        banner.style.color = '#4a1010';
+        banner.textContent = `${unplaceable} matched element${unplaceable === 1 ? '' : 's'} hidden, with no position on the page`;
+      }
+
       markTimer = setTimeout(clearMarks, HIGHLIGHT_MS);
+      return { hidden: placed.filter((p) => p.hidden).length };
     }
 
     const onMove = (e: MouseEvent) => {
@@ -285,9 +352,9 @@ export default defineContentScript({
         // both browsers. Cross-frame highlighting arrives with SPEC §16.
         if (window.top !== window) return;
         const targets = resolveCandidate(document, m.candidate);
-        highlightAll(targets);
+        const { hidden } = highlightAll(targets);
         // Answered as a message, not a reply — sendResponse is not portable.
-        browser.runtime.sendMessage({ type: 'HIGHLIGHT_RESULT', count: targets.length }).catch(() => {});
+        browser.runtime.sendMessage({ type: 'HIGHLIGHT_RESULT', count: targets.length, hidden }).catch(() => {});
       }
     });
   },

--- a/v3/scripts/check-manifests.mjs
+++ b/v3/scripts/check-manifests.mjs
@@ -16,6 +16,8 @@ const EXPECT = {
     'devtools_page': (m) => m.devtools_page === 'devtools.html',
     'background.service_worker': (m) => typeof m.background?.service_worker === 'string',
     'no gecko settings': (m) => m.browser_specific_settings == null,
+    // sidePanel is Chrome 114+; storage.session is 102+.
+    'minimum_chrome_version covers sidePanel': (m) => Number(m.minimum_chrome_version) >= 114,
   },
   'firefox-mv3': {
     'manifest_version': (m) => m.manifest_version === 3,
@@ -29,6 +31,9 @@ const EXPECT = {
     'devtools_page': (m) => m.devtools_page === 'devtools.html',
     'background.scripts': (m) => Array.isArray(m.background?.scripts),
     'gecko.id': (m) => typeof m.browser_specific_settings?.gecko?.id === 'string',
+    // storage.session is Firefox 115+, which is the highest floor here.
+    'strict_min_version covers storage.session': (m) =>
+      parseFloat(m.browser_specific_settings?.gecko?.strict_min_version) >= 115,
   },
 };
 

--- a/v3/src/engine/candidates.ts
+++ b/v3/src/engine/candidates.ts
@@ -140,7 +140,7 @@ export function matchesText(actual: string, expected: string, exact: boolean | u
  * applies this by default (`includeHidden: false`) and we must too, or the eye
  * counts hidden elements the test will never see.
  */
-function ariaHidden(el: Element): boolean {
+export function ariaHidden(el: Element): boolean {
   for (let cur: Element | null = el; cur; cur = cur.parentElement) {
     if (cur.getAttribute('aria-hidden') === 'true') return true;
     if ((cur as HTMLElement).hidden) return true;

--- a/v3/src/engine/interactive.ts
+++ b/v3/src/engine/interactive.ts
@@ -1,0 +1,87 @@
+// Which descendants a scan collects (SPEC §4).
+//
+// Role-derived, not tagName: `<div role="button">` is a control and `<a>`
+// without an href is not. The set is the four interactive buckets from the
+// method mapping (SPEC §11) — actionable, text, toggle, select — so anything
+// scan collects is something the generator knows how to write methods for.
+// `static` is deliberately absent: a scan of a page would otherwise return
+// every heading, paragraph and image on it. Those go in one at a time with Add.
+import { ariaHidden, safeRole } from './candidates';
+
+export const INTERACTIVE_ROLES: ReadonlySet<string> = new Set([
+  // actionable
+  'button',
+  'link',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'tab',
+  'option',
+  'treeitem',
+  // text
+  'textbox',
+  'searchbox',
+  'spinbutton',
+  'slider',
+  // toggle
+  'checkbox',
+  'radio',
+  'switch',
+  // select
+  'combobox',
+  'listbox',
+]);
+
+export function isInteractiveRole(role: string | null): boolean {
+  return role != null && INTERACTIVE_ROLES.has(role);
+}
+
+/**
+ * Form controls that HTML-AAM maps to NO role at all, so a role-only rule
+ * misses them. `input[type=password]` is the one that matters: a scan of a
+ * login form that skips the password field is plainly broken. The date and
+ * time family, colour and file pickers are in the same position.
+ *
+ * `hidden` is excluded — it is never rendered and never interactive.
+ */
+const ROLELESS_INPUT_TYPES: ReadonlySet<string> = new Set([
+  'password',
+  'file',
+  'color',
+  'date',
+  'datetime-local',
+  'month',
+  'time',
+  'week',
+]);
+
+function isRolelessControl(el: Element): boolean {
+  return el.localName === 'input' && ROLELESS_INPUT_TYPES.has((el as HTMLInputElement).type);
+}
+
+/** Something a scan should collect: an interactive role, or a control with none. */
+export function isInteractive(el: Element): boolean {
+  return isInteractiveRole(safeRole(el)) || isRolelessControl(el);
+}
+
+/**
+ * The interactive descendants of `root`, in document order.
+ *
+ * The root itself is never included — a scan models what is *inside* the
+ * container you chose (SPEC §4).
+ *
+ * `includeHidden` is the `modelHiddenElements` setting. Off, elements excluded
+ * from the accessibility tree are skipped, which is the same rule `getByRole`
+ * applies, so a scan cannot collect something the generated locator could never
+ * find. On, they are kept: a validation message or an unopened modal is real
+ * page-object material, and Add cannot reach what is not rendered.
+ */
+export function collectInteractive(root: Element, includeHidden: boolean): Element[] {
+  const found: Element[] = [];
+  for (const el of Array.from(root.querySelectorAll('*'))) {
+    if (!isInteractive(el)) continue;
+    if (!includeHidden && ariaHidden(el)) continue;
+    found.push(el);
+  }
+  return found;
+}

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -39,7 +39,9 @@ export type ContentToPanel =
   // single model update, so the table does not animate in row by row.
   | { type: 'ELEMENTS_PICKED'; results: ElementResult[] }
   | { type: 'PICKING_STOPPED' }
-  | { type: 'HIGHLIGHT_RESULT'; count: number };
+  // `hidden` is how many of those matches have no box of their own, so the
+  // count can say why nothing was outlined where you expected it.
+  | { type: 'HIGHLIGHT_RESULT'; count: number; hidden: number };
 
 // Messages panel → background.
 //

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -8,7 +8,10 @@ import type { TabModel } from './model';
 // 'scan' takes a container and is not wired up yet.
 export type PickMode = 'add' | 'scan';
 export type PanelToContent =
-  | { type: 'START_PICKING'; mode: PickMode }
+  // `includeHidden` is the modelHiddenElements setting (SPEC §14), passed in
+  // rather than read in the page: the panel already has it, and a content
+  // script reading storage would need its own access level.
+  | { type: 'START_PICKING'; mode: PickMode; includeHidden: boolean }
   | { type: 'STOP_PICKING' }
   // Walk the pick target up or down the DOM (SPEC §4). Sent by the panel
   // because focus is there after clicking Add Element, so the page never sees
@@ -32,6 +35,9 @@ export type PanelToContent =
 // plainly reachable.
 export type ContentToPanel =
   | { type: 'ELEMENT_PICKED'; result: ElementResult }
+  // A scan's haul, in one message rather than N: the background adds them in a
+  // single model update, so the table does not animate in row by row.
+  | { type: 'ELEMENTS_PICKED'; results: ElementResult[] }
   | { type: 'PICKING_STOPPED' }
   | { type: 'HIGHLIGHT_RESULT'; count: number };
 

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -684,3 +684,63 @@ test('appendTypeToName changes how a pick is named (SPEC §13)', async () => {
 
   await panel.evaluate(() => chrome.storage.sync.remove('options'));
 });
+
+test('scan adds a container\'s interactive descendants, not the container (SPEC §4)', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  for (const open of context.pages()) {
+    if (open.url().startsWith('chrome-extension://')) await open.close();
+  }
+
+  const { page, tabId } = await openFixture(sw as never, 'scan');
+
+  const panel = await context.newPage();
+  await panel.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await panel.evaluate(() => {
+    (window as unknown as { __msgs: unknown[] }).__msgs = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+    });
+  });
+
+  const model = async () =>
+    (await panel.evaluate(() => (window as unknown as { __msgs: { type: string; model?: { elements: { name: string; role: string | null }[] } }[] }).__msgs))
+      .filter((m) => m.type === 'MODEL')
+      .at(-1)?.model;
+
+  await panel.evaluate(
+    (id) =>
+      chrome.runtime.sendMessage({
+        type: 'RELAY_TO_TAB',
+        tabId: id,
+        message: { type: 'START_PICKING', mode: 'scan', includeHidden: false },
+      }),
+    tabId
+  );
+
+  // Reach the <form> with the arrow keys, which is what they are for: clicking
+  // the middle of a form lands on a child input, and scanning that collects
+  // nothing. Hover a control inside it, then walk up.
+  const label = page.locator('[data-page-modeller="label"]');
+  await page.getByRole('button', { name: 'Sign in' }).hover();
+  for (let i = 0; i < 5 && !/› form$/.test((await label.textContent()) ?? ''); i++) {
+    await page.keyboard.press('ArrowUp');
+  }
+  await expect(label).toHaveText(/› form$/);
+  await page.keyboard.press('Enter');
+
+  await expect.poll(async () => (await model())?.elements.length).toBeGreaterThan(0);
+  const elements = (await model())!.elements;
+
+  // Only the form's own controls, and never the form itself.
+  expect(elements.map((e) => e.name)).toEqual(['EmailAddress', 'Password', 'RememberMe', 'SignIn']);
+  // The password field has NO role — HTML-AAM maps input[type=password] to
+  // none — which is exactly why the rule cannot be role-only.
+  expect(elements.map((e) => e.role)).toEqual(['textbox', null, 'checkbox', 'button']);
+
+  // Static content inside the form — the four labels — is not collected: a scan
+  // of a page would otherwise return every piece of text on it.
+  expect(elements).toHaveLength(4);
+});

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -744,3 +744,45 @@ test('scan adds a container\'s interactive descendants, not the container (SPEC 
   // of a page would otherwise return every piece of text on it.
   expect(elements).toHaveLength(4);
 });
+
+test('a hidden match is marked on its nearest visible ancestor', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'hidden-eye', 'edgecases.html');
+  await collectMessages(sw as never);
+
+  const marks = page.locator('[data-page-modeller="highlight"]');
+
+  // A visible control marks itself, solid.
+  await sw.evaluate(
+    (id) => chrome.tabs.sendMessage(id, { type: 'HIGHLIGHT', candidate: { kind: 'css', value: '#hidden-host' } }),
+    tabId
+  );
+  await expect(marks).toHaveCount(1);
+  await expect(marks.first()).not.toHaveAttribute('data-hidden', 'true');
+
+  // A hidden one has no box of its own, so it is marked on the nearest
+  // ancestor that has one — dashed, and captioned, rather than drawn nowhere.
+  await sw.evaluate(
+    (id) =>
+      chrome.tabs.sendMessage(id, {
+        type: 'HIGHLIGHT',
+        candidate: { kind: 'css', value: '[data-spike="hidden-in-visible-parent"]' },
+      }),
+    tabId
+  );
+  await expect(marks).toHaveCount(1);
+  await expect(marks.first()).toHaveAttribute('data-hidden', 'true');
+  await expect(marks.first()).toContainText('hidden element');
+
+  // And the count says so, or "1 element matches" with nothing outlined where
+  // you expected it reads as a failure.
+  await expect
+    .poll(async () =>
+      (await sw.evaluate(() => (globalThis as unknown as { __picks: { type: string; hidden?: number }[] }).__picks))
+        .filter((m) => m.type === 'HIGHLIGHT_RESULT')
+        .at(-1)?.hidden
+    )
+    .toBe(1);
+});

--- a/v3/tests/fixtures/edgecases.html
+++ b/v3/tests/fixtures/edgecases.html
@@ -71,6 +71,11 @@
     <!-- 18. duplicate accessible name (ambiguous role+name) -->
     <button data-spike="dup-name-a">Continue</button>
     <button data-spike="dup-name-b">Continue</button>
-  </main>
+    <!-- A hidden control inside a visible box: the eye has nothing of its own to
+       outline, so it marks the nearest ancestor that does have one. -->
+  <div id="hidden-host" style="width: 200px; height: 40px; border: 1px solid #ccc">
+    <button data-spike="hidden-in-visible-parent" style="display: none">Ghost action</button>
+  </div>
+</main>
 </body>
 </html>

--- a/v3/tests/unit/interactive.test.ts
+++ b/v3/tests/unit/interactive.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { collectInteractive, isInteractiveRole } from '../../src/engine/interactive';
+
+function root(html: string): Element {
+  document.body.innerHTML = `<div id="root">${html}</div>`;
+  return document.getElementById('root')!;
+}
+
+const names = (els: Element[]) => els.map((e) => e.getAttribute('data-n'));
+
+describe('isInteractiveRole', () => {
+  it('accepts the four interactive buckets', () => {
+    for (const role of ['button', 'link', 'textbox', 'checkbox', 'combobox', 'listbox', 'tab', 'switch']) {
+      expect(isInteractiveRole(role), role).toBe(true);
+    }
+  });
+
+  it('rejects static roles', () => {
+    // A scan of a page would otherwise return every heading and image on it.
+    for (const role of ['heading', 'img', 'paragraph', 'cell', 'main', null]) {
+      expect(isInteractiveRole(role), String(role)).toBe(false);
+    }
+  });
+});
+
+describe('collectInteractive', () => {
+  it('takes interactive descendants in document order', () => {
+    const el = root(`
+      <h1 data-n="heading">Ignored</h1>
+      <a href="/a" data-n="link">A</a>
+      <p data-n="para">Ignored</p>
+      <button data-n="button">B</button>
+      <input data-n="input" aria-label="C" />
+    `);
+    expect(names(collectInteractive(el, false))).toEqual(['link', 'button', 'input']);
+  });
+
+  it('is role-derived, not tagName-derived', () => {
+    const el = root(`
+      <div role="button" data-n="div-button">Go</div>
+      <a data-n="anchor-no-href">Not a link</a>
+    `);
+    // <a> without href has no link role; <div role="button"> is a control.
+    expect(names(collectInteractive(el, false))).toEqual(['div-button']);
+  });
+
+  it('never includes the container itself', () => {
+    // You are modelling what is inside the section you chose (SPEC §4).
+    document.body.innerHTML = '<div role="button" id="root"><span>x</span></div>';
+    const el = document.getElementById('root')!;
+    expect(collectInteractive(el, false)).toEqual([]);
+  });
+
+  it('skips elements hidden from the accessibility tree by default', () => {
+    const el = root(`
+      <button data-n="visible">Yes</button>
+      <button data-n="aria-hidden" aria-hidden="true">No</button>
+      <button data-n="attr-hidden" hidden>No</button>
+      <div style="display: none"><button data-n="in-hidden-parent">No</button></div>
+    `);
+    expect(names(collectInteractive(el, false))).toEqual(['visible']);
+  });
+
+  it('includes them when modelHiddenElements is on', () => {
+    // A validation message or an unopened modal is real page-object material,
+    // and Add cannot reach what is not rendered (SPEC §4).
+    const el = root(`
+      <button data-n="visible">Yes</button>
+      <button data-n="hidden" aria-hidden="true">Also</button>
+    `);
+    expect(names(collectInteractive(el, true))).toEqual(['visible', 'hidden']);
+  });
+
+  it('collects form controls that HTML-AAM gives no role', () => {
+    // input[type=password] has no ARIA role, so a role-only rule skips it — and
+    // a scan of a login form that misses the password field is plainly broken.
+    const el = root(`
+      <input type="password" data-n="password" />
+      <input type="file" data-n="file" />
+      <input type="date" data-n="date" />
+      <input type="hidden" data-n="hidden" />
+    `);
+    expect(names(collectInteractive(el, false))).toEqual(['password', 'file', 'date']);
+  });
+
+  it('finds controls at any depth', () => {
+    const el = root('<div><section><form><button data-n="deep">Deep</button></form></section></div>');
+    expect(names(collectInteractive(el, false))).toEqual(['deep']);
+  });
+});

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -8,7 +8,7 @@
         :is-adding="isAdding"
         :show-tooltips="settings.showTooltips"
         @update:framework-id="setFramework"
-        @scan="notYet('Scan')"
+        @scan="toggleScan"
         @add="toggleAdd"
         @delete-model="deleteModel"
         @generate="notYet('Generate Code')"
@@ -63,7 +63,7 @@ import EditElementDialog from './EditElementDialog.vue';
 import { defaultFrameworkId } from '@/src/frameworks';
 import { displayLocator } from '@/src/locators/display';
 import { activeCandidate, emptyModel, type ModelElement, type TabModel } from '@/src/model';
-import { isMessage, PANEL_PORT, type BackgroundToPanel, type PanelToBackground, type PanelToContent } from '@/src/messaging';
+import { isMessage, PANEL_PORT, type BackgroundToPanel, type PanelToBackground, type PanelToContent, type PickMode } from '@/src/messaging';
 import { hostKey } from '@/host/types';
 import { applyTheme } from './theme';
 import type { LocatorCandidate } from '@/src/engine/types';
@@ -268,14 +268,28 @@ host.onTabChanged((next) => {
   if (next != null) toBackground({ type: 'GET_MODEL', tabId: next });
 });
 
-async function toggleAdd() {
-  if (isAdding.value) return stopPicking();
+async function startPicking(mode: PickMode) {
   const target = tabId.value ?? (await host.getTabId());
   tabId.value = target;
   if (target == null) return;
-  send(target, { type: 'START_PICKING', mode: 'add' });
+  send(target, { type: 'START_PICKING', mode, includeHidden: settings.value.modelHiddenElements });
   // Optimistic: TAB_UNREACHABLE resets it if the page cannot be reached.
-  isAdding.value = true;
+  if (mode === 'scan') isScanning.value = true;
+  else isAdding.value = true;
+}
+
+async function toggleAdd() {
+  if (isAdding.value) return stopPicking();
+  await startPicking('add');
+}
+
+/**
+ * Scan is once per model (SPEC §4) — the toolbar disables it once anything has
+ * been added, so this only ever starts on an empty model.
+ */
+async function toggleScan() {
+  if (isScanning.value) return stopPicking();
+  await startPicking('scan');
 }
 
 function setFramework(frameworkId: string) {

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -201,7 +201,7 @@ function onRuntimeMessage(msg: unknown) {
   } else if (incoming.type === 'FROM_TAB') {
     const m = incoming.message;
     if (m.type === 'PICKING_STOPPED') isAdding.value = isScanning.value = false;
-    else if (m.type === 'HIGHLIGHT_RESULT') showMatchCount(m.count);
+    else if (m.type === 'HIGHLIGHT_RESULT') showMatchCount(m.count, m.hidden);
   }
 }
 
@@ -326,7 +326,7 @@ function saveEdit(payload: { name: string; selectedIndex: number; override?: Loc
   editing.value = undefined;
 }
 
-function showMatchCount(count: number) {
+function showMatchCount(count: number, hidden = 0) {
   const tone =
     count === 1
       ? { icon: 'check_circle', color: 'positive' }
@@ -334,9 +334,13 @@ function showMatchCount(count: number) {
         ? { icon: 'error', color: 'negative' }
         : { icon: 'warning', color: 'warning' };
 
+  // Say when a match is hidden. Otherwise "1 element matches" with nothing
+  // outlined reads as a failure, when the locator is doing exactly its job.
+  const aside = hidden > 0 ? ` — ${hidden === count ? (count === 1 ? 'it is' : 'all') : hidden} hidden` : '';
+
   notice('matchCount', {
     ...tone,
-    message: `${count} element${count === 1 ? '' : 's'} match${count === 1 ? 'es' : ''} that locator`,
+    message: `${count} element${count === 1 ? '' : 's'} match${count === 1 ? 'es' : ''} that locator${aside}`,
     // Close takes the highlight with it, so the page is never left marked up
     // with no explanation. Only on the explicit action: a dismiss handler would
     // also fire when this notice is replaced by the next eye click, wiping the

--- a/v3/wxt.config.ts
+++ b/v3/wxt.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import { defineConfig } from 'wxt';
 import vue from '@vitejs/plugin-vue';
 import { quasar, transformAssetUrls } from '@quasar/vite-plugin';
@@ -39,6 +40,16 @@ export default defineConfig({
       },
     }),
   }),
+
+  // web-ext launches a throwaway profile by default, so every `npm run dev`
+  // started with empty storage.sync — settings never survived a restart, and
+  // neither did being logged in to whatever site you were modelling. These live
+  // under .wxt/, which is gitignored.
+  webExt: {
+    keepProfileChanges: true,
+    chromiumProfile: resolve('.wxt/chrome-profile'),
+    firefoxProfile: resolve('.wxt/firefox-profile'),
+  },
 
   vite: () => ({
     plugins: [vue({ template: { transformAssetUrls } }), quasar({})],

--- a/v3/wxt.config.ts
+++ b/v3/wxt.config.ts
@@ -1,8 +1,33 @@
-import { mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { defineConfig } from 'wxt';
 import vue from '@vitejs/plugin-vue';
 import { quasar, transformAssetUrls } from '@quasar/vite-plugin';
+
+/**
+ * Chrome *stable*, not whatever is newest.
+ *
+ * chrome-launcher picks the most recent installation it finds, which on a
+ * machine with Canary installed means testing against Canary — and Canary will
+ * happily hide a version problem that the declared floor
+ * (`minimum_chrome_version`) exists to catch.
+ *
+ * Returns undefined when stable is not where it is expected, so web-ext falls
+ * back to its own search rather than failing to launch. `CHROME_PATH` wins, as
+ * chrome-launcher itself honours it.
+ */
+function chromeStable(): string | undefined {
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  const candidates: Record<string, string[]> = {
+    darwin: ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'],
+    linux: ['/usr/bin/google-chrome', '/usr/bin/google-chrome-stable', '/opt/google/chrome/chrome'],
+    win32: [
+      'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+      'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    ],
+  };
+  return (candidates[process.platform] ?? []).find((path) => existsSync(path));
+}
 
 function devProfile(name: string): string {
   const path = resolve('.wxt', name);
@@ -61,6 +86,7 @@ export default defineConfig({
   // Created here because chrome-launcher writes its log INTO the profile
   // directory without creating it first, and dies with ENOENT if it is missing.
   webExt: {
+    binaries: { chrome: chromeStable() },
     keepProfileChanges: true,
     chromiumProfile: devProfile('chrome-profile'),
     firefoxProfile: devProfile('firefox-profile'),

--- a/v3/wxt.config.ts
+++ b/v3/wxt.config.ts
@@ -22,6 +22,11 @@ export default defineConfig({
     description: 'Pick a DOM element and generate a verified Playwright Page Object Model.',
     // `sidePanel` is Chromium-only and is rejected by Firefox; WXT adds it to
     // the Chrome build itself when it sees the sidepanel entrypoint.
+    // The side panel API is Chrome 114+, and it is the highest floor anything
+    // here has — without this the store would offer the extension to browsers
+    // where the panel silently does not exist. Firefox's floor is declared as
+    // gecko.strict_min_version below.
+    minimum_chrome_version: '114',
     // `storage` covers storage.session, where the per-tab models live (SPEC §5)
     // — the service worker is terminated after 30s idle and cannot hold them —
     // and storage.sync for settings (SPEC §14).

--- a/v3/wxt.config.ts
+++ b/v3/wxt.config.ts
@@ -1,7 +1,14 @@
+import { mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { defineConfig } from 'wxt';
 import vue from '@vitejs/plugin-vue';
 import { quasar, transformAssetUrls } from '@quasar/vite-plugin';
+
+function devProfile(name: string): string {
+  const path = resolve('.wxt', name);
+  mkdirSync(path, { recursive: true });
+  return path;
+}
 
 // Validated stack (Spike #2): drive Vite directly with the Vue + Quasar plugins.
 export default defineConfig({
@@ -45,10 +52,13 @@ export default defineConfig({
   // started with empty storage.sync — settings never survived a restart, and
   // neither did being logged in to whatever site you were modelling. These live
   // under .wxt/, which is gitignored.
+  //
+  // Created here because chrome-launcher writes its log INTO the profile
+  // directory without creating it first, and dies with ENOENT if it is missing.
   webExt: {
     keepProfileChanges: true,
-    chromiumProfile: resolve('.wxt/chrome-profile'),
-    firefoxProfile: resolve('.wxt/firefox-profile'),
+    chromiumProfile: devProfile('chrome-profile'),
+    firefoxProfile: devProfile('firefox-profile'),
   },
 
   vite: () => ({


### PR DESCRIPTION
`REWRITE-PLAN.md` §12 step 10 (SPEC §4). Pick a container, and its interactive descendants become rows. The container itself never does — you're modelling what's *inside* the section you chose.

## What counts as interactive

The four buckets of SPEC §11 — actionable, text, toggle, select — so anything a scan collects is something the generator can write methods for. **`static` is deliberately excluded**, or scanning a page would return every heading, paragraph and image on it. Those go in one at a time with Add.

## The rule can't be role-only

The E2E caught this on its first run: scanning `login.html`'s form silently omitted the **password field**. Per HTML-AAM, `input[type=password]` maps to **no ARIA role at all** — so a role-only rule skips it, and a scan of a login form that misses the password is plainly broken.

The date/time family, colour and file pickers are in the same position. `type=hidden` stays excluded — never rendered, never interactive.

## Details worth knowing

- **`modelHiddenElements` is honoured**, passed in the `START_PICKING` message rather than read in the page — the panel already has it, and a content script reading storage would need its own access level.
- **A scan's haul travels as one `ELEMENTS_PICKED`**, not N messages, so the background adds it in a single model update and the table doesn't animate in row by row.
- **Single picks and scans share one path**, so both name and rank identically. `usedNames` is derived from the model and recomputed per element — otherwise a scan of ten "Delete" buttons would name them all the same.

## This is why ancestor navigation came first

Writing the test proved the sequencing argument: `page.locator('form').click()` lands on a child input, and scanning *that* collects nothing. The test walks up with the arrow keys, exactly as a user has to. Scanning a container with a mouse alone would have been miserable.

## Hand-test

Scan a `<form>` or a nav region. Check the container itself isn't added, that Scan greys out afterwards (once per model), and that a password field appears. Then turn on **Model hidden elements** in Options and scan something with a hidden control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)