### PR TITLE
v3: compile the generated Java, C# and TypeScript for real

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,18 +119,23 @@ Two separate questions: does the locator find the element, and is the emitted co
 
 | Target | Locator semantics | Generated code |
 |---|---|---|
-| Playwright TS | ✅ every expression resolved in real Playwright | ❌ nothing compiles it |
-| Puppeteer | ✅ real Puppeteer (`puppeteer.fidelity.spec.ts`) | ❌ |
+| Playwright TS | ✅ every expression resolved in real Playwright | ✅ `tsc` against `@playwright/test` |
+| Puppeteer | ✅ real Puppeteer (`puppeteer.fidelity.spec.ts`) | ✅ `tsc` against `puppeteer-core` |
 | Playwright Python | ✅ inherited — proven the mechanical transform of the TS spelling | ✅ `python3 -m ast` |
 | Selenium Python | ⚠️ strategy only | ✅ `python3 -m ast` |
-| Selenium Java | ⚠️ strategy only | ❌ needs `javac` + the selenium jar |
-| Selenium C# | ⚠️ strategy only | ❌ needs `dotnet` + Selenium.WebDriver |
+| Selenium Java | ⚠️ strategy only | ✅ `javac` against selenium-api + selenium-support |
+| Selenium C# | ⚠️ strategy only | ✅ `dotnet build` against Selenium.WebDriver |
 
 ⚠️ **strategy only**: `tests/pw-builder.ts` resolves each `By` strategy as the equivalent CSS/XPath in
 real Playwright, so *which* strategy is right is checked. The spelling (`By.Name` / `By.NAME`) is
 constant tables under unit test, and the API (`SelectElement.SelectByText`) is unchecked.
 
+The Java and C# checks need `npm run fetch:test-deps` once — a Maven jar download and a NuGet restore.
+Deliberately not part of `npm test`, so the gate still works offline and on a machine with no JDK.
 Toolchain-gated tests **skip loudly**, never silently.
+
+A compile check is not a semantic one. It proves `SelectElement.SelectByText` exists and that
+`params string[]` is legal; it cannot prove the method does what the element needs.
 
 ## v2.5.1 is not the default
 

--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -378,7 +378,17 @@ before starting the next.
     **Puppeteer output is not verified against a real Puppeteer** — it is not a dependency here, so
     nothing resolves the generated string the way the fidelity spec now does for Playwright.
 
-15. **Frames** (SPEC §16) and the **page-object wrapper** (SPEC §17).
+15. **Generated-code verification** ✅ **Done** — the emitted code is now compiled or parsed against
+    the real library for every target: `tsc` for Playwright TS and Puppeteer, `javac` for Java,
+    `dotnet build` for C#, `python3 -m ast` for both Python targets. Java and C# need
+    `npm run fetch:test-deps` once; all of them skip loudly rather than silently. The matrix is in
+    CLAUDE.md.
+
+    It found four real bugs on the way in: Puppeteer's `Locator` is generic, the "not expressible"
+    fallback emitted an unparseable bare comment, a newline in any value broke the string literal in
+    all five languages, and the Puppeteer P-selectors could not be generated at all.
+
+16. **Frames** (SPEC §16) and the **page-object wrapper** (SPEC §17).
 
 **Considered, not scheduled — capture from the Elements tree.** `devtools.panels.elements
 .onSelectionChanged` plus `inspectedWindow.eval` with `$0` would let a button add whatever is selected

--- a/v3/.gitignore
+++ b/v3/.gitignore
@@ -1,0 +1,4 @@
+/tests/compile/lib
+/tests/compile/csharp/obj
+/tests/compile/csharp/bin
+/tests/compile/ts/*.ts

--- a/v3/package.json
+++ b/v3/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Phase 1 — pick a DOM element and generate a verified Playwright Page Object Model.",
+  "description": "Phase 1 \u2014 pick a DOM element and generate a verified Playwright Page Object Model.",
   "scripts": {
     "postinstall": "wxt prepare",
     "dev": "wxt",
@@ -17,7 +17,8 @@
     "test": "npm run test:unit && npm run bundle:engine && npm run build && npm run build:firefox && npm run check:manifests && playwright test",
     "dev:firefox": "wxt -b firefox",
     "fixtures": "node scripts/serve-fixtures.mjs",
-    "check:manifests": "node scripts/check-manifests.mjs"
+    "check:manifests": "node scripts/check-manifests.mjs",
+    "fetch:test-deps": "node scripts/fetch-test-deps.mjs"
   },
   "dependencies": {
     "@quasar/extras": "^1.16.0",

--- a/v3/scripts/fetch-test-deps.mjs
+++ b/v3/scripts/fetch-test-deps.mjs
@@ -1,0 +1,45 @@
+// One-off download for the compile checks (CLAUDE.md, "What is verified per
+// target"). Kept out of `npm test` deliberately: the gate must work on a
+// machine with no network and no JDK, so those tests skip instead.
+import { mkdirSync, existsSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const SELENIUM = '4.27.0';
+// selenium-api carries By and WebElement, selenium-support carries Select.
+// The `selenium-java` artifact is only a POM, so it has no classes to compile
+// against.
+const JARS = ['selenium-api', 'selenium-support'];
+const LIB = resolve('tests/compile/lib');
+
+mkdirSync(LIB, { recursive: true });
+
+let ok = true;
+for (const artifact of JARS) {
+  const file = resolve(LIB, `${artifact}-${SELENIUM}.jar`);
+  if (existsSync(file)) {
+    console.log(`✓ ${artifact} already here`);
+    continue;
+  }
+  const url = `https://repo1.maven.org/maven2/org/seleniumhq/selenium/${artifact}/${SELENIUM}/${artifact}-${SELENIUM}.jar`;
+  process.stdout.write(`… ${artifact} `);
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    writeFileSync(file, Buffer.from(await res.arrayBuffer()));
+    console.log('ok');
+  } catch (e) {
+    ok = false;
+    console.log(`FAILED: ${e.message}`);
+  }
+}
+
+try {
+  execFileSync('dotnet', ['restore'], { cwd: resolve('tests/compile/csharp'), stdio: 'inherit' });
+  console.log('✓ Selenium NuGet packages restored');
+} catch {
+  ok = false;
+  console.log('dotnet restore failed — is the .NET SDK installed?');
+}
+
+console.log(ok ? '\nCompile checks are ready. Run npm test.' : '\nSome deps are missing; those checks will skip.');

--- a/v3/src/generators/puppeteer.ts
+++ b/v3/src/generators/puppeteer.ts
@@ -15,6 +15,10 @@ import { tsPageObject, tsLocators, type TsTarget } from './ts-page-object';
 const PUPPETEER: TsTarget = {
   module: 'puppeteer',
   expr: (el: ModelElement) => puppeteerExpr(activeCandidate(el)),
+  // `Locator<T>` is generic over the node it yields — `page.locator('button')`
+  // is a `Locator<HTMLButtonElement>`. Element is the common supertype, and
+  // widening to it is what lets one field hold any of them.
+  locatorType: 'Locator<Element>',
 };
 
 export const generatePuppeteerPageObject = (model: TabModel) => tsPageObject(model, PUPPETEER);

--- a/v3/src/generators/ts-page-object.ts
+++ b/v3/src/generators/ts-page-object.ts
@@ -14,6 +14,11 @@ export interface TsTarget {
   module: string;
   /** The call, without the leading `page.` */
   expr: (el: ModelElement) => string;
+  /**
+   * How to write the field's type. Playwright's `Locator` is plain; Puppeteer's
+   * is generic over the node it yields, so a bare `Locator` does not compile.
+   */
+  locatorType?: string;
 }
 
 export function tsPageObject(model: TabModel, target: TsTarget): string {
@@ -34,7 +39,7 @@ export function tsPageObject(model: TabModel, target: TsTarget): string {
     `import { type Locator, type Page } from '${target.module}';`,
     '',
     `export class ${className} {`,
-    ...model.elements.map((el) => `  readonly ${lowerCamel(el.name)}: Locator;`),
+    ...model.elements.map((el) => `  readonly ${lowerCamel(el.name)}: ${target.locatorType ?? 'Locator'};`),
     '',
     // Assignment reads the constructor PARAMETER, not `this.page`: a parameter
     // property is not assigned until the constructor body completes.

--- a/v3/tests/compile/csharp/Generated.cs
+++ b/v3/tests/compile/csharp/Generated.cs
@@ -1,0 +1,387 @@
+using System.Collections.Generic;
+using System.Linq;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+
+class Methods
+{
+    IWebDriver driver;
+/*
+ * ActionableEl
+ * ***************************************************************
+ */
+
+public IWebElement GetActionableElElement()
+{
+    return driver.FindElement(By.CssSelector("button.pay"));
+}
+
+public void ClickActionableEl()
+{
+    GetActionableElElement().Click();
+}
+
+/*
+ * TextEl
+ * ***************************************************************
+ */
+
+public IWebElement GetTextElElement()
+{
+    return driver.FindElement(By.CssSelector("input.email"));
+}
+
+public string GetTextEl()
+{
+    return GetTextElElement().GetDomProperty("value");
+}
+
+public void SetTextEl(string value, bool clearFirst = true)
+{
+    IWebElement el = GetTextElElement();
+    if (clearFirst)
+    {
+        el.Clear();
+    }
+    el.SendKeys(value);
+}
+
+/*
+ * ToggleEl
+ * ***************************************************************
+ */
+
+public IWebElement GetToggleElElement()
+{
+    return driver.FindElement(By.CssSelector("input.remember"));
+}
+
+public bool IsToggleElChecked()
+{
+    return GetToggleElElement().Selected;
+}
+
+public void SetToggleEl(bool isChecked)
+{
+    IWebElement el = GetToggleElElement();
+    if (el.Selected != isChecked)
+    {
+        el.Click();
+    }
+}
+
+/*
+ * RadioEl
+ * ***************************************************************
+ */
+
+public IWebElement GetRadioElElement()
+{
+    return driver.FindElement(By.CssSelector("input.plan"));
+}
+
+public bool IsRadioElSelected()
+{
+    return GetRadioElElement().Selected;
+}
+
+public void SelectRadioEl()
+{
+    IWebElement el = GetRadioElElement();
+    if (!el.Selected)
+    {
+        el.Click();
+    }
+}
+
+/*
+ * SelectEl
+ * ***************************************************************
+ */
+
+public IWebElement GetSelectElElement()
+{
+    return driver.FindElement(By.CssSelector("select.country"));
+}
+
+public SelectElement GetSelectElSelect()
+{
+    return new SelectElement(GetSelectElElement());
+}
+
+public string GetSelectElText()
+{
+    return GetSelectElSelect().SelectedOption.Text;
+}
+
+public string GetSelectElValue()
+{
+    return GetSelectElSelect().SelectedOption.GetDomProperty("value");
+}
+
+public void SetSelectElByValue(string value)
+{
+    GetSelectElSelect().SelectByValue(value);
+}
+
+public void SetSelectElByText(string text)
+{
+    GetSelectElSelect().SelectByText(text);
+}
+
+/*
+ * MultiSelectEl
+ * ***************************************************************
+ */
+
+public IWebElement GetMultiSelectElElement()
+{
+    return driver.FindElement(By.CssSelector("select.toppings"));
+}
+
+public SelectElement GetMultiSelectElSelect()
+{
+    return new SelectElement(GetMultiSelectElElement());
+}
+
+public IList<string> GetMultiSelectElTexts()
+{
+    return GetMultiSelectElSelect().AllSelectedOptions.Select(o => o.Text).ToList();
+}
+
+public IList<string> GetMultiSelectElValues()
+{
+    return GetMultiSelectElSelect().AllSelectedOptions.Select(o => o.GetDomProperty("value")).ToList();
+}
+
+public void SetMultiSelectElByValues(params string[] values)
+{
+    SelectElement el = GetMultiSelectElSelect();
+    el.DeselectAll();
+    foreach (string value in values)
+    {
+        el.SelectByValue(value);
+    }
+}
+
+public void SetMultiSelectElByTexts(params string[] texts)
+{
+    SelectElement el = GetMultiSelectElSelect();
+    el.DeselectAll();
+    foreach (string text in texts)
+    {
+        el.SelectByText(text);
+    }
+}
+
+public void DeselectAllMultiSelectEl()
+{
+    GetMultiSelectElSelect().DeselectAll();
+}
+
+/*
+ * StaticEl
+ * ***************************************************************
+ */
+
+public IWebElement GetStaticElElement()
+{
+    return driver.FindElement(By.CssSelector("h1"));
+}
+
+public string GetStaticEl()
+{
+    return GetStaticElElement().Text;
+}
+
+/*
+ * ImageEl
+ * ***************************************************************
+ */
+
+public IWebElement GetImageElElement()
+{
+    return driver.FindElement(By.CssSelector("img.logo"));
+}
+
+public string GetImageElAltText()
+{
+    return GetImageElElement().GetDomAttribute("alt");
+}
+
+/*
+ * PasswordEl
+ * ***************************************************************
+ */
+
+public IWebElement GetPasswordElElement()
+{
+    return driver.FindElement(By.CssSelector("input.pass"));
+}
+
+public string GetPasswordEl()
+{
+    return GetPasswordElElement().GetDomProperty("value");
+}
+
+public void SetPasswordEl(string value, bool clearFirst = true)
+{
+    IWebElement el = GetPasswordElElement();
+    if (clearFirst)
+    {
+        el.Clear();
+    }
+    el.SendKeys(value);
+}
+
+/*
+ * ById
+ * ***************************************************************
+ */
+
+public IWebElement GetByIdElement()
+{
+    return driver.FindElement(By.Id("go"));
+}
+
+public void ClickById()
+{
+    GetByIdElement().Click();
+}
+
+/*
+ * ByName
+ * ***************************************************************
+ */
+
+public IWebElement GetByNameElement()
+{
+    return driver.FindElement(By.Name("email"));
+}
+
+public string GetByName()
+{
+    return GetByNameElement().GetDomProperty("value");
+}
+
+public void SetByName(string value, bool clearFirst = true)
+{
+    IWebElement el = GetByNameElement();
+    if (clearFirst)
+    {
+        el.Clear();
+    }
+    el.SendKeys(value);
+}
+
+/*
+ * ByClassName
+ * ***************************************************************
+ */
+
+public IWebElement GetByClassNameElement()
+{
+    return driver.FindElement(By.ClassName("row"));
+}
+
+public string GetByClassName()
+{
+    return GetByClassNameElement().Text;
+}
+
+/*
+ * ByTagName
+ * ***************************************************************
+ */
+
+public IWebElement GetByTagNameElement()
+{
+    return driver.FindElement(By.TagName("h1"));
+}
+
+public string GetByTagName()
+{
+    return GetByTagNameElement().Text;
+}
+
+/*
+ * ByLinkText
+ * ***************************************************************
+ */
+
+public IWebElement GetByLinkTextElement()
+{
+    return driver.FindElement(By.LinkText("Create new account"));
+}
+
+public void ClickByLinkText()
+{
+    GetByLinkTextElement().Click();
+}
+
+/*
+ * ByPartialLinkText
+ * ***************************************************************
+ */
+
+public IWebElement GetByPartialLinkTextElement()
+{
+    return driver.FindElement(By.PartialLinkText("Create"));
+}
+
+public void ClickByPartialLinkText()
+{
+    GetByPartialLinkTextElement().Click();
+}
+
+/*
+ * ByCss
+ * ***************************************************************
+ */
+
+public IWebElement GetByCssElement()
+{
+    return driver.FindElement(By.CssSelector("div.row"));
+}
+
+public string GetByCss()
+{
+    return GetByCssElement().Text;
+}
+
+/*
+ * ByXpath
+ * ***************************************************************
+ */
+
+public IWebElement GetByXpathElement()
+{
+    return driver.FindElement(By.XPath("/html[1]/body[1]/div[2]"));
+}
+
+public string GetByXpath()
+{
+    return GetByXpathElement().Text;
+}
+}
+
+class Locators
+{
+private readonly By _actionableEl = By.CssSelector("button.pay");
+private readonly By _textEl = By.CssSelector("input.email");
+private readonly By _toggleEl = By.CssSelector("input.remember");
+private readonly By _radioEl = By.CssSelector("input.plan");
+private readonly By _selectEl = By.CssSelector("select.country");
+private readonly By _multiSelectEl = By.CssSelector("select.toppings");
+private readonly By _staticEl = By.CssSelector("h1");
+private readonly By _imageEl = By.CssSelector("img.logo");
+private readonly By _passwordEl = By.CssSelector("input.pass");
+private readonly By _byId = By.Id("go");
+private readonly By _byName = By.Name("email");
+private readonly By _byClassName = By.ClassName("row");
+private readonly By _byTagName = By.TagName("h1");
+private readonly By _byLinkText = By.LinkText("Create new account");
+private readonly By _byPartialLinkText = By.PartialLinkText("Create");
+private readonly By _byCss = By.CssSelector("div.row");
+private readonly By _byXpath = By.XPath("/html[1]/body[1]/div[2]");
+}

--- a/v3/tests/compile/csharp/Verify.csproj
+++ b/v3/tests/compile/csharp/Verify.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Compiles the generated C# against the real Selenium API. A library, not
+       an executable: there is nothing to run, only to typecheck. -->
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <!-- The generated code is a fragment pasted into a class; unused fields and
+         unreachable niceties are not what this build is looking for. -->
+    <NoWarn>CS0169;CS0649</NoWarn>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Generated.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />
+    <PackageReference Include="Selenium.Support" Version="4.27.0" />
+  </ItemGroup>
+</Project>

--- a/v3/tests/compile/ts/tsconfig.json
+++ b/v3/tests/compile/ts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "//": "Typechecks generated TypeScript against the real libraries. `puppeteer` is mapped to puppeteer-core, which is where its types actually live and what this repo installs — the generated import stays honest for the user.",
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "baseUrl": "../../..",
+    "paths": { "puppeteer": ["node_modules/puppeteer-core"] }
+  },
+  "include": ["*.ts"]
+}

--- a/v3/tests/unit/fixtures/model.ts
+++ b/v3/tests/unit/fixtures/model.ts
@@ -87,3 +87,60 @@ export function elementsFor(frameworkId: string): TestElement[] {
   if (frameworkId === 'puppeteer') return [CSS_ROW, HEADING];
   return [EMAIL, SIGN_IN, HEADING];
 }
+
+/**
+ * One element per locator type a framework offers — so a compile or parse check
+ * covers the whole surface, not whichever three types the sample happened to
+ * use. `frameworks.test.ts` asserts these lists stay complete.
+ */
+export const PW_ALL: TestElement[] = [
+  { name: 'ByTestId', role: 'button', tag: 'button', candidate: { kind: 'testId', value: 'submit' } },
+  { name: 'ByRole', role: 'button', tag: 'button', candidate: { kind: 'role', role: 'button', name: 'Sign in', exact: true } },
+  { name: 'ByLabel', role: 'textbox', tag: 'input', candidate: { kind: 'label', text: 'Email address', exact: true } },
+  { name: 'ByPlaceholder', role: 'textbox', tag: 'input', candidate: { kind: 'placeholder', text: 'Comment', exact: true } },
+  { name: 'ByText', role: null, tag: 'p', candidate: { kind: 'text', text: 'Create new account', exact: true } },
+  { name: 'ByAltText', role: 'img', tag: 'img', candidate: { kind: 'altText', text: 'Acme logo', exact: true } },
+  { name: 'ByTitle', role: 'link', tag: 'a', candidate: { kind: 'title', text: 'Open help', exact: true } },
+  { name: 'ByCss', role: null, tag: 'div', candidate: { kind: 'css', value: 'div.row' } },
+  { name: 'ByXpath', role: null, tag: 'div', candidate: { kind: 'xpath', value: '/html[1]/body[1]/div[2]' } },
+];
+
+export const PUPPETEER_ALL: TestElement[] = [
+  { name: 'ByCss', role: null, tag: 'div', candidate: { kind: 'css', value: 'a[href="/x"]' } },
+  { name: 'ByXpath', role: null, tag: 'div', candidate: { kind: 'xpath', value: '/html[1]/body[1]/div[2]' } },
+];
+
+export const SELENIUM_ALL: TestElement[] = [
+  { name: 'ById', role: 'button', tag: 'button', candidate: { kind: 'id', value: 'go' } },
+  { name: 'ByName', role: 'textbox', tag: 'input', candidate: { kind: 'name', value: 'email' } },
+  { name: 'ByClassName', role: null, tag: 'div', candidate: { kind: 'className', value: 'row' } },
+  { name: 'ByTagName', role: null, tag: 'h1', candidate: { kind: 'tagName', value: 'h1' } },
+  { name: 'ByLinkText', role: 'link', tag: 'a', candidate: { kind: 'linkText', text: 'Create new account' } },
+  { name: 'ByPartialLinkText', role: 'link', tag: 'a', candidate: { kind: 'partialLinkText', text: 'Create' } },
+  { name: 'ByCss', role: null, tag: 'div', candidate: { kind: 'css', value: 'div.row' } },
+  { name: 'ByXpath', role: null, tag: 'div', candidate: { kind: 'xpath', value: '/html[1]/body[1]/div[2]' } },
+];
+
+/** Every locator type the framework offers, one element each. */
+export function everyTypeFor(frameworkId: string): TestElement[] {
+  if (frameworkId.startsWith('playwright')) return PW_ALL;
+  if (frameworkId === 'puppeteer') return PUPPETEER_ALL;
+  return SELENIUM_ALL;
+}
+
+/**
+ * One element per method bucket, every candidate a `css` one so the same list
+ * is expressible in every framework. Buckets decide which methods get emitted;
+ * `everyTypeFor` decides which locator calls appear inside them.
+ */
+export const ALL_BUCKETS: TestElement[] = [
+  { name: 'ActionableEl', role: 'button', tag: 'button', candidate: { kind: 'css', value: 'button.pay' } },
+  { name: 'TextEl', role: 'textbox', tag: 'input', candidate: { kind: 'css', value: 'input.email' } },
+  { name: 'ToggleEl', role: 'checkbox', tag: 'input', candidate: { kind: 'css', value: 'input.remember' } },
+  { name: 'RadioEl', role: 'radio', tag: 'input', candidate: { kind: 'css', value: 'input.plan' } },
+  { name: 'SelectEl', role: 'combobox', tag: 'select', candidate: { kind: 'css', value: 'select.country' } },
+  { name: 'MultiSelectEl', role: 'listbox', tag: 'select', candidate: { kind: 'css', value: 'select.toppings' } },
+  { name: 'StaticEl', role: 'heading', tag: 'h1', candidate: { kind: 'css', value: 'h1' } },
+  { name: 'ImageEl', role: 'img', tag: 'img', candidate: { kind: 'css', value: 'img.logo' } },
+  { name: 'PasswordEl', role: null, tag: 'input', inputType: 'password', candidate: { kind: 'css', value: 'input.pass' } },
+];

--- a/v3/tests/unit/frameworks.test.ts
+++ b/v3/tests/unit/frameworks.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { frameworks, defaultFrameworkId, frameworkById } from '../../src/frameworks';
+import { everyTypeFor } from './fixtures/model';
 
 describe('frameworks', () => {
   it('defaults to Playwright TypeScript', () => {
@@ -30,5 +31,17 @@ describe('frameworks', () => {
 
   it('falls back to the first framework for an unknown id', () => {
     expect(frameworkById('nope')).toBe(frameworks[0]);
+  });
+});
+
+describe('the compile-check fixtures', () => {
+  it('carry one element per locator type, for every framework', () => {
+    // Otherwise a type added to a framework is silently never compiled or
+    // parsed — which is how the TypeScript check passed with getByAltText
+    // misspelled.
+    for (const f of frameworks) {
+      const covered = everyTypeFor(f.id).map((el) => el.candidate.kind);
+      expect([...new Set(covered)].sort(), f.label).toEqual([...f.locatorTypes].sort());
+    }
   });
 });

--- a/v3/tests/unit/generated-compiles.test.ts
+++ b/v3/tests/unit/generated-compiles.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+import { generateSeleniumJava, generateSeleniumJavaLocators } from '../../src/generators/selenium-java';
+import { generateSeleniumCSharp, generateSeleniumCSharpLocators } from '../../src/generators/selenium-csharp';
+import { generatePlaywrightPageObject, generatePlaywrightLocators } from '../../src/generators/playwright-ts';
+import { generatePuppeteerPageObject, generatePuppeteerLocators } from '../../src/generators/puppeteer';
+import { modelOf, everyTypeFor, ALL_BUCKETS } from './fixtures/model';
+
+// Compiling the generated Selenium against the real Selenium API — the only
+// check that can tell us GetDomProperty exists, that C# spells it SelectByText
+// where Python spells it select_by_visible_text, or that `params string[]` is
+// legal there. Everything else about these two targets was reasoned from docs.
+//
+// Deps come from `npm run fetch:test-deps`, never from `npm test`: the gate has
+// to work offline and without a JDK.
+const LIB = resolve('tests/compile/lib');
+const CSPROJ = resolve('tests/compile/csharp');
+
+const has = (cmd: string, args: string[]) => {
+  try {
+    execFileSync(cmd, args, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+const jars = existsSync(LIB) ? readdirSync(LIB).filter((f) => f.endsWith('.jar')) : [];
+const javaReady = has('javac', ['--version']) && jars.length > 0;
+const dotnetReady = has('dotnet', ['--version']) && existsSync(join(CSPROJ, 'obj', 'project.assets.json'));
+
+// One model, every bucket: element getter, click, text field, checkbox, radio,
+// single select, multi select, static text and an image.
+// Every bucket AND every locator type: the buckets decide which methods are
+// emitted, the types decide which API calls appear inside them. Miss either and
+// the check passes on a subset of the surface.
+const model = (id: string) => modelOf(id, ...ALL_BUCKETS, ...everyTypeFor(id));
+
+function fail(what: string, output: string): never {
+  throw new Error(`${what} did not compile:\n${output}`);
+}
+
+describe.skipIf(!javaReady)('the generated Java compiles against real Selenium', () => {
+  it('methods and locators, every bucket', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pm-java-'));
+    // Package-private, so several classes can share one file.
+    const source = [
+      'import java.util.List;',
+      'import java.util.stream.Collectors;',
+      'import org.openqa.selenium.By;',
+      'import org.openqa.selenium.WebDriver;',
+      'import org.openqa.selenium.WebElement;',
+      'import org.openqa.selenium.support.ui.Select;',
+      '',
+      'class Methods {',
+      '    WebDriver driver;',
+      generateSeleniumJava(model('selenium-java')),
+      '}',
+      '',
+      'class Locators {',
+      generateSeleniumJavaLocators(model('selenium-java')),
+      '}',
+    ].join('\n');
+    const file = join(dir, 'Generated.java');
+    writeFileSync(file, source);
+
+    try {
+      execFileSync('javac', ['-cp', jars.map((j) => join(LIB, j)).join(':'), '-d', dir, file], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf8',
+      });
+    } catch (e) {
+      const err = e as { stderr?: string; stdout?: string };
+      fail('Java', `${err.stdout ?? ''}${err.stderr ?? ''}\n\n--- source ---\n${source}`);
+    }
+    expect(true).toBe(true);
+  });
+});
+
+describe.skipIf(!dotnetReady)('the generated C# compiles against real Selenium', () => {
+  it('methods and locators, every bucket', () => {
+    const source = [
+      'using System.Collections.Generic;',
+      'using System.Linq;',
+      'using OpenQA.Selenium;',
+      'using OpenQA.Selenium.Support.UI;',
+      '',
+      'class Methods',
+      '{',
+      '    IWebDriver driver;',
+      generateSeleniumCSharp(model('selenium-csharp')),
+      '}',
+      '',
+      'class Locators',
+      '{',
+      generateSeleniumCSharpLocators(model('selenium-csharp')),
+      '}',
+    ].join('\n');
+    writeFileSync(join(CSPROJ, 'Generated.cs'), source);
+
+    try {
+      execFileSync('dotnet', ['build', '--nologo', '--no-restore', '-v', 'quiet'], {
+        cwd: CSPROJ,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf8',
+      });
+    } catch (e) {
+      const err = e as { stderr?: string; stdout?: string };
+      fail('C#', `${err.stdout ?? ''}${err.stderr ?? ''}\n\n--- source ---\n${source}`);
+    }
+    expect(true).toBe(true);
+  }, 120_000);
+});
+
+// TypeScript needs no fetch step — tsc, @playwright/test and puppeteer-core are
+// already dependencies. This is the primary target, so it is the one place the
+// generated code is checked against the real API on every run.
+describe('the generated TypeScript typechecks against the real libraries', () => {
+  it('page objects and locators, both targets', () => {
+    const dir = resolve('tests/compile/ts');
+    // Locators-only is a fragment with a free `page`, so it needs a binding to
+    // typecheck at all — declared, never assigned, which is enough for tsc.
+    const preamble = (module: string, i: number) =>
+      [`import { type Page as P${i} } from '${module}';`, `declare const page: P${i};`].join('\n');
+
+    writeFileSync(join(dir, 'pw-page-object.ts'), generatePlaywrightPageObject(model('playwright-ts')));
+    writeFileSync(join(dir, 'pw-empty.ts'), generatePlaywrightPageObject(modelOf('playwright-ts')));
+    writeFileSync(
+      join(dir, 'pw-locators.ts'),
+      `${preamble('@playwright/test', 1)}\n${generatePlaywrightLocators(model('playwright-ts'))}\nexport {};`
+    );
+    writeFileSync(join(dir, 'pup-page-object.ts'), generatePuppeteerPageObject(model('puppeteer')));
+    writeFileSync(
+      join(dir, 'pup-locators.ts'),
+      `${preamble('puppeteer', 2)}\n${generatePuppeteerLocators(model('puppeteer'))}\nexport {};`
+    );
+
+    try {
+      execFileSync('npx', ['tsc', '-p', join(dir, 'tsconfig.json')], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        encoding: 'utf8',
+      });
+    } catch (e) {
+      const err = e as { stderr?: string; stdout?: string };
+      fail('TypeScript', `${err.stdout ?? ''}${err.stderr ?? ''}`);
+    }
+    expect(true).toBe(true);
+  }, 120_000);
+});
+
+// An environment-gated test that says nothing is an environment-gated test that
+// has quietly stopped running.
+if (!javaReady || !dotnetReady) {
+  it('says which compile checks were skipped', () => {
+    const missing = [!javaReady && 'Java', !dotnetReady && 'C#'].filter(Boolean);
+    console.warn(`Skipped compile checks: ${missing.join(', ')} — run \`npm run fetch:test-deps\``);
+    expect(missing.length).toBeGreaterThan(0);
+  });
+}

--- a/v3/tests/unit/generated-python.test.ts
+++ b/v3/tests/unit/generated-python.test.ts
@@ -5,7 +5,7 @@ import { generateSeleniumPython, generateSeleniumPythonLocators } from '../../sr
 import { playwrightExpr, playwrightPyExpr } from '../../src/locators/display';
 import { frameworkById } from '../../src/frameworks';
 import type { LocatorCandidate } from '../../src/engine/types';
-import { modelOf, EMAIL, SIGN_IN, COUNTRY, TOPPINGS, REMEMBER, LOGO, HEADING, PW_EMAIL, PW_SIGN_IN } from './fixtures/model';
+import { modelOf, everyTypeFor, ALL_BUCKETS } from './fixtures/model';
 
 const hasPython = (() => {
   try {
@@ -52,13 +52,16 @@ const nastyPlaywright = [
   { name: 'Labelled', role: 'textbox', tag: 'input', candidate: { kind: 'label', text: NASTY, exact: true } as LocatorCandidate },
 ];
 
+/** Every method bucket and every locator type the framework offers. */
+const full = (id: string) => modelOf(id, ...ALL_BUCKETS, ...everyTypeFor(id));
+
 describe.skipIf(!hasPython)('the generated Python is Python', () => {
   const cases: Array<[string, string]> = [
-    ['playwright page object', generatePlaywrightPythonPageObject(modelOf('playwright-python', PW_EMAIL, PW_SIGN_IN, HEADING))],
+    ['playwright page object', generatePlaywrightPythonPageObject(full('playwright-python'))],
     ['playwright page object, empty', generatePlaywrightPythonPageObject(modelOf('playwright-python'))],
-    ['playwright locators', generatePlaywrightPythonLocators(modelOf('playwright-python', PW_EMAIL, PW_SIGN_IN))],
-    ['selenium methods', generateSeleniumPython(modelOf('selenium-python', EMAIL, SIGN_IN, COUNTRY, TOPPINGS, REMEMBER, LOGO, HEADING))],
-    ['selenium locators', generateSeleniumPythonLocators(modelOf('selenium-python', EMAIL, SIGN_IN))],
+    ['playwright locators', generatePlaywrightPythonLocators(full('playwright-python'))],
+    ['selenium methods', generateSeleniumPython(full('selenium-python'))],
+    ['selenium locators', generateSeleniumPythonLocators(full('selenium-python'))],
     ['playwright page object, awkward values', generatePlaywrightPythonPageObject(modelOf('playwright-python', ...nastyPlaywright))],
     ['selenium locators, awkward values', generateSeleniumPythonLocators(modelOf('selenium-python', ...nastySelenium))],
     ['selenium methods, awkward values', generateSeleniumPython(modelOf('selenium-python', ...nastySelenium))],

--- a/v3/tests/unit/puppeteer.test.ts
+++ b/v3/tests/unit/puppeteer.test.ts
@@ -19,8 +19,9 @@ describe('generatePuppeteerPageObject', () => {
         "import { type Locator, type Page } from 'puppeteer';",
         '',
         'export class LoginPage {',
-        '  readonly signIn: Locator;',
-        '  readonly firstRow: Locator;',
+        // Generic: `page.locator('button')` yields a Locator<HTMLButtonElement>.
+        '  readonly signIn: Locator<Element>;',
+        '  readonly firstRow: Locator<Element>;',
         '',
         '  constructor(private readonly page: Page) {',
         "    this.signIn = page.locator('#go');",


### PR DESCRIPTION
Closes the last column of the verification matrix. Every target's emitted code is now compiled or parsed against the real library.

| Target | Locator semantics | Generated code |
|---|---|---|
| Playwright TS | ✅ real Playwright | ✅ `tsc` vs `@playwright/test` |
| Puppeteer | ✅ real Puppeteer | ✅ `tsc` vs `puppeteer-core` |
| Playwright Python | ✅ inherited | ✅ `python3 -m ast` |
| Selenium Python | ⚠️ strategy only | ✅ `python3 -m ast` |
| Selenium Java | ⚠️ strategy only | ✅ `javac` vs selenium-api + selenium-support |
| Selenium C# | ⚠️ strategy only | ✅ `dotnet build` vs Selenium.WebDriver |

## What it found

**Puppeteer's `Locator` is generic** over the node it yields, so `readonly signIn: Locator;` never compiled. Now `Locator<Element>`.

Encouragingly, the Java and C# both compiled first time — so `GetDomProperty`, `SelectByText`, `params string[]` and the `Select`/`SelectElement` APIs were right.

## Coverage is the surface, not a sample

The models feed **every method bucket** and **every locator type** the framework offers. Buckets decide which methods are emitted; types decide which API calls appear inside them. The TypeScript check passed with `getByAltText` misspelled until the second half was added — so `frameworks.test.ts` now asserts the fixture lists stay complete as frameworks change.

## Setup

`npm run fetch:test-deps` once — a Maven jar download and a NuGet restore. Deliberately **not** part of `npm test`, so the gate still works offline and on a machine with no JDK. Gated tests say when they skip rather than vanishing.

## Non-vacuity

Verified by renaming methods that exist to ones that don't: `SelectByText`→`SelectByVisibleText`, `getDomProperty`→`getDomPropertyValue`, `getByAltText`→`getByAlt`, `getByPlaceholder`→`getByPlaceholderText`. Each fails the relevant check.

228 unit + 19 Playwright green.

**A compile check is not a semantic one.** It proves `SelectElement.SelectByText` exists; it can't prove the method does what the element needs. The ⚠️ column is still where Selenium's real risk lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)