### PR TITLE
v3: prefix generated Playwright xpath with `xpath=`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,10 @@ change.** v3 work goes on the `v3-rewrite` branch, inside `v3/`.
 Note the branch is `v3-rewrite`, not `v3` — a branch named `v3` would be ambiguous with the `v3/`
 directory in every revision argument (`git log v3`, `git show v3:file`).
 
+**Always `gh pr create --base v3-rewrite`.** `gh` defaults the base to the repo's default branch,
+`master`. A v3 branch PR'd that way does not carry one commit — squash-merging it collapses the whole
+`v3-rewrite`..branch difference into `master` (97 files the one time it happened, #75/#76).
+
 > **Until the `v3-rewrite` branch merges, `v3/` and `docs/v3/` exist only on that branch** — `git checkout v3-rewrite` before
 > looking for anything below. This file is on `master` so the orientation is available from either side.
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -446,6 +446,13 @@ is itself unique. Scoping cannot save a genuinely repeated element — the delet
 row — so the full chain is **scope → `.nth()` within the scope → CSS/XPath**, the tail being
 **[inferred]**.
 
+### XPath needs its prefix **[settled]**
+
+`page.locator('xpath=…')`, always. Playwright infers XPath only from a leading `//` or `..`; the
+engine's fallback path starts with a single `/`, which is parsed as CSS and throws. Prefixed
+unconditionally — `//` would survive bare, but two spellings of one thing is one more thing to get
+wrong.
+
 ### Name matching **[settled]**
 
 Always emit `exact: true`. The engine certifies uniqueness at pick time and substring matching

--- a/v3/src/locators/display.ts
+++ b/v3/src/locators/display.ts
@@ -27,8 +27,13 @@ export function playwrightExpr(c: LocatorCandidate): string {
     case 'title':
       return `getByTitle(${q(c.text)}${c.exact ? ', { exact: true }' : ''})`;
     case 'css':
-    case 'xpath':
       return `locator(${q(c.value)})`;
+    case 'xpath':
+      // The `xpath=` prefix is not optional. Playwright only infers XPath from
+      // a leading `//` or `..`, and the engine's fallback path starts with a
+      // single `/` — `locator('/html[1]/body[1]/div[2]')` is parsed as CSS and
+      // throws "Unexpected token /".
+      return `locator(${q(`xpath=${c.value}`)})`;
     default:
       // Selenium's By strategies have no Playwright call. They should not reach
       // a Playwright model, but if one is hand-typed and the framework changes,

--- a/v3/tests/engine.fidelity.spec.ts
+++ b/v3/tests/engine.fidelity.spec.ts
@@ -2,7 +2,11 @@ import { test, expect } from '@playwright/test';
 import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
 import { buildLocator } from './pw-builder';
+import { playwrightExpr } from '../src/locators/display';
+import { frameworkById } from '../src/frameworks';
 import type { ElementResult } from '../src/engine/types';
+
+const PLAYWRIGHT_KINDS = new Set(frameworkById('playwright-ts').locatorTypes);
 
 // The crown-jewel correctness gate: every locator the engine deems unique must
 // resolve uniquely to the correct element in a REAL Playwright run.
@@ -50,6 +54,21 @@ test('locator engine matches real Playwright resolution', async ({ page }) => {
         const findsIt = await loc.evaluateAll((els, id) => els.some((e) => e.getAttribute('data-spike') === id), spikeId);
         if (!findsIt) {
           failures.push(`${fixture}/${spikeId}: ${candidate.kind} resolves, but not to ${spikeId}`);
+        }
+
+        // And the GENERATED STRING, not just the IR. `playwrightExpr` is what
+        // lands in the user's page object, and it has its own way to be wrong
+        // independently of the candidate being right: an XPath needs the
+        // `xpath=` prefix, because Playwright infers XPath only from a leading
+        // `//` or `..` and the engine's fallback path starts with one slash.
+        if (PLAYWRIGHT_KINDS.has(candidate.kind)) {
+          const expr = playwrightExpr(candidate);
+          const generated = await new Function('page', `return page.${expr};`)(page)
+            .count()
+            .catch((e: Error) => `threw: ${String(e).split('\n')[0]}`);
+          if (generated !== actual) {
+            failures.push(`${fixture}/${spikeId}: page.${expr} gave ${generated}, expected ${actual}`);
+          }
         }
       }
 

--- a/v3/tests/unit/display.test.ts
+++ b/v3/tests/unit/display.test.ts
@@ -18,6 +18,20 @@ describe('displayLocator', () => {
     expect(playwrightExpr({ kind: 'role', role: 'link', name: 'About' })).toBe("getByRole('link', { name: 'About' })");
   });
 
+  it('prefixes an xpath, which Playwright will not infer', () => {
+    // Playwright reads a leading `//` or `..` as XPath and everything else as
+    // CSS. The engine's fallback path starts with a single `/`, so without the
+    // prefix the generated call throws "Unexpected token /".
+    expect(playwrightExpr({ kind: 'xpath', value: '/html[1]/body[1]/div[2]' })).toBe(
+      "locator('xpath=/html[1]/body[1]/div[2]')"
+    );
+    // Prefixed unconditionally: `//` would work bare, but two spellings of the
+    // same thing is one more thing to get wrong.
+    expect(playwrightExpr({ kind: 'xpath', value: '//*[@id="t"]' })).toBe("locator('xpath=//*[@id=\"t\"]')");
+    // CSS is untouched.
+    expect(playwrightExpr({ kind: 'css', value: 'button.pay' })).toBe("locator('button.pay')");
+  });
+
   it('renders other frameworks as type: value', () => {
     expect(displayLocator({ kind: 'css', value: 'button.pay' }, 'selenium-java')).toBe('css: button.pay');
     expect(displayLocator({ kind: 'xpath', value: '//a[1]' }, 'puppeteer')).toBe('xpath: //a[1]');


### PR DESCRIPTION
Re-targeted at `v3-rewrite`. This is the fix #75 described; #75 itself went to `master` by mistake and is reverted by #76.

---

`page.locator('/html[1]/body[1]/div[2]')` throws:

```
Unexpected token "/" while parsing css selector "/html[1]/body[1]/div[2]". Did you mean to CSS.escape it?
```

Playwright infers XPath only from a leading `//` or `..`. The engine's fallback path (`xpathFor`, used whenever an element has no id) starts with a single `/`, so **every such element generated a broken locator** — in the model table and in the generated page object.

Fixed by emitting `locator('xpath=…')` unconditionally.

## Why the tests missed it

`tests/pw-builder.ts` adds `xpath=` itself, so the fidelity spec resolved the *IR* and never the string we emit. It now also evaluates `page.<generated expr>` against the real page. Reverting the one-line fix fails it on every fixture element:

```
login.html/nav-home: page.locator('/html[1]/body[1]/header[1]/nav[1]/a[1]') gave threw: Error: locator.count: Unexpected token "/" ...
```

## Also

CLAUDE.md now records the `--base v3-rewrite` requirement that caused #75.

## Verification

`npm test` green — 160 unit, 18 Playwright. Hand-check: model an element with no `id`, switch its locator to xpath, and the eye should still find it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)