### PR TITLE
v3: generate Playwright TypeScript, and output shapes

### DIFF
--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -359,8 +359,12 @@ before starting the next.
     fixes. `src/generators/classify.ts` maps role to bucket and is shared by every generator to come;
     `ui/CodeDialog.vue` is the read-only view with Copy. Awaiting hand-test.
 
-12. **Playwright** (SPEC §12). Structured locators, ancestor scoping, `exact: true`. The primary target
-    going forward, so it gets its own step rather than riding along with the other generators.
+12. **Playwright** (SPEC §12). ✅ **Generator done** — `src/generators/playwright-ts.ts`, sharing the
+    role classifier with Selenium so the two cannot disagree on what an element is. Awaiting hand-test.
+
+    **Ancestor scoping is still to do**, and is its own increment: it needs a chained candidate in the
+    IR and engine work to find and verify a scoping ancestor, not just a change of output. Until then an
+    ambiguous role+name falls back to css or xpath, which works but is not idiomatic.
 
 13. **Remaining generators** — Selenium C#/Python, Puppeteer, Playwright Python.
 

--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -366,9 +366,15 @@ before starting the next.
     IR and engine work to find and verify a scoping ancestor, not just a change of output. Until then an
     ambiguous role+name falls back to css or xpath, which works but is not idiomatic.
 
-13. **Remaining generators** — Selenium C#/Python, Puppeteer, Playwright Python.
+13. **Output shapes** (SPEC §11). ✅ **Done** — every framework offers "Locators only" alongside its
+    structured shape, chosen in the code dialog. Playwright's structured shape was reshaped to a page
+    object of constructor-assigned `readonly` fields; its per-element action wrappers are gone, because
+    a `Locator` is already the action API. Awaiting hand-test.
 
-14. **Frames** (SPEC §16) and the **page-object wrapper** (SPEC §17).
+14. **Remaining generators** — Selenium C#/Python, Puppeteer, Playwright Python. Each supplies both
+    shapes.
+
+15. **Frames** (SPEC §16) and the **page-object wrapper** (SPEC §17).
 
 **Considered, not scheduled — capture from the Elements tree.** `devtools.panels.elements
 .onSelectionChanged` plus `inspectedWindow.eval` with `$0` would let a button add whatever is selected

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -280,7 +280,36 @@ dialog.
 ## 11. Generate Code
 
 Read-only view of the generated code, titled with the framework, with a **copy to clipboard** button.
-Per element: a banner comment, a getter, and interaction methods keyed to what the element is. **[settled]**
+**[settled]**
+
+### Output shapes **[settled]**
+
+The same locators, arranged the way that framework's users arrange them. The dialog offers the shapes
+its framework has; the first is the default. Shape is a dialog-local choice — it does not touch the
+model.
+
+| Framework | Shapes |
+|---|---|
+| Selenium (all languages) | **Methods** (default) · Locators only |
+| Playwright (all languages) | **Page object** (default) · Locators only |
+| Puppeteer | **Locators only** |
+
+**Locators only** exists for every framework: locator declarations and nothing else, for the many teams
+with their own page-object conventions. Our locators, none of our opinions — and the one output still
+useful when the surrounding structure is wrong for them.
+
+```java
+private final By emailAddress = By.name("email");
+private final By signIn = By.id("go");
+```
+
+User-supplied templates are deliberately **not** offered. Two shapes cover the split that matters —
+take our structure, or take just the locators. **[settled]**
+
+### Selenium's Methods shape
+
+Per element: a banner comment, a getter, and interaction methods keyed to what the element is.
+**[settled]**
 
 ```java
 /*
@@ -424,35 +453,41 @@ undermines that afterwards: a later "About us" link turns a unique `About` locat
 one. `exact` still trims surrounding whitespace. A renamed element then fails loudly rather than
 drifting onto the wrong target.
 
-### Method bodies **[settled]**
+### Page object shape **[settled]**
 
-Not a substitution of the Selenium templates; the API differs enough to change shape.
+Not a translation of the Selenium template. `readonly` fields assigned in the constructor — the shape
+Playwright's own docs show.
 
-| Bucket | Playwright |
-|---|---|
-| element | `get{Name}Locator()` returns a lazy `Locator` — no staleness, no explicit waits |
-| actionable | `await get{Name}().click()` |
-| text | `fill(value)` — one call, replaces `clear()` + `sendKeys()`; read with `inputValue()` |
-| toggle | `check()` / `uncheck()` / `isChecked()` — real primitives, so no click-to-toggle dance |
-| select (single) | `selectOption(value)` |
-| select (multi) | `selectOption([...])` — one call, no `deselectAll` loop |
-| static | `textContent()` |
+```ts
+import { type Locator, type Page } from '@playwright/test';
 
-Two v2.5.1 bugs cannot occur here: `fill()` clears first by construction, and radio `set(false)` is
-expressible only as `uncheck()`, which Playwright rejects on a radio rather than silently doing nothing.
+export class LoginPage {
+  readonly emailAddress: Locator;
+  readonly signIn: Locator;
 
-All methods are `async`; TypeScript returns `Promise<...>`. Methods reference a bare `page`, mirroring
-how the Selenium templates reference a bare `driver` — the surrounding class supplies it.
+  constructor(private readonly page: Page) {
+    this.emailAddress = page.getByLabel('Email address', { exact: true });
+    this.signIn = page.getByRole('button', { name: 'Sign in', exact: true });
+  }
+}
+```
 
-The getter is `get{Name}Locator()`, not `get{Name}()`: a text field needs `get{Name}()` for its value,
-and a Locator is not an element, so borrowing Selenium's `get{Name}Element()` would be doubly wrong.
+**No per-element action wrappers.** A `Locator` is lazy, reusable and *is* the action API, so
+`clickSignIn()` wrapping `.click()` adds a name and nothing else — `loginPage.signIn.click()` reads
+better. Those wrappers earn their place in Selenium, where `findElement` returns something that goes
+stale; here they are ceremony, and they multiply per bucket into a wall of code nobody asked for.
 
-Three differences from Selenium worth naming, all because Playwright has a primitive where Selenium
-needs a sequence: `fill()` clears by construction; `check()`/`uncheck()` verify the resulting state
-rather than clicking and hoping; and `selectOption()` replaces the whole selection, so a multi-select
-needs no `deselectAll` step and cannot accidentally add to what was already chosen. Appending to a text
-field stays reachable via `pressSequentially`, as `clearFirst` does in Selenium — one method here, since
-TypeScript has default arguments.
+**No composite methods.** `login(email, password)` is the point of a page object and needs domain
+knowledge this tool does not have. The user adds those — the tool exists to shortcut the locators.
+
+Field names are the element name, lower-camel. Assignment reads the constructor **parameter** `page`,
+not `this.page`: the parameter property is not assigned until the constructor body completes.
+
+Class name comes from the last path segment of the model's URL — `/account/login.html` → `LoginPage`,
+`facebook.com` → `FacebookPage`, no URL → `GeneratedPage`. Rename it; the tool cannot know what you call
+the page. **[inferred]**
+
+No banner comments. Field names carry the same information in a fifth of the lines.
 
 ### Test IDs **[inferred]**
 
@@ -598,17 +633,15 @@ guaranteed-broken reference. Emit the actions only. **[settled]**
 
 Nested frames extend the chain — one `switchTo().frame()` per level, outermost first.
 
-## 17. Page-object wrapper
+## 17. Selenium page-object wrapper
 
-The code dialog carries a **Methods / Full page object** toggle that re-renders in place. One Generate
-Code button, both outputs visible without regenerating, toolbar unchanged. **[settled]**
+The shape selector is built (§11), and Playwright's default shape is already a full page object. What is
+left is a **third Selenium shape** — Methods · Page object · Locators only — wrapping the methods in a
+class declaration, imports, and a constructor taking the `driver` they currently reference bare.
+**[inferred]**
 
-Methods-only stays the default (§11). The wrapper adds the class declaration, imports, and a constructor
-taking the `page`/`driver` the methods already reference bare. **[inferred]**
-
-A wrapper needs a **class name**, which methods-only does not — so the field belongs in this mode and
-nowhere else. It is an editable field in the dialog, prefilled from the page title or URL path
-(`/checkout` → `CheckoutPage`): right most of the time, always overridable. **[inferred]**
+Class name is derived as it is for Playwright (§12). Making it an **editable field** in the dialog is
+the obvious next step and is not built. **[open]**
 
 ## 18. Still open
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -424,13 +424,13 @@ undermines that afterwards: a later "About us" link turns a unique `About` locat
 one. `exact` still trims surrounding whitespace. A renamed element then fails loudly rather than
 drifting onto the wrong target.
 
-### Method bodies **[inferred]**
+### Method bodies **[settled]**
 
 Not a substitution of the Selenium templates; the API differs enough to change shape.
 
 | Bucket | Playwright |
 |---|---|
-| element | `get{Name}()` returns a lazy `Locator` — no staleness, no explicit waits |
+| element | `get{Name}Locator()` returns a lazy `Locator` — no staleness, no explicit waits |
 | actionable | `await get{Name}().click()` |
 | text | `fill(value)` — one call, replaces `clear()` + `sendKeys()`; read with `inputValue()` |
 | toggle | `check()` / `uncheck()` / `isChecked()` — real primitives, so no click-to-toggle dance |
@@ -442,7 +442,17 @@ Two v2.5.1 bugs cannot occur here: `fill()` clears first by construction, and ra
 expressible only as `uncheck()`, which Playwright rejects on a radio rather than silently doing nothing.
 
 All methods are `async`; TypeScript returns `Promise<...>`. Methods reference a bare `page`, mirroring
-how the Selenium templates reference a bare `driver` — the surrounding class supplies it. **[inferred]**
+how the Selenium templates reference a bare `driver` — the surrounding class supplies it.
+
+The getter is `get{Name}Locator()`, not `get{Name}()`: a text field needs `get{Name}()` for its value,
+and a Locator is not an element, so borrowing Selenium's `get{Name}Element()` would be doubly wrong.
+
+Three differences from Selenium worth naming, all because Playwright has a primitive where Selenium
+needs a sequence: `fill()` clears by construction; `check()`/`uncheck()` verify the resulting state
+rather than clicking and hoping; and `selectOption()` replaces the whole selection, so a multi-select
+needs no `deselectAll` step and cannot accidentally add to what was already chosen. Appending to a text
+field stays reachable via `pressSequentially`, as `clearFirst` does in Selenium — one method here, since
+TypeScript has default arguments.
 
 ### Test IDs **[inferred]**
 

--- a/v3/README.md
+++ b/v3/README.md
@@ -13,7 +13,7 @@ the stack validated in the feasibility study (WXT + Vue 3 + Quasar + TypeScript,
 - **Panel UI** (`ui/`) — Quasar: `AppToolbar` (SPEC §3) over `ModelTable` (SPEC §6). One app, three
   surfaces. Shell only so far — capture, generation and the dialogs are the next increments.
 - **Generators** (`src/generators/`) — `classify.ts` maps role to method bucket; `selenium-java.ts` is
-  the reference template (SPEC §11).
+  the reference template (SPEC §11), `playwright-ts.ts` the primary target (SPEC §12).
 - **Frameworks** (`src/frameworks.ts`) — the targets and the locator types each can express (SPEC §7).
 - **Settings** (`src/settings.ts`, `ui/OptionsPage.vue`) — `storage.sync`, read live by every surface
   (SPEC §14).

--- a/v3/src/generators/class-name.ts
+++ b/v3/src/generators/class-name.ts
@@ -1,0 +1,33 @@
+// A name for the generated class (SPEC §17).
+//
+// Derived from the page the model was built on, because typing one is friction
+// and `GeneratedPage` is nobody's idea of a class name. The user can rename it
+// afterwards; being roughly right beats being blank.
+const FALLBACK = 'GeneratedPage';
+
+export function classNameFor(url: string | null): string {
+  if (!url) return FALLBACK;
+
+  let path: string;
+  try {
+    const parsed = new URL(url);
+    // The last meaningful path segment: /shop/checkout/ → checkout. Failing
+    // that the host, so example.com becomes ExampleComPage rather than nothing.
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    path = segments.at(-1) ?? parsed.hostname;
+  } catch {
+    return FALLBACK;
+  }
+
+  // Drop a file extension: checkout.html → checkout.
+  const words = path
+    .replace(/\.[a-z0-9]+$/i, '')
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean);
+  if (words.length === 0) return FALLBACK;
+
+  const name = words.map((w) => w[0].toUpperCase() + w.slice(1)).join('');
+  // Identifiers cannot start with a digit.
+  const safe = /^\d/.test(name) ? `Page${name}` : name;
+  return safe.endsWith('Page') ? safe : `${safe}Page`;
+}

--- a/v3/src/generators/index.ts
+++ b/v3/src/generators/index.ts
@@ -1,27 +1,52 @@
 // Framework → generated source (SPEC §11).
 //
-// Only Selenium Java so far — the reference template. The others are additive:
-// one file each, all consuming the same model.
+// Each framework offers one or more *shapes*: the same locators, arranged the
+// way that framework's users arrange them. The first is the default.
+//
+// Every framework gets a "Locators only" shape. It is the escape hatch for the
+// many teams with their own page-object conventions — our locators, none of our
+// opinions — and it is the one output that is useful even when the surrounding
+// structure is wrong for them.
 import { frameworkById } from '../frameworks';
 import type { TabModel } from '../model';
-import { generatePlaywrightTs } from './playwright-ts';
-import { generateSeleniumJava } from './selenium-java';
+import { generatePlaywrightPageObject, generatePlaywrightLocators } from './playwright-ts';
+import { generateSeleniumJava, generateSeleniumJavaLocators } from './selenium-java';
 
-type Generator = (model: TabModel) => string;
-
-const GENERATORS: Record<string, Generator> = {
-  'playwright-ts': generatePlaywrightTs,
-  'selenium-java': generateSeleniumJava,
-};
-
-export function canGenerate(frameworkId: string): boolean {
-  return frameworkId in GENERATORS;
+export interface OutputShape {
+  id: string;
+  /** Shown in the code dialog's shape selector. */
+  label: string;
+  generate: (model: TabModel) => string;
 }
 
-export function generateCode(model: TabModel): string {
-  const generate = GENERATORS[model.frameworkId];
-  if (generate) return generate(model);
-  // Better to say which target is missing than to show an empty dialog.
-  const done = Object.keys(GENERATORS).map((id) => frameworkById(id).label).join(', ');
-  return `// ${frameworkById(model.frameworkId).label} is not generated yet.\n// Available so far: ${done}.`;
+const SHAPES: Record<string, readonly OutputShape[]> = {
+  'playwright-ts': [
+    { id: 'page-object', label: 'Page object', generate: generatePlaywrightPageObject },
+    { id: 'locators', label: 'Locators only', generate: generatePlaywrightLocators },
+  ],
+  'selenium-java': [
+    { id: 'methods', label: 'Methods', generate: generateSeleniumJava },
+    { id: 'locators', label: 'Locators only', generate: generateSeleniumJavaLocators },
+  ],
+};
+
+/** The shapes a framework offers; empty when the framework is not generated yet. */
+export function shapesFor(frameworkId: string): readonly OutputShape[] {
+  return SHAPES[frameworkId] ?? [];
+}
+
+export function canGenerate(frameworkId: string): boolean {
+  return shapesFor(frameworkId).length > 0;
+}
+
+/** `shapeId` defaults to the framework's first shape. */
+export function generateCode(model: TabModel, shapeId?: string): string {
+  const shapes = shapesFor(model.frameworkId);
+  if (shapes.length === 0) {
+    // Better to say which target is missing than to show an empty dialog.
+    const done = Object.keys(SHAPES).map((id) => frameworkById(id).label).join(', ');
+    return `// ${frameworkById(model.frameworkId).label} is not generated yet.\n// Available so far: ${done}.`;
+  }
+  const shape = shapes.find((s) => s.id === shapeId) ?? shapes[0];
+  return shape.generate(model);
 }

--- a/v3/src/generators/index.ts
+++ b/v3/src/generators/index.ts
@@ -4,11 +4,13 @@
 // one file each, all consuming the same model.
 import { frameworkById } from '../frameworks';
 import type { TabModel } from '../model';
+import { generatePlaywrightTs } from './playwright-ts';
 import { generateSeleniumJava } from './selenium-java';
 
 type Generator = (model: TabModel) => string;
 
 const GENERATORS: Record<string, Generator> = {
+  'playwright-ts': generatePlaywrightTs,
   'selenium-java': generateSeleniumJava,
 };
 
@@ -20,5 +22,6 @@ export function generateCode(model: TabModel): string {
   const generate = GENERATORS[model.frameworkId];
   if (generate) return generate(model);
   // Better to say which target is missing than to show an empty dialog.
-  return `// ${frameworkById(model.frameworkId).label} is not generated yet.\n// Selenium WebDriver Java is the only target so far.`;
+  const done = Object.keys(GENERATORS).map((id) => frameworkById(id).label).join(', ');
+  return `// ${frameworkById(model.frameworkId).label} is not generated yet.\n// Available so far: ${done}.`;
 }

--- a/v3/src/generators/names.ts
+++ b/v3/src/generators/names.ts
@@ -1,0 +1,6 @@
+// Element names are PascalCase (engine/naming.ts), which suits a method suffix
+// — `getEmailAddressElement`. As a variable or field, most languages want
+// lower-camel.
+export function lowerCamel(name: string): string {
+  return name[0].toLowerCase() + name.slice(1);
+}

--- a/v3/src/generators/playwright-ts.ts
+++ b/v3/src/generators/playwright-ts.ts
@@ -1,0 +1,92 @@
+// Playwright, TypeScript (SPEC §12). The primary target.
+//
+// Not a translation of the Selenium template: the API differs enough to change
+// the shape. Locators are lazy, so a getter costs nothing and never goes stale;
+// auto-waiting removes explicit waits; and `fill`, `check` and `selectOption`
+// replace several hand-rolled sequences.
+import { activeCandidate, type ModelElement, type TabModel } from '../model';
+import { playwrightExpr } from '../locators/display';
+import { classify, isImage } from './classify';
+
+function banner(name: string): string {
+  return `/*\n * ${name}\n * ***************************************************************\n */`;
+}
+
+/** The locator getter every element gets. `page` is assumed in scope, as
+ *  `driver` is in the Selenium template. */
+function locator(el: ModelElement): string {
+  return `get${el.name}Locator(): Locator {\n    return page.${playwrightExpr(activeCandidate(el))};\n}`;
+}
+
+function methods(el: ModelElement): string[] {
+  const n = el.name;
+  const loc = `get${n}Locator()`;
+  const out: string[] = [locator(el)];
+
+  switch (classify(el)) {
+    case 'actionable':
+      out.push(`async click${n}(): Promise<void> {\n    await ${loc}.click();\n}`);
+      break;
+
+    case 'text':
+      out.push(
+        `async get${n}(): Promise<string> {\n    return ${loc}.inputValue();\n}`,
+        // fill() clears by construction, so v2.5.1's append-by-accident cannot
+        // happen here. Appending is still reachable, as in the Selenium
+        // template — TypeScript has default arguments, so it is one method.
+        `async set${n}(value: string, clearFirst = true): Promise<void> {\n    if (clearFirst) {\n        await ${loc}.fill(value);\n    } else {\n        await ${loc}.pressSequentially(value);\n    }\n}`
+      );
+      break;
+
+    case 'toggle':
+      out.push(
+        `async is${n}Checked(): Promise<boolean> {\n    return ${loc}.isChecked();\n}`,
+        // check/uncheck are real primitives; no click-to-toggle dance, and they
+        // verify the resulting state themselves.
+        `async set${n}(checked: boolean): Promise<void> {\n    await (checked ? ${loc}.check() : ${loc}.uncheck());\n}`
+      );
+      break;
+
+    case 'radio':
+      // uncheck() throws on a radio, which is Playwright agreeing that
+      // v2.5.1's set(false) never meant anything.
+      out.push(
+        `async is${n}Selected(): Promise<boolean> {\n    return ${loc}.isChecked();\n}`,
+        `async select${n}(): Promise<void> {\n    await ${loc}.check();\n}`
+      );
+      break;
+
+    case 'select':
+      out.push(
+        `async get${n}Value(): Promise<string> {\n    return ${loc}.inputValue();\n}`,
+        `async set${n}ByValue(value: string): Promise<void> {\n    await ${loc}.selectOption({ value });\n}`,
+        `async set${n}ByText(label: string): Promise<void> {\n    await ${loc}.selectOption({ label });\n}`
+      );
+      break;
+
+    case 'multiSelect':
+      out.push(
+        `async get${n}Values(): Promise<string[]> {\n    return ${loc}.evaluate((el: HTMLSelectElement) =>\n        Array.from(el.selectedOptions, (o) => o.value)\n    );\n}`,
+        // selectOption replaces the whole selection, so there is no deselectAll
+        // step and no way to accidentally add to what was already chosen.
+        `async set${n}ByValues(...values: string[]): Promise<void> {\n    await ${loc}.selectOption(values.map((value) => ({ value })));\n}`,
+        `async set${n}ByTexts(...labels: string[]): Promise<void> {\n    await ${loc}.selectOption(labels.map((label) => ({ label })));\n}`,
+        `async deselectAll${n}(): Promise<void> {\n    await ${loc}.selectOption([]);\n}`
+      );
+      break;
+
+    case 'static':
+      out.push(
+        isImage(el)
+          ? `async get${n}AltText(): Promise<string | null> {\n    return ${loc}.getAttribute('alt');\n}`
+          : `async get${n}(): Promise<string | null> {\n    return ${loc}.textContent();\n}`
+      );
+      break;
+  }
+
+  return out;
+}
+
+export function generatePlaywrightTs(model: TabModel): string {
+  return model.elements.map((el) => [banner(el.name), ...methods(el)].join('\n\n')).join('\n\n');
+}

--- a/v3/src/generators/playwright-ts.ts
+++ b/v3/src/generators/playwright-ts.ts
@@ -6,87 +6,62 @@
 // replace several hand-rolled sequences.
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import { playwrightExpr } from '../locators/display';
-import { classify, isImage } from './classify';
+import { classNameFor } from './class-name';
+import { lowerCamel } from './names';
 
-function banner(name: string): string {
-  return `/*\n * ${name}\n * ***************************************************************\n */`;
+/** `page.getByRole(…)` for one element. */
+function expr(el: ModelElement): string {
+  return `page.${playwrightExpr(activeCandidate(el))}`;
 }
 
-/** The locator getter every element gets. `page` is assumed in scope, as
- *  `driver` is in the Selenium template. */
-function locator(el: ModelElement): string {
-  return `get${el.name}Locator(): Locator {\n    return page.${playwrightExpr(activeCandidate(el))};\n}`;
-}
-
-function methods(el: ModelElement): string[] {
-  const n = el.name;
-  const loc = `get${n}Locator()`;
-  const out: string[] = [locator(el)];
-
-  switch (classify(el)) {
-    case 'actionable':
-      out.push(`async click${n}(): Promise<void> {\n    await ${loc}.click();\n}`);
-      break;
-
-    case 'text':
-      out.push(
-        `async get${n}(): Promise<string> {\n    return ${loc}.inputValue();\n}`,
-        // fill() clears by construction, so v2.5.1's append-by-accident cannot
-        // happen here. Appending is still reachable, as in the Selenium
-        // template — TypeScript has default arguments, so it is one method.
-        `async set${n}(value: string, clearFirst = true): Promise<void> {\n    if (clearFirst) {\n        await ${loc}.fill(value);\n    } else {\n        await ${loc}.pressSequentially(value);\n    }\n}`
-      );
-      break;
-
-    case 'toggle':
-      out.push(
-        `async is${n}Checked(): Promise<boolean> {\n    return ${loc}.isChecked();\n}`,
-        // check/uncheck are real primitives; no click-to-toggle dance, and they
-        // verify the resulting state themselves.
-        `async set${n}(checked: boolean): Promise<void> {\n    await (checked ? ${loc}.check() : ${loc}.uncheck());\n}`
-      );
-      break;
-
-    case 'radio':
-      // uncheck() throws on a radio, which is Playwright agreeing that
-      // v2.5.1's set(false) never meant anything.
-      out.push(
-        `async is${n}Selected(): Promise<boolean> {\n    return ${loc}.isChecked();\n}`,
-        `async select${n}(): Promise<void> {\n    await ${loc}.check();\n}`
-      );
-      break;
-
-    case 'select':
-      out.push(
-        `async get${n}Value(): Promise<string> {\n    return ${loc}.inputValue();\n}`,
-        `async set${n}ByValue(value: string): Promise<void> {\n    await ${loc}.selectOption({ value });\n}`,
-        `async set${n}ByText(label: string): Promise<void> {\n    await ${loc}.selectOption({ label });\n}`
-      );
-      break;
-
-    case 'multiSelect':
-      out.push(
-        `async get${n}Values(): Promise<string[]> {\n    return ${loc}.evaluate((el: HTMLSelectElement) =>\n        Array.from(el.selectedOptions, (o) => o.value)\n    );\n}`,
-        // selectOption replaces the whole selection, so there is no deselectAll
-        // step and no way to accidentally add to what was already chosen.
-        `async set${n}ByValues(...values: string[]): Promise<void> {\n    await ${loc}.selectOption(values.map((value) => ({ value })));\n}`,
-        `async set${n}ByTexts(...labels: string[]): Promise<void> {\n    await ${loc}.selectOption(labels.map((label) => ({ label })));\n}`,
-        `async deselectAll${n}(): Promise<void> {\n    await ${loc}.selectOption([]);\n}`
-      );
-      break;
-
-    case 'static':
-      out.push(
-        isImage(el)
-          ? `async get${n}AltText(): Promise<string | null> {\n    return ${loc}.getAttribute('alt');\n}`
-          : `async get${n}(): Promise<string | null> {\n    return ${loc}.textContent();\n}`
-      );
-      break;
+/**
+ * The idiomatic page object: readonly locators assigned in the constructor,
+ * which is the shape Playwright's own documentation shows.
+ *
+ * No per-element action wrappers, deliberately. A `Locator` is lazy, reusable
+ * and *is* the action API, so `clickLogIn()` around `.click()` adds a name and
+ * nothing else — the test reads better as `loginPage.logIn.click()`. Those
+ * wrappers earn their place in Selenium, where `findElement` returns something
+ * that goes stale; here they are ceremony.
+ *
+ * Composite methods — `login(email, password)` — are the point of a page
+ * object, and they need domain knowledge this tool does not have. The user
+ * writes those.
+ */
+export function generatePlaywrightPageObject(model: TabModel): string {
+  const className = classNameFor(model.url);
+  if (model.elements.length === 0) {
+    return [
+      "import { type Page } from '@playwright/test';",
+      '',
+      `export class ${className} {`,
+      '  constructor(private readonly page: Page) {}',
+      '}',
+      '',
+    ].join('\n');
   }
 
-  return out;
+  const fields = model.elements.map((el) => `  readonly ${lowerCamel(el.name)}: Locator;`);
+  const assignments = model.elements.map((el) => `    this.${lowerCamel(el.name)} = ${expr(el)};`);
+
+  return [
+    "import { type Locator, type Page } from '@playwright/test';",
+    '',
+    `export class ${className} {`,
+    ...fields,
+    '',
+    '  constructor(private readonly page: Page) {',
+    ...assignments,
+    '  }',
+    '}',
+    '',
+  ].join('\n');
 }
 
-export function generatePlaywrightTs(model: TabModel): string {
-  return model.elements.map((el) => [banner(el.name), ...methods(el)].join('\n\n')).join('\n\n');
+/**
+ * Locators only (SPEC §11) — the escape hatch for anyone with their own page
+ * object conventions, which is most teams. Our locators, none of our opinions.
+ */
+export function generatePlaywrightLocators(model: TabModel): string {
+  return model.elements.map((el) => `const ${lowerCamel(el.name)} = ${expr(el)};`).join('\n');
 }

--- a/v3/src/generators/selenium-java.ts
+++ b/v3/src/generators/selenium-java.ts
@@ -5,6 +5,7 @@
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import type { LocatorCandidate } from '../engine/types';
 import { classify, isImage } from './classify';
+import { lowerCamel } from './names';
 
 /** Java string literal: only `\` and `"` need escaping for our values. */
 const q = (value: string) => `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
@@ -117,6 +118,16 @@ function methods(el: ModelElement): string[] {
   }
 
   return out;
+}
+
+/**
+ * Locators only (SPEC §11): `By` fields to paste into your own page object.
+ * `final`, because a `By` is an immutable description of how to find something.
+ */
+export function generateSeleniumJavaLocators(model: TabModel): string {
+  return model.elements
+    .map((el) => `private final By ${lowerCamel(el.name)} = ${by(activeCandidate(el))};`)
+    .join('\n');
 }
 
 export function generateSeleniumJava(model: TabModel): string {

--- a/v3/tests/unit/CodeDialog.test.ts
+++ b/v3/tests/unit/CodeDialog.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
-import { Quasar, QBtn, QDialog, QCard, QCardSection, QCardActions, QToolbar, QToolbarTitle } from 'quasar';
+import { Quasar, QBtn, QBtnToggle, QDialog, QCard, QCardSection, QCardActions, QToolbar, QToolbarTitle } from 'quasar';
 import CodeDialog from '../../ui/CodeDialog.vue';
 import { emptyModel, type ModelElement, type TabModel } from '../../src/model';
 
@@ -38,7 +38,7 @@ async function render(model: TabModel) {
     props: { model },
     global: {
       plugins: [Quasar],
-      components: { QBtn, QDialog, QCard, QCardSection, QCardActions, QToolbar, QToolbarTitle },
+      components: { QBtn, QBtnToggle, QDialog, QCard, QCardSection, QCardActions, QToolbar, QToolbarTitle },
     },
     attachTo: document.body,
   }) as ReturnType<typeof mount>;
@@ -47,6 +47,15 @@ async function render(model: TabModel) {
 }
 
 const codeText = () => document.body.querySelector('[data-testid="code-output"]')?.textContent ?? '';
+
+/** Click one of the shape toggle's buttons by its label. */
+async function chooseShape(label: string) {
+  const buttons = document.body.querySelectorAll('[data-testid="code-shape"] button');
+  const button = [...buttons].find((b) => b.textContent?.trim() === label);
+  if (!button) throw new Error(`no shape button labelled ${label}`);
+  (button as HTMLElement).click();
+  await nextTick();
+}
 
 describe('CodeDialog', () => {
   it('is titled with the framework, as v2.5.1 was', async () => {
@@ -62,7 +71,16 @@ describe('CodeDialog', () => {
 
   it('generates for Playwright too', async () => {
     await render(modelWith('playwright-ts', { name: 'Email' }));
-    expect(codeText()).toContain('getEmailLocator(): Locator {');
+    expect(codeText()).toContain('readonly email: Locator;');
+  });
+
+  it('switches shape without touching the model', async () => {
+    const model = modelWith('playwright-ts', { name: 'Email' });
+    await render(model);
+    await chooseShape('Locators only');
+    expect(codeText()).toContain('const email = page.');
+    expect(codeText()).not.toContain('export class');
+    expect(model.elements).toHaveLength(1);
   });
 
   it('says which target is missing rather than showing nothing', async () => {

--- a/v3/tests/unit/CodeDialog.test.ts
+++ b/v3/tests/unit/CodeDialog.test.ts
@@ -60,10 +60,16 @@ describe('CodeDialog', () => {
     expect(codeText()).toContain('public void setEmail(String value) {');
   });
 
-  it('says which target is missing rather than showing nothing', async () => {
-    // Only Selenium Java exists so far; an empty dialog would look broken.
+  it('generates for Playwright too', async () => {
     await render(modelWith('playwright-ts', { name: 'Email' }));
-    expect(codeText()).toContain('Playwright (TypeScript) is not generated yet');
+    expect(codeText()).toContain('getEmailLocator(): Locator {');
+  });
+
+  it('says which target is missing rather than showing nothing', async () => {
+    // Not every target exists yet; an empty dialog would look broken.
+    await render(modelWith('puppeteer', { name: 'Email' }));
+    expect(codeText()).toContain('Puppeteer is not generated yet');
+    expect(codeText()).toContain('Available so far:');
   });
 
   it('renders an empty model without failing', async () => {

--- a/v3/tests/unit/class-name.test.ts
+++ b/v3/tests/unit/class-name.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { classNameFor } from '../../src/generators/class-name';
+
+describe('classNameFor', () => {
+  it('uses the last path segment', () => {
+    expect(classNameFor('https://shop.example.com/shop/checkout')).toBe('CheckoutPage');
+    expect(classNameFor('https://example.com/checkout/')).toBe('CheckoutPage');
+  });
+
+  it('drops a file extension', () => {
+    expect(classNameFor('http://localhost:5199/login.html')).toBe('LoginPage');
+  });
+
+  it('joins a multi-word segment', () => {
+    expect(classNameFor('https://example.com/order-confirmation')).toBe('OrderConfirmationPage');
+  });
+
+  it('falls back to the host at the root, without the TLD', () => {
+    // The extension-strip earns its keep twice: login.html → Login, and
+    // facebook.com → Facebook.
+    expect(classNameFor('https://facebook.com/')).toBe('FacebookPage');
+  });
+
+  it('does not repeat Page when the path already says it', () => {
+    expect(classNameFor('https://example.com/checkout-page')).toBe('CheckoutPage');
+  });
+
+  it('does not start an identifier with a digit', () => {
+    expect(classNameFor('https://example.com/2fa')).toBe('Page2faPage');
+  });
+
+  it('falls back when there is no url or it is unparseable', () => {
+    expect(classNameFor(null)).toBe('GeneratedPage');
+    expect(classNameFor('not a url')).toBe('GeneratedPage');
+  });
+});

--- a/v3/tests/unit/playwright-ts.test.ts
+++ b/v3/tests/unit/playwright-ts.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { generatePlaywrightTs } from '../../src/generators/playwright-ts';
+import { emptyModel, type ModelElement, type TabModel } from '../../src/model';
+import type { LocatorCandidate } from '../../src/engine/types';
+
+function model(...elements: Array<Partial<ModelElement> & { name: string; candidate: LocatorCandidate }>): TabModel {
+  const m = emptyModel('playwright-ts');
+  m.elements = elements.map(({ candidate, ...el }, i) => ({
+    id: `el-${i}`,
+    tag: 'div',
+    role: null,
+    accessibleName: null,
+    suggestedName: el.name,
+    selectedIndex: 0,
+    preferredIndex: 0,
+    candidates: [{ candidate, predictedCount: 1 }],
+    ...el,
+  })) as ModelElement[];
+  return m;
+}
+
+const gen = (...args: Parameters<typeof model>) => generatePlaywrightTs(model(...args));
+
+describe('generatePlaywrightTs', () => {
+  it('emits a lazy locator getter, not an element lookup', () => {
+    // A Locator is lazy, so it never goes stale and costs nothing to hold.
+    const out = gen({
+      name: 'SignIn',
+      role: 'button',
+      tag: 'button',
+      candidate: { kind: 'role', role: 'button', name: 'Sign in', exact: true },
+    });
+    expect(out).toContain('getSignInLocator(): Locator {');
+    expect(out).toContain("return page.getByRole('button', { name: 'Sign in', exact: true });");
+  });
+
+  it('keeps exact: true, which the engine guarantees', () => {
+    const out = gen({ name: 'About', role: 'link', tag: 'a', candidate: { kind: 'text', text: 'About', exact: true } });
+    expect(out).toContain("getByText('About', { exact: true })");
+  });
+
+  it('awaits every action and types the promise', () => {
+    const out = gen({ name: 'SignIn', role: 'button', tag: 'button', candidate: { kind: 'css', value: 'button' } });
+    expect(out).toContain('async clickSignIn(): Promise<void> {');
+    expect(out).toContain('await getSignInLocator().click();');
+  });
+
+  it('fills a text field, and can append instead', () => {
+    // fill() clears by construction, so v2.5.1's accidental append cannot
+    // happen — but appending stays reachable, as in the Selenium template.
+    const out = gen({ name: 'Email', role: 'textbox', tag: 'input', candidate: { kind: 'label', text: 'Email', exact: true } });
+    expect(out).toContain('async setEmail(value: string, clearFirst = true): Promise<void> {');
+    expect(out).toContain('.fill(value);');
+    expect(out).toContain('.pressSequentially(value);');
+    expect(out).toContain('.inputValue();');
+  });
+
+  it('uses check and uncheck rather than clicking to toggle', () => {
+    const out = gen({ name: 'Remember', role: 'checkbox', tag: 'input', candidate: { kind: 'css', value: '#r' } });
+    expect(out).toContain('await (checked ? getRememberLocator().check() : getRememberLocator().uncheck());');
+    expect(out).not.toContain('.click()');
+  });
+
+  it('gives a radio check() only — uncheck() throws on one', () => {
+    // Playwright agreeing that v2.5.1's set(false) never meant anything.
+    const out = gen({ name: 'Pro', role: 'radio', tag: 'input', candidate: { kind: 'css', value: '#p' } });
+    expect(out).toContain('async selectPro(): Promise<void> {');
+    expect(out).toContain('.check();');
+    expect(out).not.toContain('uncheck');
+  });
+
+  it('selects by value or label on a single select', () => {
+    const out = gen({ name: 'Country', role: 'combobox', tag: 'select', candidate: { kind: 'css', value: '#c' } });
+    expect(out).toContain('await getCountryLocator().selectOption({ value });');
+    expect(out).toContain('await getCountryLocator().selectOption({ label });');
+  });
+
+  it('replaces the whole selection on a multi-select', () => {
+    // selectOption replaces, so there is no deselectAll step and no way to
+    // accidentally add to what was already chosen — unlike Selenium.
+    const out = gen({ name: 'Toppings', role: 'listbox', tag: 'select', candidate: { kind: 'css', value: '#t' } });
+    expect(out).toContain('async setToppingsByValues(...values: string[]): Promise<void> {');
+    expect(out).toContain('values.map((value) => ({ value }))');
+    expect(out).toContain('async deselectAllToppings(): Promise<void> {');
+    expect(out).toContain('.selectOption([]);');
+  });
+
+  it('reads a static element, and an image by its alt', () => {
+    expect(gen({ name: 'Welcome', role: 'heading', tag: 'h1', candidate: { kind: 'css', value: 'h1' } })).toContain(
+      '.textContent();'
+    );
+    const img = gen({ name: 'Logo', role: 'img', tag: 'img', candidate: { kind: 'altText', text: 'Acme' } });
+    expect(img).toContain("getAttribute('alt');");
+    expect(img).not.toContain('clickLogo');
+  });
+
+  it('classifies a password field as text despite it having no role', () => {
+    const out = gen({ name: 'Password', role: null, tag: 'input', inputType: 'password', candidate: { kind: 'css', value: '#p' } });
+    expect(out).toContain('async setPassword(');
+  });
+
+  it('emits nothing for an empty model', () => {
+    expect(generatePlaywrightTs(emptyModel('playwright-ts'))).toBe('');
+  });
+});

--- a/v3/tests/unit/playwright-ts.test.ts
+++ b/v3/tests/unit/playwright-ts.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { generatePlaywrightTs } from '../../src/generators/playwright-ts';
+import {
+  generatePlaywrightPageObject,
+  generatePlaywrightLocators,
+} from '../../src/generators/playwright-ts';
 import { emptyModel, type ModelElement, type TabModel } from '../../src/model';
 import type { LocatorCandidate } from '../../src/engine/types';
 
 function model(...elements: Array<Partial<ModelElement> & { name: string; candidate: LocatorCandidate }>): TabModel {
   const m = emptyModel('playwright-ts');
+  m.url = 'https://example.com/account/login.html';
   m.elements = elements.map(({ candidate, ...el }, i) => ({
     id: `el-${i}`,
     tag: 'div',
@@ -19,87 +23,83 @@ function model(...elements: Array<Partial<ModelElement> & { name: string; candid
   return m;
 }
 
-const gen = (...args: Parameters<typeof model>) => generatePlaywrightTs(model(...args));
+const email: Parameters<typeof model>[0] = {
+  name: 'EmailAddress',
+  role: 'textbox',
+  tag: 'input',
+  candidate: { kind: 'label', text: 'Email address', exact: true },
+};
+const signIn: Parameters<typeof model>[0] = {
+  name: 'SignIn',
+  role: 'button',
+  tag: 'button',
+  candidate: { kind: 'role', role: 'button', name: 'Sign in', exact: true },
+};
 
-describe('generatePlaywrightTs', () => {
-  it('emits a lazy locator getter, not an element lookup', () => {
-    // A Locator is lazy, so it never goes stale and costs nothing to hold.
-    const out = gen({
-      name: 'SignIn',
-      role: 'button',
-      tag: 'button',
-      candidate: { kind: 'role', role: 'button', name: 'Sign in', exact: true },
-    });
-    expect(out).toContain('getSignInLocator(): Locator {');
-    expect(out).toContain("return page.getByRole('button', { name: 'Sign in', exact: true });");
+describe('generatePlaywrightPageObject', () => {
+  it('names the class from the page URL', () => {
+    expect(generatePlaywrightPageObject(model(email))).toContain('export class LoginPage {');
   });
 
-  it('keeps exact: true, which the engine guarantees', () => {
-    const out = gen({ name: 'About', role: 'link', tag: 'a', candidate: { kind: 'text', text: 'About', exact: true } });
-    expect(out).toContain("getByText('About', { exact: true })");
-  });
-
-  it('awaits every action and types the promise', () => {
-    const out = gen({ name: 'SignIn', role: 'button', tag: 'button', candidate: { kind: 'css', value: 'button' } });
-    expect(out).toContain('async clickSignIn(): Promise<void> {');
-    expect(out).toContain('await getSignInLocator().click();');
-  });
-
-  it('fills a text field, and can append instead', () => {
-    // fill() clears by construction, so v2.5.1's accidental append cannot
-    // happen — but appending stays reachable, as in the Selenium template.
-    const out = gen({ name: 'Email', role: 'textbox', tag: 'input', candidate: { kind: 'label', text: 'Email', exact: true } });
-    expect(out).toContain('async setEmail(value: string, clearFirst = true): Promise<void> {');
-    expect(out).toContain('.fill(value);');
-    expect(out).toContain('.pressSequentially(value);');
-    expect(out).toContain('.inputValue();');
-  });
-
-  it('uses check and uncheck rather than clicking to toggle', () => {
-    const out = gen({ name: 'Remember', role: 'checkbox', tag: 'input', candidate: { kind: 'css', value: '#r' } });
-    expect(out).toContain('await (checked ? getRememberLocator().check() : getRememberLocator().uncheck());');
-    expect(out).not.toContain('.click()');
-  });
-
-  it('gives a radio check() only — uncheck() throws on one', () => {
-    // Playwright agreeing that v2.5.1's set(false) never meant anything.
-    const out = gen({ name: 'Pro', role: 'radio', tag: 'input', candidate: { kind: 'css', value: '#p' } });
-    expect(out).toContain('async selectPro(): Promise<void> {');
-    expect(out).toContain('.check();');
-    expect(out).not.toContain('uncheck');
-  });
-
-  it('selects by value or label on a single select', () => {
-    const out = gen({ name: 'Country', role: 'combobox', tag: 'select', candidate: { kind: 'css', value: '#c' } });
-    expect(out).toContain('await getCountryLocator().selectOption({ value });');
-    expect(out).toContain('await getCountryLocator().selectOption({ label });');
-  });
-
-  it('replaces the whole selection on a multi-select', () => {
-    // selectOption replaces, so there is no deselectAll step and no way to
-    // accidentally add to what was already chosen — unlike Selenium.
-    const out = gen({ name: 'Toppings', role: 'listbox', tag: 'select', candidate: { kind: 'css', value: '#t' } });
-    expect(out).toContain('async setToppingsByValues(...values: string[]): Promise<void> {');
-    expect(out).toContain('values.map((value) => ({ value }))');
-    expect(out).toContain('async deselectAllToppings(): Promise<void> {');
-    expect(out).toContain('.selectOption([]);');
-  });
-
-  it('reads a static element, and an image by its alt', () => {
-    expect(gen({ name: 'Welcome', role: 'heading', tag: 'h1', candidate: { kind: 'css', value: 'h1' } })).toContain(
-      '.textContent();'
+  it('declares readonly fields and assigns them in the constructor', () => {
+    const out = generatePlaywrightPageObject(model(email, signIn));
+    expect(out).toContain('  readonly emailAddress: Locator;');
+    expect(out).toContain('  readonly signIn: Locator;');
+    expect(out).toContain('  constructor(private readonly page: Page) {');
+    expect(out).toContain("    this.emailAddress = page.getByLabel('Email address', { exact: true });");
+    expect(out).toContain(
+      "    this.signIn = page.getByRole('button', { name: 'Sign in', exact: true });"
     );
-    const img = gen({ name: 'Logo', role: 'img', tag: 'img', candidate: { kind: 'altText', text: 'Acme' } });
-    expect(img).toContain("getAttribute('alt');");
-    expect(img).not.toContain('clickLogo');
   });
 
-  it('classifies a password field as text despite it having no role', () => {
-    const out = gen({ name: 'Password', role: null, tag: 'input', inputType: 'password', candidate: { kind: 'css', value: '#p' } });
-    expect(out).toContain('async setPassword(');
+  it('assigns from the constructor parameter, not this.page', () => {
+    // `this.page` is not assigned until the parameter property is applied, so
+    // reading it in the constructor body is the classic undefined-locator bug.
+    expect(generatePlaywrightPageObject(model(email))).not.toContain('this.page.getBy');
+  });
+
+  it('imports both types, type-only', () => {
+    expect(generatePlaywrightPageObject(model(email))).toContain(
+      "import { type Locator, type Page } from '@playwright/test';"
+    );
+  });
+
+  it('wraps no actions — a Locator is already the action API', () => {
+    // The whole point of the reshape: `page.signIn.click()` beats
+    // `page.clickSignIn()`. Composite methods are the user's to add.
+    const out = generatePlaywrightPageObject(model(email, signIn));
+    expect(out).not.toContain('async ');
+    expect(out).not.toContain('click');
+    expect(out).not.toContain('fill');
+  });
+
+  it('emits a usable empty class, with no unused Locator import', () => {
+    const out = generatePlaywrightPageObject(emptyModel('playwright-ts'));
+    expect(out).toBe(
+      [
+        "import { type Page } from '@playwright/test';",
+        '',
+        'export class GeneratedPage {',
+        '  constructor(private readonly page: Page) {}',
+        '}',
+        '',
+      ].join('\n')
+    );
+  });
+});
+
+describe('generatePlaywrightLocators', () => {
+  it('emits bare consts, with no class around them', () => {
+    const out = generatePlaywrightLocators(model(email, signIn));
+    expect(out).toBe(
+      [
+        "const emailAddress = page.getByLabel('Email address', { exact: true });",
+        "const signIn = page.getByRole('button', { name: 'Sign in', exact: true });",
+      ].join('\n')
+    );
   });
 
   it('emits nothing for an empty model', () => {
-    expect(generatePlaywrightTs(emptyModel('playwright-ts'))).toBe('');
+    expect(generatePlaywrightLocators(emptyModel('playwright-ts'))).toBe('');
   });
 });

--- a/v3/tests/unit/selenium-java.test.ts
+++ b/v3/tests/unit/selenium-java.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateSeleniumJava } from '../../src/generators/selenium-java';
+import { generateSeleniumJava, generateSeleniumJavaLocators } from '../../src/generators/selenium-java';
 import { emptyModel, type ModelElement, type TabModel } from '../../src/model';
 import type { LocatorCandidate } from '../../src/engine/types';
 
@@ -137,5 +137,26 @@ describe('generateSeleniumJava', () => {
     expect(out).toContain('* A');
     expect(out).toContain('* B');
     expect(generateSeleniumJava(emptyModel('selenium-java'))).toBe('');
+  });
+});
+
+describe('generateSeleniumJavaLocators', () => {
+  it('emits By fields and no methods', () => {
+    const out = generateSeleniumJavaLocators(
+      model(
+        { name: 'EmailAddress', role: 'textbox', tag: 'input', candidate: { kind: 'name', value: 'email' } },
+        { name: 'SignIn', role: 'button', tag: 'button', candidate: { kind: 'id', value: 'go' } }
+      )
+    );
+    expect(out).toBe(
+      [
+        'private final By emailAddress = By.name("email");',
+        'private final By signIn = By.id("go");',
+      ].join('\n')
+    );
+  });
+
+  it('emits nothing for an empty model', () => {
+    expect(generateSeleniumJavaLocators(emptyModel('selenium-java'))).toBe('');
   });
 });

--- a/v3/ui/CodeDialog.vue
+++ b/v3/ui/CodeDialog.vue
@@ -18,7 +18,7 @@
         <q-btn flat dense no-caps icon="content_copy" label="Copy" data-testid="code-copy" @click="copy" />
       </q-toolbar>
 
-      <q-card-section class="q-pa-none">
+      <q-card-section class="code-body q-pa-none">
         <!-- Read-only, as in v2.5.1: the model is edited in the table, not here. -->
         <pre class="code" data-testid="code-output">{{ code }}</pre>
       </q-card-section>
@@ -66,11 +66,27 @@ async function copy() {
 </script>
 
 <style scoped>
-.code-card {
-  width: 100%;
-  max-width: 900px;
+/* Doubled class to out-specify Quasar's `.q-dialog__inner--minimized > div`,
+   which caps a dialog at 560px wide and 100dvh - 48px tall. */
+.code-card.code-card {
+  /* Fixed to the viewport, not to the content: switching shape changes the
+     line count wildly, and a card that resizes under the pointer is jarring.
+     The dialog's own padding supplies the surrounding margin. */
+  width: 90vw;
+  max-width: 90vw;
+  height: 90vh;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
   background: var(--pm-page-bg);
   color: var(--pm-text);
+}
+
+/* min-height: 0 or the flex item refuses to shrink below its content and the
+   code scrolls the card instead of itself. */
+.code-body {
+  flex: 1;
+  min-height: 0;
 }
 
 .dialog-header {
@@ -88,8 +104,8 @@ async function copy() {
 .code {
   margin: 0;
   padding: 16px;
+  height: 100%;
   /* The panel is narrow; long locators scroll rather than widening the dialog. */
-  max-height: 60vh;
   overflow: auto;
   font: 12px/1.6 ui-monospace, SFMono-Regular, monospace;
   white-space: pre;

--- a/v3/ui/CodeDialog.vue
+++ b/v3/ui/CodeDialog.vue
@@ -3,6 +3,18 @@
     <q-card class="code-card">
       <q-toolbar class="dialog-header">
         <q-toolbar-title class="text-subtitle1">{{ frameworkLabel }}</q-toolbar-title>
+        <!-- Shapes are per-framework, so this is hidden when there is only one. -->
+        <q-btn-toggle
+          v-if="shapes.length > 1"
+          v-model="shapeId"
+          :options="shapeOptions"
+          flat
+          dense
+          no-caps
+          toggle-color="primary"
+          class="shape-toggle q-mr-sm"
+          data-testid="code-shape"
+        />
         <q-btn flat dense no-caps icon="content_copy" label="Copy" data-testid="code-copy" @click="copy" />
       </q-toolbar>
 
@@ -22,7 +34,7 @@
 import { ref, computed } from 'vue';
 import { useQuasar } from 'quasar';
 import { frameworkById } from '@/src/frameworks';
-import { generateCode } from '@/src/generators';
+import { generateCode, shapesFor } from '@/src/generators';
 import type { TabModel } from '@/src/model';
 
 const props = defineProps<{ model: TabModel }>();
@@ -32,7 +44,14 @@ const $q = useQuasar();
 const open = ref(true);
 
 const frameworkLabel = computed(() => frameworkById(props.model.frameworkId).label);
-const code = computed(() => generateCode(props.model));
+
+// Dialog-local, not stored on the model: which shape you want to read is a
+// property of this glance at the code, not of the elements you have captured.
+const shapes = computed(() => shapesFor(props.model.frameworkId));
+const shapeOptions = computed(() => shapes.value.map((s) => ({ label: s.label, value: s.id })));
+const shapeId = ref(shapes.value[0]?.id);
+
+const code = computed(() => generateCode(props.model, shapeId.value));
 
 async function copy() {
   try {
@@ -59,6 +78,11 @@ async function copy() {
   color: var(--pm-toolbar-fg);
   border-bottom: 1px solid var(--pm-rule);
   min-height: 44px;
+}
+
+.shape-toggle {
+  border: 1px solid var(--pm-rule);
+  border-radius: 4px;
 }
 
 .code {


### PR DESCRIPTION
Playwright (TypeScript) generation, plus a shape selector in the code dialog.

## Output shapes (SPEC §11)

The same locators, arranged the way that framework's users arrange them. First is the default.

| Framework | Shapes |
|---|---|
| Selenium Java | **Methods** · Locators only |
| Playwright (TS) | **Page object** · Locators only |

"Locators only" is for the many teams with their own page-object conventions — our locators, none of our opinions.

## Playwright's page object (SPEC §12)

```ts
import { type Locator, type Page } from '@playwright/test';

export class LoginPage {
  readonly emailAddress: Locator;
  readonly signIn: Locator;

  constructor(private readonly page: Page) {
    this.emailAddress = page.getByLabel('Email address', { exact: true });
    this.signIn = page.getByRole('button', { name: 'Sign in', exact: true });
  }
}
```

No per-element action wrappers: a `Locator` is lazy and is already the action API, so `loginPage.signIn.click()` beats `loginPage.clickSignIn()`. Those wrappers earn their place in Selenium, where `findElement` goes stale. No composite methods either — `login(email, password)` needs domain knowledge this tool does not have.

Class name from the URL's last path segment (`/account/login.html` → `LoginPage`), renamed by hand.

## Verification

`npm test` green — 159 unit, 18 Playwright. **Not yet hand-tested in a browser**, which is the actual gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)