### PR TITLE
v3: verify the generated Python

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,25 @@ The automation that does earn its place is the part hand-testing cannot repeat c
 spec re-runs 43 DOM edge cases against real Playwright on every change, and the extension E2E proves the
 built extension still loads before a manual session starts. Keep both green, but neither is the gate.
 
+### What is verified per target
+
+Two separate questions: does the locator find the element, and is the emitted code valid.
+
+| Target | Locator semantics | Generated code |
+|---|---|---|
+| Playwright TS | ✅ every expression resolved in real Playwright | ❌ nothing compiles it |
+| Puppeteer | ✅ real Puppeteer (`puppeteer.fidelity.spec.ts`) | ❌ |
+| Playwright Python | ✅ inherited — proven the mechanical transform of the TS spelling | ✅ `python3 -m ast` |
+| Selenium Python | ⚠️ strategy only | ✅ `python3 -m ast` |
+| Selenium Java | ⚠️ strategy only | ❌ needs `javac` + the selenium jar |
+| Selenium C# | ⚠️ strategy only | ❌ needs `dotnet` + Selenium.WebDriver |
+
+⚠️ **strategy only**: `tests/pw-builder.ts` resolves each `By` strategy as the equivalent CSS/XPath in
+real Playwright, so *which* strategy is right is checked. The spelling (`By.Name` / `By.NAME`) is
+constant tables under unit test, and the API (`SelectElement.SelectByText`) is unchecked.
+
+Toolchain-gated tests **skip loudly**, never silently.
+
 ## v2.5.1 is not the default
 
 The shipping code is 10-15 years old and carries decisions made for a browser landscape that no longer

--- a/v3/src/generators/selenium-csharp.ts
+++ b/v3/src/generators/selenium-csharp.ts
@@ -8,9 +8,9 @@ import type { LocatorCandidate } from '../engine/types';
 import { byParts, type ByKind } from './selenium';
 import { classify, isImage } from './classify';
 import { underscoreCamel } from './names';
+import { doubleQuoted } from '../quote';
 
-/** C# string literal: only `\` and `"` need escaping for our values. */
-const q = (value: string) => `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+const q = doubleQuoted;
 
 const BY: Record<ByKind, string> = {
   id: 'Id',
@@ -25,7 +25,7 @@ const BY: Record<ByKind, string> = {
 
 function by(c: LocatorCandidate): string {
   const parts = byParts(c);
-  return parts ? `By.${BY[parts.kind]}(${q(parts.value)})` : `/* ${c.kind} is not expressible in Selenium */`;
+  return parts ? `By.${BY[parts.kind]}(${q(parts.value)})` : `null /* ${c.kind} is not expressible in Selenium */`;
 }
 
 function banner(name: string): string {

--- a/v3/src/generators/selenium-java.ts
+++ b/v3/src/generators/selenium-java.ts
@@ -6,9 +6,9 @@ import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import type { LocatorCandidate } from '../engine/types';
 import { classify, isImage } from './classify';
 import { lowerCamel } from './names';
+import { doubleQuoted } from '../quote';
 
-/** Java string literal: only `\` and `"` need escaping for our values. */
-const q = (value: string) => `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+const q = doubleQuoted;
 
 function by(c: LocatorCandidate): string {
   switch (c.kind) {
@@ -30,8 +30,9 @@ function by(c: LocatorCandidate): string {
       return `By.xpath(${q(c.value)})`;
     default:
       // Selection only ever picks a type the framework can express (SPEC §7),
-      // so this is unreachable — but say so rather than emitting nothing.
-      return `/* ${c.kind} is not expressible in Selenium */`;
+      // so this is unreachable — but say so rather than emitting nothing, and
+      // keep it parseable: a syntax error names a column, not an element.
+      return `null /* ${c.kind} is not expressible in Selenium */`;
   }
 }
 

--- a/v3/src/generators/selenium-python.ts
+++ b/v3/src/generators/selenium-python.ts
@@ -8,9 +8,10 @@ import type { LocatorCandidate } from '../engine/types';
 import { byParts, type ByKind } from './selenium';
 import { classify, isImage } from './classify';
 import { snake, upperSnake } from './names';
+import { doubleQuoted } from '../quote';
 
-/** Python string literal, double-quoted (Black's default). */
-const q = (value: string) => `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+/** Double-quoted, Black's default. */
+const q = doubleQuoted;
 
 const BY: Record<ByKind, string> = {
   id: 'ID',
@@ -26,7 +27,7 @@ const BY: Record<ByKind, string> = {
 /** The `(By.X, "value")` pair — Python's locator is a tuple, not an object. */
 function byTuple(c: LocatorCandidate): string {
   const parts = byParts(c);
-  return parts ? `(By.${BY[parts.kind]}, ${q(parts.value)})` : `# ${c.kind} is not expressible in Selenium`;
+  return parts ? `(By.${BY[parts.kind]}, ${q(parts.value)})` : `None  # ${c.kind} is not expressible in Selenium`;
 }
 
 function find(c: LocatorCandidate): string {

--- a/v3/src/locators/display.ts
+++ b/v3/src/locators/display.ts
@@ -4,9 +4,10 @@
 // framework expression instead (SPEC §12) — `getByRole` takes a role AND a
 // name, so there is no single value to put after a colon.
 import type { LocatorCandidate } from '../engine/types';
+import { singleQuoted, doubleQuoted } from '../quote';
 
-const q = (s: string) => `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
-const qq = (s: string) => `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+const q = singleQuoted;
+const qq = doubleQuoted;
 
 /** The Playwright call this candidate becomes. */
 export function playwrightExpr(c: LocatorCandidate): string {

--- a/v3/src/quote.ts
+++ b/v3/src/quote.ts
@@ -1,0 +1,26 @@
+// String literals, for every language we generate.
+//
+// JavaScript, TypeScript, Java, C# and Python happen to agree on the escapes
+// that matter — a doubled backslash, the quote character, \n, \r, \t and
+// \uXXXX — so one implementation serves all five. Five near-copies is how one
+// of them ends up escaping less than the others.
+//
+// The newline is the one that bites: values reach here from the Edit dialog as
+// well as the engine, and a literal newline inside a single-line string is a
+// syntax error in all five languages.
+function body(value: string, quote: string): string {
+  return (
+    value
+      .replace(/\\/g, '\\\\')
+      .split(quote)
+      .join(`\\${quote}`)
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\t/g, '\\t')
+      // Anything else non-printable, spelled the way all five understand.
+      .replace(/[\u0000-\u001f\u007f]/g, (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`)
+  );
+}
+
+export const singleQuoted = (value: string) => `'${body(value, "'")}'`;
+export const doubleQuoted = (value: string) => `"${body(value, '"')}"`;

--- a/v3/tests/unit/fixtures/model.ts
+++ b/v3/tests/unit/fixtures/model.ts
@@ -58,3 +58,32 @@ export const HEADING: TestElement = {
   tag: 'h1',
   candidate: { kind: 'css', value: 'h1' },
 };
+
+// Playwright and Puppeteer cannot express `name` or `id` (SPEC §7), so a model
+// built from the Selenium fixtures above renders as garbage under them. Ask for
+// the right ones rather than remembering to.
+export const PW_EMAIL: TestElement = {
+  name: 'EmailAddress',
+  role: 'textbox',
+  tag: 'input',
+  candidate: { kind: 'label', text: 'Email address', exact: true },
+};
+export const PW_SIGN_IN: TestElement = {
+  name: 'SignIn',
+  role: 'button',
+  tag: 'button',
+  candidate: { kind: 'role', role: 'button', name: 'Sign in', exact: true },
+};
+export const CSS_ROW: TestElement = {
+  name: 'FirstRow',
+  role: null,
+  tag: 'div',
+  candidate: { kind: 'css', value: 'div.row' },
+};
+
+/** Elements the given framework can actually express. */
+export function elementsFor(frameworkId: string): TestElement[] {
+  if (frameworkId.startsWith('playwright')) return [PW_EMAIL, PW_SIGN_IN, HEADING];
+  if (frameworkId === 'puppeteer') return [CSS_ROW, HEADING];
+  return [EMAIL, SIGN_IN, HEADING];
+}

--- a/v3/tests/unit/generated-python.test.ts
+++ b/v3/tests/unit/generated-python.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { generatePlaywrightPythonPageObject, generatePlaywrightPythonLocators } from '../../src/generators/playwright-python';
+import { generateSeleniumPython, generateSeleniumPythonLocators } from '../../src/generators/selenium-python';
+import { playwrightExpr, playwrightPyExpr } from '../../src/locators/display';
+import { frameworkById } from '../../src/frameworks';
+import type { LocatorCandidate } from '../../src/engine/types';
+import { modelOf, EMAIL, SIGN_IN, COUNTRY, TOPPINGS, REMEMBER, LOGO, HEADING, PW_EMAIL, PW_SIGN_IN } from './fixtures/model';
+
+const hasPython = (() => {
+  try {
+    execFileSync('python3', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+/** Hand the source to Python's own parser. Syntax errors come back as errors. */
+function parses(source: string): true | string {
+  try {
+    execFileSync('python3', ['-c', 'import ast, sys; ast.parse(sys.stdin.read())'], {
+      input: source,
+      stdio: ['pipe', 'ignore', 'pipe'],
+      encoding: 'utf8',
+    });
+    return true;
+  } catch (e) {
+    const err = e as { stderr?: string };
+    return (err.stderr ?? String(e)).trim();
+  }
+}
+
+// Values that have broken a generator before, or plausibly could: quotes of
+// both kinds, a backslash, a newline in an accessible name, and a non-ASCII
+// character. Real pages have all of these.
+const NASTY = 'He said "hi" \\ it\'s\nthere — ✓';
+const shared = [
+  { name: 'Pathy', role: null, tag: 'div', candidate: { kind: 'xpath', value: '/html[1]/body[1]/div[2]' } as LocatorCandidate },
+  { name: 'Attrish', role: null, tag: 'a', candidate: { kind: 'css', value: `a[href="/x\\"${NASTY}"]` } as LocatorCandidate },
+];
+// Selection never hands Selenium a role candidate (SPEC §7), so the awkward
+// value reaches it through the strategies it does use.
+const nastySelenium = [
+  ...shared,
+  { name: 'Named', role: 'textbox', tag: 'input', candidate: { kind: 'name', value: NASTY } as LocatorCandidate },
+  { name: 'Linked', role: 'link', tag: 'a', candidate: { kind: 'linkText', text: NASTY } as LocatorCandidate },
+];
+const nastyPlaywright = [
+  ...shared,
+  { name: 'Quoted', role: 'button', tag: 'button', candidate: { kind: 'role', role: 'button', name: NASTY, exact: true } as LocatorCandidate },
+  { name: 'Labelled', role: 'textbox', tag: 'input', candidate: { kind: 'label', text: NASTY, exact: true } as LocatorCandidate },
+];
+
+describe.skipIf(!hasPython)('the generated Python is Python', () => {
+  const cases: Array<[string, string]> = [
+    ['playwright page object', generatePlaywrightPythonPageObject(modelOf('playwright-python', PW_EMAIL, PW_SIGN_IN, HEADING))],
+    ['playwright page object, empty', generatePlaywrightPythonPageObject(modelOf('playwright-python'))],
+    ['playwright locators', generatePlaywrightPythonLocators(modelOf('playwright-python', PW_EMAIL, PW_SIGN_IN))],
+    ['selenium methods', generateSeleniumPython(modelOf('selenium-python', EMAIL, SIGN_IN, COUNTRY, TOPPINGS, REMEMBER, LOGO, HEADING))],
+    ['selenium locators', generateSeleniumPythonLocators(modelOf('selenium-python', EMAIL, SIGN_IN))],
+    ['playwright page object, awkward values', generatePlaywrightPythonPageObject(modelOf('playwright-python', ...nastyPlaywright))],
+    ['selenium locators, awkward values', generateSeleniumPythonLocators(modelOf('selenium-python', ...nastySelenium))],
+    ['selenium methods, awkward values', generateSeleniumPython(modelOf('selenium-python', ...nastySelenium))],
+    ['playwright locators, awkward values', generatePlaywrightPythonLocators(modelOf('playwright-python', ...nastyPlaywright))],
+  ];
+
+  for (const [what, source] of cases) {
+    it(what, () => {
+      expect(parses(source), source).toBe(true);
+    });
+  }
+});
+
+if (!hasPython) {
+  // Silence is how an environment-gated test rots. Say it out loud instead.
+  it('python3 is not installed, so the Python output was not parsed', () => {
+    expect(hasPython).toBe(false);
+  });
+}
+
+// ---- Playwright Python against the Playwright TypeScript we do verify ----
+//
+// The TS expression is resolved in a real browser by the fidelity spec. The
+// Python one is the same API in snake_case, so proving it is the mechanical
+// transform of the TS one inherits that verification — and catches the failure
+// that actually threatens it, a wrong method name like get_by_alt for
+// getByAltText.
+const camel = (s: string) => s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+const method = (expr: string) => expr.slice(0, expr.indexOf('('));
+/** Every string literal in the expression, unescaped. */
+const literals = (expr: string, quote: "'" | '"') => {
+  const re = new RegExp(`${quote}((?:[^${quote}\\\\]|\\\\.)*)${quote}`, 'g');
+  return [...expr.matchAll(re)].map((m) => m[1].replace(/\\(.)/g, '$1'));
+};
+
+const SAMPLES: Record<string, LocatorCandidate> = {
+  testId: { kind: 'testId', value: 'submit' },
+  role: { kind: 'role', role: 'button', name: NASTY, exact: true },
+  label: { kind: 'label', text: 'Email address', exact: true },
+  placeholder: { kind: 'placeholder', text: 'Leave a comment', exact: true },
+  text: { kind: 'text', text: 'Create new account', exact: true },
+  altText: { kind: 'altText', text: 'Acme logo', exact: true },
+  title: { kind: 'title', text: 'Open help', exact: true },
+  css: { kind: 'css', value: 'a[href="/x"]' },
+  xpath: { kind: 'xpath', value: '/html[1]/body[1]' },
+};
+
+describe('the Playwright Python expression tracks the TypeScript one', () => {
+  it('covers every type Playwright offers', () => {
+    expect(Object.keys(SAMPLES).sort()).toEqual([...frameworkById('playwright-python').locatorTypes].sort());
+  });
+
+  for (const [kind, candidate] of Object.entries(SAMPLES)) {
+    it(`${kind}: same method, same arguments`, () => {
+      const ts = playwrightExpr(candidate);
+      const py = playwrightPyExpr(candidate);
+      expect(camel(method(py)), `${py} vs ${ts}`).toBe(method(ts));
+      expect(literals(py, '"')).toEqual(literals(ts, "'"));
+    });
+  }
+
+  it('says exact the Python way', () => {
+    expect(playwrightPyExpr(SAMPLES.label)).toContain('exact=True');
+    expect(playwrightPyExpr({ kind: 'label', text: 'Email' })).not.toContain('exact');
+  });
+});

--- a/v3/tests/unit/generators.test.ts
+++ b/v3/tests/unit/generators.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { canGenerate, generateCode, shapesFor } from '../../src/generators';
 import { frameworks } from '../../src/frameworks';
-import { modelOf, EMAIL, SIGN_IN } from './fixtures/model';
+import { modelOf, elementsFor, SIGN_IN } from './fixtures/model';
 
 describe('the generator registry', () => {
   it('covers every framework the toolbar offers', () => {
@@ -9,7 +9,11 @@ describe('the generator registry', () => {
     // that is not offered at all.
     for (const f of frameworks) {
       expect(canGenerate(f.id), f.label).toBe(true);
-      expect(generateCode(modelOf(f.id, EMAIL, SIGN_IN)), f.label).not.toBe('');
+      const code = generateCode(modelOf(f.id, ...elementsFor(f.id)));
+      expect(code, f.label).not.toBe('');
+      // `type: value` in generated code means a candidate the framework cannot
+      // express leaked through the display fallback.
+      expect(code, f.label).not.toMatch(/= \w+: /);
     }
   });
 


### PR DESCRIPTION
`python3` now parses every Python output — both generators, both shapes, empty models, and values carrying quotes, a backslash, a newline and non-ASCII.

## Two real bugs it found

1. **The "not expressible" fallback emitted a bare `# comment` as a value**, so the file didn't parse. It's unreachable by SPEC §7, but a syntax error names a column, not an element — now `None  # …`, and `null /* … */` in Java and C# for the same reason.
2. **A newline in any value broke the string literal in all five languages.** The four quoting helpers each escaped a slightly different set. `src/quote.ts` is now the only one: backslash, quote, `\n` `\r` `\t`, and any other control character as `\uXXXX` — spellings all five languages share. Values reach the generators from the Edit dialog as well as the engine, so this is reachable.

## Playwright Python inherits its semantics

Rather than re-proving it, the chain is: the TS expression is resolved in a real browser by the fidelity spec, and a table over **every** locator type asserts the Python one is its mechanical transform — same method after snake→camel, same string arguments. Verified non-vacuous: renaming `get_by_alt_text` to `get_by_alt` fails it.

## Also

Test fixtures gained `elementsFor(frameworkId)`. Half of them were handing Playwright a `name` candidate it can't express, so the registry smoke test was asserting *garbage* is non-empty. It now also rejects `type: value` leaking from the display fallback into generated code.

## Verification matrix, now in CLAUDE.md

| Target | Locator semantics | Generated code |
|---|---|---|
| Playwright TS | ✅ real Playwright | ❌ |
| Puppeteer | ✅ real Puppeteer | ❌ |
| Playwright Python | ✅ inherited | ✅ `ast` |
| Selenium Python | ⚠️ strategy only | ✅ `ast` |
| Selenium Java | ⚠️ strategy only | ❌ |
| Selenium C# | ⚠️ strategy only | ❌ |

Toolchain-gated tests skip loudly, never silently.

224 unit + 19 Playwright green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)