### PR TITLE
v3: generate Selenium WebDriver Java

### DIFF
--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -355,7 +355,9 @@ before starting the next.
 10. **Scan** (SPEC §4). ✅ **Done** — container pick, interactive descendants, a11y-tree filtered,
     honouring `modelHiddenElements`. Awaiting hand-test.
 
-11. **Generate Code** (SPEC §11). Selenium Java first — the reference template — with the six fixes.
+11. **Generate Code** (SPEC §11). ✅ **Selenium Java done** — the reference template, with the six
+    fixes. `src/generators/classify.ts` maps role to bucket and is shared by every generator to come;
+    `ui/CodeDialog.vue` is the read-only view with Copy. Awaiting hand-test.
 
 12. **Playwright** (SPEC §12). Structured locators, ancestor scoping, `exact: true`. The primary target
     going forward, so it gets its own step rather than riding along with the other generators.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -305,10 +305,11 @@ Classification is by **computed a11y role**, not `tagName`. Five buckets: **[set
 |---|---|---|
 | **actionable** | button, link, menuitem, tab, option | `click{Name}()` |
 | **text** | textbox, searchbox, spinbutton | `get{Name}()` · `set{Name}(String)` |
-| **toggle** | checkbox, radio, switch | `get{Name}(): boolean` · `set{Name}(boolean)` |
+| **toggle** | checkbox, switch | `is{Name}Checked()` · `set{Name}(boolean)` |
 | **select (single)** | combobox | `get{Name}Select()` · `get{Name}Text()` · `get{Name}Value()` · `set{Name}ByValue()` · `set{Name}ByText()` |
 | **select (multi)** | listbox | `get{Name}Select()` · `get{Name}Texts()` · `get{Name}Values()` · `set{Name}ByValues(...)` · `set{Name}ByTexts(...)` · `deselectAll{Name}()` |
-| **static** | everything else | `get{Name}()` → text |
+| **radio** | radio | `is{Name}Selected()` · `select{Name}()` |
+| **static** | everything else | `get{Name}()` → text, or `get{Name}AltText()` for an image |
 
 Every element also gets a banner comment and `get{Name}Element()`.
 
@@ -324,7 +325,9 @@ Every element also gets a banner comment and `get{Name}Element()`.
 4. **`img` is static, not clickable.** It was in both `isClickable` and `isInteractive`, so images got
    `click{Name}()` and no text accessor. The accessor must read **`alt`** (or the accessible name) —
    `getText()` returns an empty string for an image.
-5. **Radio `set(false)` was a no-op.** Clicking a checked radio does not uncheck it.
+5. **Radio `set(false)` was a no-op.** Clicking a checked radio does not uncheck it, so a radio gets
+   `is{Name}Selected()` and `select{Name}()` — selecting is the only verb that means anything — rather
+   than a `set{Name}(boolean)` half of which silently did nothing.
 
 6. **Multi-selects were silently wrong.** On a `<select multiple>`, `selectByValue()` *adds* to the
    selection rather than replacing it, so the generated `set{Name}ByValue()` left prior selections in

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -363,7 +363,12 @@ Also: the templates emit a stray leading space on every line.
 
 ### Locator lists per framework
 
-Selenium Java / C# / Python: `id, linkText, partialLinkText, name, css, xpath, className, tagName`.
+Selenium Java / C# / Python: `name, id, linkText, partialLinkText, css, xpath, className, tagName`.
+
+**`name` ahead of `id`, unlike v2.5.1.** A name is semantic and submitted with the form, so frameworks
+almost never generate one; ids they generate constantly — React's `useId` gave Facebook's password field
+`id="_r_6_"` alongside `name="pass"`. Only form controls have a name, so everywhere else `id` still wins,
+and a shared name (a radio group) is never chosen because a candidate must resolve uniquely (§7).
 Puppeteer: `css, xpath`. Robot Framework and Protractor are dropped.
 
 Playwright: `testId, role, label, placeholder, text, altText, title, css, xpath` **[inferred]** — the
@@ -478,7 +483,7 @@ alone rather than becoming `SubmitButtonButton`. Read per pick, so the setting t
 name anyone would choose, and it changes on the next build of the site under test. Detected by known
 CSS-in-JS shapes (emotion, styled-components, CSS Modules, leading-underscore hashes, React `useId`) and
 by a run of four or more consonants, which real words and abbreviations — `btn`, `nav`, `col` — stay
-under. Deliberately conservative in the cheap direction: a false positive only falls through to the next
+under. React's `useId` is covered in both its forms: `:r6:` / `«r6»` from React 18, `_r_6_` from 19. Deliberately conservative in the cheap direction: a false positive only falls through to the next
 rule, while a false negative ships a name that rots. **[settled]**
 
 De-dupe by counter: a second `About` becomes `About2`.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -304,7 +304,7 @@ Classification is by **computed a11y role**, not `tagName`. Five buckets: **[set
 | Bucket | Roles | Methods (Selenium Java shown) |
 |---|---|---|
 | **actionable** | button, link, menuitem, tab, option | `click{Name}()` |
-| **text** | textbox, searchbox, spinbutton | `get{Name}()` · `set{Name}(String)` |
+| **text** | textbox, searchbox, spinbutton | `get{Name}()` · `set{Name}(String)` · `set{Name}(String, boolean clearFirst)` |
 | **toggle** | checkbox, switch | `is{Name}Checked()` · `set{Name}(boolean)` |
 | **select (single)** | combobox | `get{Name}Select()` · `get{Name}Text()` · `get{Name}Value()` · `set{Name}ByValue()` · `set{Name}ByText()` |
 | **select (multi)** | listbox | `get{Name}Select()` · `get{Name}Texts()` · `get{Name}Values()` · `set{Name}ByValues(...)` · `set{Name}ByTexts(...)` · `deselectAll{Name}()` |
@@ -321,7 +321,10 @@ Every element also gets a banner comment and `get{Name}Element()`.
    `<a>` with no `href` was treated as a link when it has no link role.
 2. **`getDomProperty("value")`, not `getAttribute("value")`.** The attribute is the *initial* value; it
    does not change as the user types. Selenium 4.5+ exposes the live DOM property.
-3. **`clear()` before `sendKeys()`.** The setter appended to existing content.
+3. **`clear()` before `sendKeys()`.** The setter appended to existing content. Clearing is the default,
+   not the only option: `set{Name}(value)` clears, `set{Name}(value, clearFirst)` does not have to.
+   Swapping one hard-coded behaviour for the other would just be a different wrong default. Languages
+   with default arguments express this as one method; Java needs the overload.
 4. **`img` is static, not clickable.** It was in both `isClickable` and `isInteractive`, so images got
    `click{Name}()` and no text accessor. The accessor must read **`alt`** (or the accessible name) —
    `getText()` returns an empty string for an image.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -365,10 +365,11 @@ Also: the templates emit a stray leading space on every line.
 
 Selenium Java / C# / Python: `name, id, linkText, partialLinkText, css, xpath, className, tagName`.
 
-**`name` ahead of `id`, unlike v2.5.1.** A name is semantic and submitted with the form, so frameworks
-almost never generate one; ids they generate constantly — React's `useId` gave Facebook's password field
-`id="_r_6_"` alongside `name="pass"`. Only form controls have a name, so everywhere else `id` still wins,
-and a shared name (a radio group) is never chosen because a candidate must resolve uniquely (§7).
+**`name` ahead of `id`, unlike v2.5.1.** A name is author-chosen and essentially never
+framework-generated; ids are generated constantly — React's `useId` gave Facebook's password field
+`id="_r_6_"` alongside `name="pass"`. It is not only form controls that carry one — `<a>`, `<iframe>`,
+`<map>` and `<object>` do too — but wherever it exists it was written by hand, which is the point. A
+shared name (a radio group) is never chosen, because a candidate must resolve uniquely (§7).
 Puppeteer: `css, xpath`. Robot Framework and Protractor are dropped.
 
 Playwright: `testId, role, label, placeholder, text, altText, title, css, xpath` **[inferred]** — the

--- a/v3/README.md
+++ b/v3/README.md
@@ -122,7 +122,7 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
 17. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the
-engine was validated on — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a
+engine was validated on — each links to the others, so you can move between them while testing — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a
 mismatch there is a real signal. Optional; the fidelity spec covers them automatically. They're bare
 markup, so the failures that matter — overlays, sticky headers, shadow roots, frames — only show up on
 real sites.

--- a/v3/README.md
+++ b/v3/README.md
@@ -12,6 +12,8 @@ the stack validated in the feasibility study (WXT + Vue 3 + Quasar + TypeScript,
 - **Inspector overlay** (`entrypoints/content/`) — highlight + click to pick; runs in all frames.
 - **Panel UI** (`ui/`) — Quasar: `AppToolbar` (SPEC §3) over `ModelTable` (SPEC §6). One app, three
   surfaces. Shell only so far — capture, generation and the dialogs are the next increments.
+- **Generators** (`src/generators/`) — `classify.ts` maps role to method bucket; `selenium-java.ts` is
+  the reference template (SPEC §11).
 - **Frameworks** (`src/frameworks.ts`) — the targets and the locator types each can express (SPEC §7).
 - **Settings** (`src/settings.ts`, `ui/OptionsPage.vue`) — `storage.sync`, read live by every surface
   (SPEC §14).
@@ -114,7 +116,10 @@ Automated tests are a net; this is the gate. Per increment, on **both** browsers
    switch to B, add something different, switch back — A must be intact.
 15. **Navigate within a tab** with a model built: a banner names the page it was built on and offers
     Delete Model. Navigate back and the banner clears.
-16. Table headers stay visible at the narrowest side-panel width.
+16. **Generate Code** with Selenium WebDriver Java selected: the dialog is titled with the framework,
+    the code is read-only and scrolls, and Copy puts it on the clipboard. Any other target says it is
+    not generated yet rather than showing an empty dialog.
+17. Table headers stay visible at the narrowest side-panel width.
 
 `npm run fixtures` serves `tests/fixtures/` over http if you want to pick against the four pages the
 engine was validated on — expected locators are tabulated in `docs/v3/spikes/SPIKE-RESULTS.md`, so a

--- a/v3/src/engine/candidates.ts
+++ b/v3/src/engine/candidates.ts
@@ -303,5 +303,13 @@ export function generate(el: Element): ElementResult {
 
   const preferredIndex = candidates.findIndex((c) => c.predictedCount === 1);
 
-  return { tag, role, accessibleName: name || null, suggestedName: baseName(el), candidates, preferredIndex };
+  return {
+    tag,
+    role,
+    accessibleName: name || null,
+    suggestedName: baseName(el),
+    inputType: tag === 'input' ? (el as HTMLInputElement).type : undefined,
+    candidates,
+    preferredIndex,
+  };
 }

--- a/v3/src/engine/naming.ts
+++ b/v3/src/engine/naming.ts
@@ -48,8 +48,9 @@ export function looksGenerated(value: string): boolean {
   if (/^(css|sc|emotion)-[a-z0-9]+$/i.test(value)) return true;
   if (/__[A-Za-z0-9]{4,}$/.test(value)) return true;
   if (/^_+[A-Za-z0-9]{4,}$/.test(value)) return true;
-  // React's useId: ":r1:", "«r1»".
+  // React's useId: ":r1:" and "«r1»" from React 18, "_r_6_" from React 19.
   if (/^[:«][a-z0-9]+[:»]$/i.test(value)) return true;
+  if (/^_r_[a-z0-9]+_$/i.test(value)) return true;
   // No pronounceable structure: a run of 4+ letters without a vowel. Real
   // words and abbreviations ("btn", "nav", "col") stay under that bar.
   return /[^aeiouy\W\d]{4,}/i.test(value);

--- a/v3/src/engine/types.ts
+++ b/v3/src/engine/types.ts
@@ -36,6 +36,12 @@ export interface ElementResult {
   accessibleName: string | null;
   /** Name derived in the page, before de-duplication (see naming.ts). */
   suggestedName: string;
+  /**
+   * `input`'s type, when it is one. Needed because several input types have no
+   * ARIA role at all — `password` most notably — so role alone would classify
+   * a field you type into as static (SPEC §11).
+   */
+  inputType?: string;
   candidates: RankedCandidate[];
   /** Index of the first predicted-unique candidate, or -1 if none. */
   preferredIndex: number;

--- a/v3/src/frameworks.ts
+++ b/v3/src/frameworks.ts
@@ -18,12 +18,17 @@ const PLAYWRIGHT_TYPES = ['testId', 'role', 'label', 'placeholder', 'text', 'alt
 
 // Selenium's native By strategies, in order of preference.
 //
-// `name` ahead of `id`, unlike v2.5.1. A name is semantic and submitted with
-// the form, so frameworks almost never generate one, while they generate ids
-// constantly — React's useId gave Facebook's password field `id="_r_6_"` and
-// `name="pass"`. Only form controls have a name at all, so everywhere else this
-// changes nothing and `id` still wins. Safe even for a radio group, whose
-// members share a name: a candidate is only chosen when it resolves uniquely.
+// `name` ahead of `id`, unlike v2.5.1. A name is author-chosen and essentially
+// never framework-generated, while ids are generated constantly — React's useId
+// gave Facebook's password field `id="_r_6_"` alongside `name="pass"`.
+//
+// It is not only form controls: `<a>`, `<iframe>`, `<map>` and `<object>` carry
+// a name too. That is fine — wherever it exists it was written by hand, which
+// is the whole point. A legacy `<a name="top">` is usually an anchor target
+// with no text, so it has no linkText to lose to.
+//
+// Safe even for a radio group, whose members share a name: a candidate is only
+// chosen when it resolves uniquely (SPEC §7).
 const SELENIUM_TYPES = ['name', 'id', 'linkText', 'partialLinkText', 'css', 'xpath', 'className', 'tagName'] as const;
 
 export const frameworks: readonly Framework[] = [

--- a/v3/src/frameworks.ts
+++ b/v3/src/frameworks.ts
@@ -16,8 +16,15 @@ export interface Framework {
 // Playwright's own ordering, testId first as the most change-resistant.
 const PLAYWRIGHT_TYPES = ['testId', 'role', 'label', 'placeholder', 'text', 'altText', 'title', 'css', 'xpath'] as const;
 
-// Selenium's native By strategies.
-const SELENIUM_TYPES = ['id', 'linkText', 'partialLinkText', 'name', 'css', 'xpath', 'className', 'tagName'] as const;
+// Selenium's native By strategies, in order of preference.
+//
+// `name` ahead of `id`, unlike v2.5.1. A name is semantic and submitted with
+// the form, so frameworks almost never generate one, while they generate ids
+// constantly — React's useId gave Facebook's password field `id="_r_6_"` and
+// `name="pass"`. Only form controls have a name at all, so everywhere else this
+// changes nothing and `id` still wins. Safe even for a radio group, whose
+// members share a name: a candidate is only chosen when it resolves uniquely.
+const SELENIUM_TYPES = ['name', 'id', 'linkText', 'partialLinkText', 'css', 'xpath', 'className', 'tagName'] as const;
 
 export const frameworks: readonly Framework[] = [
   { id: 'playwright-ts', label: 'Playwright (TypeScript)', locatorTypes: PLAYWRIGHT_TYPES },

--- a/v3/src/generators/classify.ts
+++ b/v3/src/generators/classify.ts
@@ -1,0 +1,44 @@
+// Which methods an element gets (SPEC §11).
+//
+// Keyed on the computed a11y role, never on tagName. v2.5.1 keyed on tags, so
+// `<div role="button">` — ubiquitous now — got no click() at all and fell
+// through to getText().
+import type { ModelElement } from '../model';
+
+export type Bucket = 'actionable' | 'text' | 'toggle' | 'radio' | 'select' | 'multiSelect' | 'static';
+
+const ACTIONABLE = new Set(['button', 'link', 'menuitem', 'menuitemcheckbox', 'menuitemradio', 'tab', 'option', 'treeitem']);
+const TEXT = new Set(['textbox', 'searchbox', 'spinbutton', 'slider']);
+const TOGGLE = new Set(['checkbox', 'switch']);
+
+/**
+ * `input[type=password]` and friends have no ARIA role at all, so a role-only
+ * classifier would call them static and generate a getText() for a field you
+ * type into. Scan already has to know this (SPEC §4); so does the generator.
+ */
+const ROLELESS_TEXT_INPUTS = new Set(['password', 'email', 'tel', 'url', 'search', 'number', 'date', 'datetime-local', 'month', 'time', 'week']);
+
+export function classify(el: Pick<ModelElement, 'role' | 'tag'> & { inputType?: string }): Bucket {
+  const { role, tag } = el;
+
+  if (role === 'radio') return 'radio';
+  if (role && TOGGLE.has(role)) return 'toggle';
+  if (role && ACTIONABLE.has(role)) return 'actionable';
+  if (role && TEXT.has(role)) return 'text';
+
+  // Selenium's Select and Playwright's selectOption both require a real
+  // <select>; `new Select(div)` throws UnexpectedTagNameException. A custom
+  // combobox built from divs is something you click open instead (SPEC §11).
+  if (role === 'combobox') return tag === 'select' ? 'select' : 'actionable';
+  if (role === 'listbox') return tag === 'select' ? 'multiSelect' : 'actionable';
+
+  if (tag === 'input' && el.inputType && ROLELESS_TEXT_INPUTS.has(el.inputType)) return 'text';
+  if (tag === 'input' && (el.inputType === 'file' || el.inputType === 'color')) return 'text';
+
+  return 'static';
+}
+
+/** Static elements are read for assertions; an image has no text, only alt. */
+export function isImage(el: Pick<ModelElement, 'role' | 'tag'>): boolean {
+  return el.role === 'img' || el.tag === 'img';
+}

--- a/v3/src/generators/index.ts
+++ b/v3/src/generators/index.ts
@@ -1,0 +1,24 @@
+// Framework → generated source (SPEC §11).
+//
+// Only Selenium Java so far — the reference template. The others are additive:
+// one file each, all consuming the same model.
+import { frameworkById } from '../frameworks';
+import type { TabModel } from '../model';
+import { generateSeleniumJava } from './selenium-java';
+
+type Generator = (model: TabModel) => string;
+
+const GENERATORS: Record<string, Generator> = {
+  'selenium-java': generateSeleniumJava,
+};
+
+export function canGenerate(frameworkId: string): boolean {
+  return frameworkId in GENERATORS;
+}
+
+export function generateCode(model: TabModel): string {
+  const generate = GENERATORS[model.frameworkId];
+  if (generate) return generate(model);
+  // Better to say which target is missing than to show an empty dialog.
+  return `// ${frameworkById(model.frameworkId).label} is not generated yet.\n// Selenium WebDriver Java is the only target so far.`;
+}

--- a/v3/src/generators/selenium-java.ts
+++ b/v3/src/generators/selenium-java.ts
@@ -1,0 +1,120 @@
+// Selenium WebDriver Java — the reference template (SPEC §11).
+//
+// Methods only, no wrapper class: `driver` is assumed to be in scope, as in
+// v2.5.1. The page-object wrapper is a later opt-in (SPEC §17).
+import { activeCandidate, type ModelElement, type TabModel } from '../model';
+import type { LocatorCandidate } from '../engine/types';
+import { classify, isImage } from './classify';
+
+/** Java string literal: only `\` and `"` need escaping for our values. */
+const q = (value: string) => `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+function by(c: LocatorCandidate): string {
+  switch (c.kind) {
+    case 'id':
+      return `By.id(${q(c.value)})`;
+    case 'name':
+      return `By.name(${q(c.value)})`;
+    case 'className':
+      return `By.className(${q(c.value)})`;
+    case 'tagName':
+      return `By.tagName(${q(c.value)})`;
+    case 'linkText':
+      return `By.linkText(${q(c.text)})`;
+    case 'partialLinkText':
+      return `By.partialLinkText(${q(c.text)})`;
+    case 'css':
+      return `By.cssSelector(${q(c.value)})`;
+    case 'xpath':
+      return `By.xpath(${q(c.value)})`;
+    default:
+      // Selection only ever picks a type the framework can express (SPEC §7),
+      // so this is unreachable — but say so rather than emitting nothing.
+      return `/* ${c.kind} is not expressible in Selenium */`;
+  }
+}
+
+function banner(name: string): string {
+  return `/*\n * ${name}\n * ***************************************************************\n */`;
+}
+
+function methods(el: ModelElement): string[] {
+  const n = el.name;
+  const out: string[] = [
+    `public WebElement get${n}Element() {\n    return driver.findElement(${by(activeCandidate(el))});\n}`,
+  ];
+
+  switch (classify(el)) {
+    case 'actionable':
+      out.push(`public void click${n}() {\n    get${n}Element().click();\n}`);
+      break;
+
+    case 'text':
+      out.push(
+        // getDomProperty, not getAttribute: the attribute is the INITIAL value
+        // and does not change as the user types (Selenium 4.5+).
+        `public String get${n}() {\n    return get${n}Element().getDomProperty("value");\n}`,
+        // clear() first, or the setter appends to what is already there.
+        `public void set${n}(String value) {\n    WebElement el = get${n}Element();\n    el.clear();\n    el.sendKeys(value);\n}`
+      );
+      break;
+
+    case 'toggle':
+      out.push(
+        `public boolean is${n}Checked() {\n    return get${n}Element().isSelected();\n}`,
+        `public void set${n}(boolean checked) {\n    WebElement el = get${n}Element();\n    if (el.isSelected() != checked) {\n        el.click();\n    }\n}`
+      );
+      break;
+
+    case 'radio':
+      // No set(false): clicking a checked radio does not uncheck it, so
+      // v2.5.1's setter silently did nothing. Selecting is the only real verb.
+      out.push(
+        `public boolean is${n}Selected() {\n    return get${n}Element().isSelected();\n}`,
+        `public void select${n}() {\n    WebElement el = get${n}Element();\n    if (!el.isSelected()) {\n        el.click();\n    }\n}`
+      );
+      break;
+
+    case 'select':
+      out.push(
+        `public Select get${n}Select() {\n    return new Select(get${n}Element());\n}`,
+        `public String get${n}Text() {\n    return get${n}Select().getFirstSelectedOption().getText();\n}`,
+        `public String get${n}Value() {\n    return get${n}Select().getFirstSelectedOption().getDomProperty("value");\n}`,
+        `public void set${n}ByValue(String value) {\n    get${n}Select().selectByValue(value);\n}`,
+        `public void set${n}ByText(String text) {\n    get${n}Select().selectByVisibleText(text);\n}`
+      );
+      break;
+
+    case 'multiSelect':
+      out.push(
+        `public Select get${n}Select() {\n    return new Select(get${n}Element());\n}`,
+        // getAllSelectedOptions, not getFirstSelectedOption: the first of N is
+        // not the answer to "what is selected".
+        `public List<String> get${n}Texts() {\n    return get${n}Select().getAllSelectedOptions().stream()\n        .map(WebElement::getText)\n        .collect(Collectors.toList());\n}`,
+        `public List<String> get${n}Values() {\n    return get${n}Select().getAllSelectedOptions().stream()\n        .map(o -> o.getDomProperty("value"))\n        .collect(Collectors.toList());\n}`,
+        // deselectAll first, or selectByValue ADDS to the selection and `set`
+        // does not mean set.
+        `public void set${n}ByValues(String... values) {\n    Select el = get${n}Select();\n    el.deselectAll();\n    for (String value : values) {\n        el.selectByValue(value);\n    }\n}`,
+        `public void set${n}ByTexts(String... texts) {\n    Select el = get${n}Select();\n    el.deselectAll();\n    for (String text : texts) {\n        el.selectByVisibleText(text);\n    }\n}`,
+        // Only for a multi-select: deselectAll throws
+        // UnsupportedOperationException on a single one.
+        `public void deselectAll${n}() {\n    get${n}Select().deselectAll();\n}`
+      );
+      break;
+
+    case 'static':
+      out.push(
+        isImage(el)
+          ? // getText() on an <img> returns an empty string; alt is the text.
+            `public String get${n}AltText() {\n    return get${n}Element().getDomAttribute("alt");\n}`
+          : `public String get${n}() {\n    return get${n}Element().getText();\n}`
+      );
+      break;
+  }
+
+  return out;
+}
+
+export function generateSeleniumJava(model: TabModel): string {
+  return model.elements.map((el) => [banner(el.name), ...methods(el)].join('\n\n')).join('\n\n');
+}

--- a/v3/src/generators/selenium-java.ts
+++ b/v3/src/generators/selenium-java.ts
@@ -54,8 +54,12 @@ function methods(el: ModelElement): string[] {
         // getDomProperty, not getAttribute: the attribute is the INITIAL value
         // and does not change as the user types (Selenium 4.5+).
         `public String get${n}() {\n    return get${n}Element().getDomProperty("value");\n}`,
-        // clear() first, or the setter appends to what is already there.
-        `public void set${n}(String value) {\n    WebElement el = get${n}Element();\n    el.clear();\n    el.sendKeys(value);\n}`
+        // Clearing is the default, because v2.5.1's setter appended and almost
+        // nobody wanted that. An overload keeps appending available rather than
+        // trading one hard-coded behaviour for the other — Java has no default
+        // arguments, so it is two methods.
+        `public void set${n}(String value) {\n    set${n}(value, true);\n}`,
+        `public void set${n}(String value, boolean clearFirst) {\n    WebElement el = get${n}Element();\n    if (clearFirst) {\n        el.clear();\n    }\n    el.sendKeys(value);\n}`
       );
       break;
 

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -118,9 +118,14 @@ test('highlighting reports its count as a message, and Close clears it', async (
       .map((m) => m.count))
     .toEqual([1]);
 
-  // A locator matching several elements highlights all of them.
-  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'HIGHLIGHT', candidate: { kind: 'css', value: 'a' } }), tabId);
-  await expect(marks).toHaveCount(3);
+  // A locator matching several elements highlights all of them. Scoped to the
+  // fixture's own markup: a bare `a` also catches the fixture navigation, and
+  // the count would then move whenever a fixture gains a link.
+  await sw.evaluate(
+    (id) => chrome.tabs.sendMessage(id, { type: 'HIGHLIGHT', candidate: { kind: 'css', value: 'header a' } }),
+    tabId
+  );
+  await expect(marks).toHaveCount(2);
 
   // Close dismisses the highlight, not just the message.
   await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'CLEAR_HIGHLIGHT' }), tabId);

--- a/v3/tests/fixtures/ambiguous.html
+++ b/v3/tests/fixtures/ambiguous.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head><meta charset="utf-8"><title>Ambiguous</title></head>
 <body>
+  <!-- Fixture navigation, for hand-testing. Deliberately outside <main>
+       so it does not change the breadcrumb of anything inside it, and
+       labelled with filenames so no link text can collide with a tagged
+       element's accessible name. -->
+  <nav aria-label="Fixtures" style="font: 12px/1.6 ui-monospace, monospace; padding: 6px 8px; border-bottom: 1px solid #ddd; margin-bottom: 12px">
+    fixtures: <a href="login.html">login</a> · <a href="widgets.html">widgets</a> · <a href="edgecases.html">edgecases</a> · <strong>ambiguous</strong>
+  </nav>
   <main>
     <!-- Two buttons with the SAME accessible name: role+name is NOT unique here.
          A good engine must detect this and fall back to a unique strategy. -->

--- a/v3/tests/fixtures/edgecases.html
+++ b/v3/tests/fixtures/edgecases.html
@@ -11,6 +11,13 @@
   </style>
 </head>
 <body>
+  <!-- Fixture navigation, for hand-testing. Deliberately outside <main>
+       so it does not change the breadcrumb of anything inside it, and
+       labelled with filenames so no link text can collide with a tagged
+       element's accessible name. -->
+  <nav aria-label="Fixtures" style="font: 12px/1.6 ui-monospace, monospace; padding: 6px 8px; border-bottom: 1px solid #ddd; margin-bottom: 12px">
+    fixtures: <a href="login.html">login</a> · <a href="widgets.html">widgets</a> · <strong>edgecases</strong> · <a href="ambiguous.html">ambiguous</a>
+  </nav>
   <main>
     <!-- 1. aria-label overrides emoji/content -->
     <button aria-label="Save document" data-spike="aria-label-btn">💾</button>

--- a/v3/tests/fixtures/login.html
+++ b/v3/tests/fixtures/login.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head><meta charset="utf-8"><title>Login</title></head>
 <body>
+  <!-- Fixture navigation, for hand-testing. Deliberately outside <main>
+       so it does not change the breadcrumb of anything inside it, and
+       labelled with filenames so no link text can collide with a tagged
+       element's accessible name. -->
+  <nav aria-label="Fixtures" style="font: 12px/1.6 ui-monospace, monospace; padding: 6px 8px; border-bottom: 1px solid #ddd; margin-bottom: 12px">
+    fixtures: <strong>login</strong> · <a href="widgets.html">widgets</a> · <a href="edgecases.html">edgecases</a> · <a href="ambiguous.html">ambiguous</a>
+  </nav>
   <header>
     <nav aria-label="Primary">
       <a href="/" data-spike="nav-home">Home</a>

--- a/v3/tests/fixtures/widgets.html
+++ b/v3/tests/fixtures/widgets.html
@@ -2,6 +2,13 @@
 <html lang="en">
 <head><meta charset="utf-8"><title>Widgets</title></head>
 <body>
+  <!-- Fixture navigation, for hand-testing. Deliberately outside <main>
+       so it does not change the breadcrumb of anything inside it, and
+       labelled with filenames so no link text can collide with a tagged
+       element's accessible name. -->
+  <nav aria-label="Fixtures" style="font: 12px/1.6 ui-monospace, monospace; padding: 6px 8px; border-bottom: 1px solid #ddd; margin-bottom: 12px">
+    fixtures: <a href="login.html">login</a> · <strong>widgets</strong> · <a href="edgecases.html">edgecases</a> · <a href="ambiguous.html">ambiguous</a>
+  </nav>
   <main>
     <h2 data-spike="section-heading">Account settings</h2>
 

--- a/v3/tests/unit/CodeDialog.test.ts
+++ b/v3/tests/unit/CodeDialog.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import { Quasar, QBtn, QDialog, QCard, QCardSection, QCardActions, QToolbar, QToolbarTitle } from 'quasar';
+import CodeDialog from '../../ui/CodeDialog.vue';
+import { emptyModel, type ModelElement, type TabModel } from '../../src/model';
+
+function modelWith(frameworkId: string, ...elements: Array<Partial<ModelElement> & { name: string }>): TabModel {
+  const m = emptyModel(frameworkId);
+  m.elements = elements.map((el, i) => ({
+    id: `el-${i}`,
+    tag: 'input',
+    role: 'textbox',
+    accessibleName: el.name,
+    suggestedName: el.name,
+    selectedIndex: 0,
+    preferredIndex: 0,
+    candidates: [{ candidate: { kind: 'id', value: 'x' }, predictedCount: 1 }],
+    ...el,
+  })) as ModelElement[];
+  return m;
+}
+
+// QDialog teleports its content, so it is not in the DOM until a tick has
+// passed — and it stays there afterwards, so each test has to clear up or the
+// next one reads the last one's dialog.
+let wrapper: ReturnType<typeof mount> | undefined;
+
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = undefined;
+  document.body.innerHTML = '';
+});
+
+async function render(model: TabModel) {
+  wrapper = mount(CodeDialog, {
+    props: { model },
+    global: {
+      plugins: [Quasar],
+      components: { QBtn, QDialog, QCard, QCardSection, QCardActions, QToolbar, QToolbarTitle },
+    },
+    attachTo: document.body,
+  }) as ReturnType<typeof mount>;
+  await nextTick();
+  return wrapper;
+}
+
+const codeText = () => document.body.querySelector('[data-testid="code-output"]')?.textContent ?? '';
+
+describe('CodeDialog', () => {
+  it('is titled with the framework, as v2.5.1 was', async () => {
+    await render(modelWith('selenium-java', { name: 'Email' }));
+    expect(document.body.textContent).toContain('Selenium WebDriver Java');
+  });
+
+  it('shows the generated code for the model', async () => {
+    await render(modelWith('selenium-java', { name: 'Email' }));
+    expect(codeText()).toContain('public WebElement getEmailElement() {');
+    expect(codeText()).toContain('public void setEmail(String value) {');
+  });
+
+  it('says which target is missing rather than showing nothing', async () => {
+    // Only Selenium Java exists so far; an empty dialog would look broken.
+    await render(modelWith('playwright-ts', { name: 'Email' }));
+    expect(codeText()).toContain('Playwright (TypeScript) is not generated yet');
+  });
+
+  it('renders an empty model without failing', async () => {
+    await render(emptyModel('selenium-java'));
+    expect(codeText()).toBe('');
+  });
+});

--- a/v3/tests/unit/naming.test.ts
+++ b/v3/tests/unit/naming.test.ts
@@ -95,6 +95,8 @@ describe('build-generated identifiers', () => {
     ['leading underscore', '<div data-t class="_2xK9f"></div>'],
     ['no vowels', '<div data-t class="Xtvsq51"></div>'],
     ['hashed id', '<div data-t id="Xtvsq51"></div>'],
+    ['React 18 useId', '<div data-t id=":r6:"></div>'],
+    ['React 19 useId', '<div data-t id="_r_6_"></div>'],
   ] as const;
 
   for (const [label, html] of rejected) {

--- a/v3/tests/unit/select.test.ts
+++ b/v3/tests/unit/select.test.ts
@@ -45,6 +45,28 @@ describe('chooseCandidate', () => {
     expect(kindFor('selenium-python')).toBe('id');
   });
 
+  it('prefers name over id for a form control', () => {
+    // Facebook's password field: id="_r_6_" from React's useId, name="pass".
+    // A name is semantic and submitted with the form, so it is almost never
+    // generated; ids are generated constantly.
+    const field: RankedCandidate[] = [
+      { candidate: { kind: 'id', value: 'pass-field' }, predictedCount: 1 },
+      { candidate: { kind: 'name', value: 'pass' }, predictedCount: 1 },
+      { candidate: { kind: 'css', value: 'input[type=password]' }, predictedCount: 1 },
+    ];
+    expect(field[chooseCandidate(field, 'selenium-java')].candidate.kind).toBe('name');
+  });
+
+  it('falls back to id when a name is shared, as in a radio group', () => {
+    // Safe to prefer name precisely because a candidate is only chosen when it
+    // resolves uniquely.
+    const radio: RankedCandidate[] = [
+      { candidate: { kind: 'id', value: 'plan-pro' }, predictedCount: 1 },
+      { candidate: { kind: 'name', value: 'plan' }, predictedCount: 3 },
+    ];
+    expect(radio[chooseCandidate(radio, 'selenium-java')].candidate.kind).toBe('id');
+  });
+
   it('prefers a unique candidate over an earlier ambiguous one', () => {
     const ambiguous: RankedCandidate[] = [
       { candidate: { kind: 'id', value: 'dup' }, predictedCount: 3 },

--- a/v3/tests/unit/selenium-java.test.ts
+++ b/v3/tests/unit/selenium-java.test.ts
@@ -65,9 +65,14 @@ describe('generateSeleniumJava', () => {
       expect(out).not.toContain('getAttribute("value")');
     });
 
-    it('clears a text field before typing into it', () => {
+    it('clears a text field by default, and lets you not', () => {
+      // v2.5.1 always appended. Clearing is the right default, but an overload
+      // keeps appending available rather than swapping one fixed behaviour for
+      // the other.
       const out = gen({ name: 'Email', role: 'textbox', tag: 'input', candidate: { kind: 'id', value: 'e' } });
-      expect(out).toMatch(/el\.clear\(\);\s*\n\s*el\.sendKeys\(value\);/);
+      expect(out).toContain('public void setEmail(String value) {\n    setEmail(value, true);\n}');
+      expect(out).toContain('public void setEmail(String value, boolean clearFirst) {');
+      expect(out).toMatch(/if \(clearFirst\) \{\s*\n\s*el\.clear\(\);/);
     });
 
     it('treats an image as static, reading alt rather than text', () => {

--- a/v3/tests/unit/selenium-java.test.ts
+++ b/v3/tests/unit/selenium-java.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { generateSeleniumJava } from '../../src/generators/selenium-java';
+import { emptyModel, type ModelElement, type TabModel } from '../../src/model';
+import type { LocatorCandidate } from '../../src/engine/types';
+
+function model(...elements: Array<Partial<ModelElement> & { name: string; candidate: LocatorCandidate }>): TabModel {
+  const m = emptyModel('selenium-java');
+  m.elements = elements.map(({ candidate, ...el }, i) => ({
+    id: `el-${i}`,
+    tag: 'div',
+    role: null,
+    accessibleName: null,
+    suggestedName: el.name,
+    selectedIndex: 0,
+    preferredIndex: 0,
+    candidates: [{ candidate, predictedCount: 1 }],
+    ...el,
+  })) as ModelElement[];
+  return m;
+}
+
+const gen = (...args: Parameters<typeof model>) => generateSeleniumJava(model(...args));
+
+describe('generateSeleniumJava', () => {
+  it('emits a banner and an element getter for everything', () => {
+    const out = gen({ name: 'SignIn', role: 'button', tag: 'button', candidate: { kind: 'id', value: 'go' } });
+    expect(out).toContain('* SignIn');
+    expect(out).toContain('public WebElement getSignInElement() {');
+    expect(out).toContain('return driver.findElement(By.id("go"));');
+  });
+
+  it('maps every locator type to its By strategy', () => {
+    const cases: Array<[LocatorCandidate, string]> = [
+      [{ kind: 'id', value: 'a' }, 'By.id("a")'],
+      [{ kind: 'name', value: 'a' }, 'By.name("a")'],
+      [{ kind: 'className', value: 'a' }, 'By.className("a")'],
+      [{ kind: 'tagName', value: 'a' }, 'By.tagName("a")'],
+      [{ kind: 'linkText', text: 'a' }, 'By.linkText("a")'],
+      [{ kind: 'partialLinkText', text: 'a' }, 'By.partialLinkText("a")'],
+      [{ kind: 'css', value: 'a' }, 'By.cssSelector("a")'],
+      [{ kind: 'xpath', value: '//a' }, 'By.xpath("//a")'],
+    ];
+    for (const [candidate, expected] of cases) {
+      expect(gen({ name: 'X', candidate }), expected).toContain(expected);
+    }
+  });
+
+  it('escapes quotes and backslashes in a locator', () => {
+    expect(gen({ name: 'X', candidate: { kind: 'css', value: 'a[title="hi"]' } })).toContain(
+      'By.cssSelector("a[title=\\"hi\\"]")'
+    );
+  });
+
+  describe('the six fixes to v2.5.1', () => {
+    it('classifies on role, not tagName', () => {
+      // v2.5.1 keyed on tags, so <div role="button"> got no click() at all.
+      const out = gen({ name: 'LogIn', role: 'button', tag: 'div', candidate: { kind: 'css', value: 'div' } });
+      expect(out).toContain('public void clickLogIn() {');
+    });
+
+    it('reads a text field with getDomProperty, not getAttribute', () => {
+      // getAttribute returns the INITIAL value and never changes as you type.
+      const out = gen({ name: 'Email', role: 'textbox', tag: 'input', candidate: { kind: 'id', value: 'e' } });
+      expect(out).toContain('getDomProperty("value")');
+      expect(out).not.toContain('getAttribute("value")');
+    });
+
+    it('clears a text field before typing into it', () => {
+      const out = gen({ name: 'Email', role: 'textbox', tag: 'input', candidate: { kind: 'id', value: 'e' } });
+      expect(out).toMatch(/el\.clear\(\);\s*\n\s*el\.sendKeys\(value\);/);
+    });
+
+    it('treats an image as static, reading alt rather than text', () => {
+      // getText() on an <img> returns an empty string.
+      const out = gen({ name: 'Logo', role: 'img', tag: 'img', candidate: { kind: 'css', value: 'img' } });
+      expect(out).toContain('public String getLogoAltText() {');
+      expect(out).toContain('getDomAttribute("alt")');
+      expect(out).not.toContain('clickLogo');
+    });
+
+    it('gives a radio no set(false), which never worked', () => {
+      // Clicking a checked radio does not uncheck it.
+      const out = gen({ name: 'Pro', role: 'radio', tag: 'input', candidate: { kind: 'id', value: 'p' } });
+      expect(out).toContain('public void selectPro() {');
+      expect(out).toContain('public boolean isProSelected() {');
+      expect(out).not.toContain('setPro(boolean');
+    });
+
+    it('replaces rather than adds on a multi-select, and reads all of it', () => {
+      const out = gen({ name: 'Toppings', role: 'listbox', tag: 'select', candidate: { kind: 'id', value: 't' } });
+      expect(out).toContain('el.deselectAll();');
+      expect(out).toContain('public void setToppingsByValues(String... values) {');
+      expect(out).toContain('getAllSelectedOptions()');
+      expect(out).toContain('public void deselectAllToppings() {');
+      expect(out).not.toContain('getFirstSelectedOption');
+    });
+  });
+
+  it('gives a single select the first-selected accessors, and no deselectAll', () => {
+    // deselectAll throws UnsupportedOperationException on a single select.
+    const out = gen({ name: 'Country', role: 'combobox', tag: 'select', candidate: { kind: 'id', value: 'c' } });
+    expect(out).toContain('getFirstSelectedOption()');
+    expect(out).toContain('public void setCountryByValue(String value) {');
+    expect(out).not.toContain('deselectAll');
+  });
+
+  it('falls back to click for a combobox that is not a real <select>', () => {
+    // new Select(div) throws UnexpectedTagNameException.
+    const out = gen({ name: 'Country', role: 'combobox', tag: 'div', candidate: { kind: 'css', value: 'div' } });
+    expect(out).toContain('public void clickCountry() {');
+    expect(out).not.toContain('new Select');
+  });
+
+  it('treats a password field as text even though it has no role', () => {
+    // input[type=password] has no ARIA role, so role alone would call it static
+    // and generate a getText() for a field you type into.
+    const out = gen({ name: 'Password', role: null, tag: 'input', inputType: 'password', candidate: { kind: 'id', value: 'p' } });
+    expect(out).toContain('public void setPassword(String value) {');
+  });
+
+  it('reads a static element as text', () => {
+    const out = gen({ name: 'Welcome', role: 'heading', tag: 'h1', candidate: { kind: 'css', value: 'h1' } });
+    expect(out).toContain('public String getWelcome() {');
+    expect(out).toContain('.getText();');
+  });
+
+  it('separates elements, and emits nothing for an empty model', () => {
+    const out = gen(
+      { name: 'A', role: 'button', tag: 'button', candidate: { kind: 'id', value: 'a' } },
+      { name: 'B', role: 'link', tag: 'a', candidate: { kind: 'linkText', text: 'b' } }
+    );
+    expect(out).toContain('* A');
+    expect(out).toContain('* B');
+    expect(generateSeleniumJava(emptyModel('selenium-java'))).toBe('');
+  });
+});

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -11,7 +11,7 @@
         @scan="toggleScan"
         @add="toggleAdd"
         @delete-model="deleteModel"
-        @generate="notYet('Generate Code')"
+        @generate="showCode = true"
       />
     </q-header>
 
@@ -38,6 +38,8 @@
           @remove="removeElement"
         />
 
+        <CodeDialog v-if="showCode" :model="model" @close="showCode = false" />
+
         <EditElementDialog
           v-if="editing"
           :key="editing.id"
@@ -60,6 +62,7 @@ import { browser } from 'wxt/browser';
 import AppToolbar from './AppToolbar.vue';
 import ModelTable, { type ModelRow } from './ModelTable.vue';
 import EditElementDialog from './EditElementDialog.vue';
+import CodeDialog from './CodeDialog.vue';
 import { defaultFrameworkId } from '@/src/frameworks';
 import { displayLocator } from '@/src/locators/display';
 import { activeCandidate, emptyModel, type ModelElement, type TabModel } from '@/src/model';
@@ -86,6 +89,7 @@ const model = ref<TabModel>(emptyModel(defaultFrameworkId));
 const isScanning = ref(false);
 const isAdding = ref(false);
 const editing = ref<ModelElement | undefined>();
+const showCode = ref(false);
 
 const rows = computed<ModelRow[]>(() =>
   model.value.elements.map((el) => ({

--- a/v3/ui/CodeDialog.vue
+++ b/v3/ui/CodeDialog.vue
@@ -1,0 +1,75 @@
+<template>
+  <q-dialog v-model="open" @hide="$emit('close')">
+    <q-card class="code-card">
+      <q-toolbar class="dialog-header">
+        <q-toolbar-title class="text-subtitle1">{{ frameworkLabel }}</q-toolbar-title>
+        <q-btn flat dense no-caps icon="content_copy" label="Copy" data-testid="code-copy" @click="copy" />
+      </q-toolbar>
+
+      <q-card-section class="q-pa-none">
+        <!-- Read-only, as in v2.5.1: the model is edited in the table, not here. -->
+        <pre class="code" data-testid="code-output">{{ code }}</pre>
+      </q-card-section>
+
+      <q-card-actions align="right">
+        <q-btn v-close-popup flat no-caps label="OK" data-testid="code-ok" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useQuasar } from 'quasar';
+import { frameworkById } from '@/src/frameworks';
+import { generateCode } from '@/src/generators';
+import type { TabModel } from '@/src/model';
+
+const props = defineProps<{ model: TabModel }>();
+defineEmits<{ close: [] }>();
+
+const $q = useQuasar();
+const open = ref(true);
+
+const frameworkLabel = computed(() => frameworkById(props.model.frameworkId).label);
+const code = computed(() => generateCode(props.model));
+
+async function copy() {
+  try {
+    await navigator.clipboard.writeText(code.value);
+    $q.notify({ message: 'Copied to clipboard', icon: 'content_copy', timeout: 1200, position: 'bottom' });
+  } catch {
+    // A panel without clipboard permission, or a denied prompt. Say so rather
+    // than appearing to have copied.
+    $q.notify({ message: 'Could not copy — select the code and copy it', icon: 'block', color: 'negative', position: 'bottom' });
+  }
+}
+</script>
+
+<style scoped>
+.code-card {
+  width: 100%;
+  max-width: 900px;
+  background: var(--pm-page-bg);
+  color: var(--pm-text);
+}
+
+.dialog-header {
+  background: var(--pm-toolbar-bg);
+  color: var(--pm-toolbar-fg);
+  border-bottom: 1px solid var(--pm-rule);
+  min-height: 44px;
+}
+
+.code {
+  margin: 0;
+  padding: 16px;
+  /* The panel is narrow; long locators scroll rather than widening the dialog. */
+  max-height: 60vh;
+  overflow: auto;
+  font: 12px/1.6 ui-monospace, SFMono-Regular, monospace;
+  white-space: pre;
+  color: var(--pm-text);
+  user-select: text;
+}
+</style>


### PR DESCRIPTION
`REWRITE-PLAN.md` §12 step 11 (SPEC §11). The reference template: **methods only, no wrapper class**, `driver` assumed in scope, as v2.5.1 did. The tool finally produces something.

## The classifier is the shared part

`src/generators/classify.ts` maps role → method bucket and will be used by every generator, so Playwright can't drift from Selenium on what an element *is*.

It also has to know the **roleless input types**: `input[type=password]` has no ARIA role, so a role-only classifier would call a field you type into `static` and emit `getText()` for it. Scan learned this the hard way in #72; the generator needs it too.

## All six fixes, each with a test naming what v2.5.1 did

| Fix | v2.5.1 |
|---|---|
| Role, not `tagName` | `<div role="button">` got no `click()` at all |
| `getDomProperty("value")` | `getAttribute` returns the *initial* value, unchanged as you type |
| `clear()` before `sendKeys()` | appended to whatever was there |
| `img` is static, read via `alt` | it was "clickable"; `getText()` on an image returns `""` |
| Radio gets `isSelected`/`select` | `set(false)` could not work — clicking a checked radio doesn't uncheck it |
| Multi-select deselects first | `selectByValue` *adds*, and `getFirstSelectedOption` returned one of N |

Single selects keep `getFirstSelectedOption` and get **no** `deselectAll`, which throws `UnsupportedOperationException` on them. A `combobox` that isn't a real `<select>` falls back to `click` — `new Select(div)` throws `UnexpectedTagNameException`.

## On the testing level

The dialog is **component-tested** rather than driven through the panel in an E2E. A panel page opened as a tab has no `devtools` API, so it resolves no tab and never holds a model — I tried, and the Generate button is correctly disabled. The generator itself is pure and has 20 unit tests; the dialog is a thin wrapper over it.

Two things that bit while writing those tests, both now commented: Quasar dialogs teleport, so the content isn't in the DOM until a tick has passed; and `attachTo: document.body` leaves each dialog behind, so one test was reading the previous one's output.

## Hand-test

Select **Selenium WebDriver Java** before modelling (the framework locks once the model has anything in it), scan a form, then **Generate Code**. Other targets should say they're not generated yet rather than showing an empty dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)