### PR TITLE
v3: add the Selenium page-object shape

### DIFF
--- a/docs/v3/REWRITE-PLAN.md
+++ b/docs/v3/REWRITE-PLAN.md
@@ -388,7 +388,11 @@ before starting the next.
     fallback emitted an unparseable bare comment, a newline in any value broke the string literal in
     all five languages, and the Puppeteer P-selectors could not be generated at all.
 
-16. **Frames** (SPEC §16) and the **page-object wrapper** (SPEC §17).
+16. **Selenium page-object wrapper** (SPEC §17) ✅ **Done** — a third shape for all three Selenium
+    languages, imports computed from the buckets present, covered by the compile checks. Python needed
+    a receiver-aware generator rather than a wrapper. Awaiting hand-test.
+
+17. **Frames** (SPEC §16) — the last of the specced behaviour.
 
 **Considered, not scheduled — capture from the Elements tree.** `devtools.panels.elements
 .onSelectionChanged` plus `inspectedWindow.eval` with `$0` would let a button add whatever is selected

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -706,10 +706,16 @@ Nested frames extend the chain — one `switchTo().frame()` per level, outermost
 
 ## 17. Selenium page-object wrapper
 
-The shape selector is built (§11), and Playwright's default shape is already a full page object. What is
-left is a **third Selenium shape** — Methods · Page object · Locators only — wrapping the methods in a
-class declaration, imports, and a constructor taking the `driver` they currently reference bare.
-**[inferred]**
+A third Selenium shape — **Methods** (default) · Page object · Locators only. Imports, a class
+declaration, and a constructor taking the `driver` the methods otherwise reference bare. **[settled]**
+
+Imports are computed from the buckets present: `Select` only when there is a select, `List` and
+`Collectors` only when there is a multi-select. Unused imports are legal and are also the first thing a
+reviewer notices.
+
+**Python is not a wrapper.** Java and C# have an implicit receiver, so the fragment drops into a class
+unchanged. Python does not: every definition gains `self` and every call site a `self.` prefix, so the
+generator is receiver-aware rather than wrapped. **[settled]**
 
 Class name is derived as it is for Playwright (§12). Making it an **editable field** in the dialog is
 the obvious next step and is not built. **[open]**

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -304,6 +304,9 @@ The same locators, arranged the way that framework's users arrange them. The dia
 its framework has; the first is the default. Shape is a dialog-local choice — it does not touch the
 model.
 
+The selector sits on **its own row** under the title, spread across the width. In the sidebar there is
+no width to share: three shapes plus Copy beside the title truncated it to *Seleniu…*. **[settled]**
+
 | Framework | Shapes |
 |---|---|
 | Selenium — Java, C#, Python | **Methods** (default) · Locators only |

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -304,8 +304,10 @@ The same locators, arranged the way that framework's users arrange them. The dia
 its framework has; the first is the default. Shape is a dialog-local choice — it does not touch the
 model.
 
-The selector sits on **its own row** under the title, spread across the width. In the sidebar there is
-no width to share: three shapes plus Copy beside the title truncated it to *Seleniu…*. **[settled]**
+The selector sits on **its own row** under the title, left-aligned, taking the width it needs up to a
+cap. In the sidebar there is no width to share — three shapes plus Copy beside the title truncated it to
+*Seleniu…* — and at DevTools width a full-bleed segmented control reads as a banner rather than a
+choice. **[settled]**
 
 | Framework | Shapes |
 |---|---|

--- a/v3/.gitignore
+++ b/v3/.gitignore
@@ -2,3 +2,5 @@
 /tests/compile/csharp/obj
 /tests/compile/csharp/bin
 /tests/compile/ts/*.ts
+/tests/compile/csharp/Generated.cs
+/tests/compile/csharp/GeneratedPageObject.cs

--- a/v3/src/generators/index.ts
+++ b/v3/src/generators/index.ts
@@ -11,9 +11,9 @@ import { frameworkById } from '../frameworks';
 import type { TabModel } from '../model';
 import { generatePlaywrightPageObject, generatePlaywrightLocators } from './playwright-ts';
 import { generatePlaywrightPythonPageObject, generatePlaywrightPythonLocators } from './playwright-python';
-import { generateSeleniumJava, generateSeleniumJavaLocators } from './selenium-java';
-import { generateSeleniumCSharp, generateSeleniumCSharpLocators } from './selenium-csharp';
-import { generateSeleniumPython, generateSeleniumPythonLocators } from './selenium-python';
+import { generateSeleniumJava, generateSeleniumJavaLocators, generateSeleniumJavaPageObject } from './selenium-java';
+import { generateSeleniumCSharp, generateSeleniumCSharpLocators, generateSeleniumCSharpPageObject } from './selenium-csharp';
+import { generateSeleniumPython, generateSeleniumPythonLocators, generateSeleniumPythonPageObject } from './selenium-python';
 import { generatePuppeteerPageObject, generatePuppeteerLocators } from './puppeteer';
 
 export interface OutputShape {
@@ -33,9 +33,23 @@ const locators = (generate: OutputShape['generate']): OutputShape => ({ id: 'loc
 const SHAPES: Record<string, readonly OutputShape[]> = {
   'playwright-ts': [pageObject(generatePlaywrightPageObject), locators(generatePlaywrightLocators)],
   'playwright-python': [pageObject(generatePlaywrightPythonPageObject), locators(generatePlaywrightPythonLocators)],
-  'selenium-java': [methods(generateSeleniumJava), locators(generateSeleniumJavaLocators)],
-  'selenium-csharp': [methods(generateSeleniumCSharp), locators(generateSeleniumCSharpLocators)],
-  'selenium-python': [methods(generateSeleniumPython), locators(generateSeleniumPythonLocators)],
+  // Methods stays the default: it is what v2.5.1 produced, and the wrapper is
+  // only useful once you have settled on a class per page.
+  'selenium-java': [
+    methods(generateSeleniumJava),
+    pageObject(generateSeleniumJavaPageObject),
+    locators(generateSeleniumJavaLocators),
+  ],
+  'selenium-csharp': [
+    methods(generateSeleniumCSharp),
+    pageObject(generateSeleniumCSharpPageObject),
+    locators(generateSeleniumCSharpLocators),
+  ],
+  'selenium-python': [
+    methods(generateSeleniumPython),
+    pageObject(generateSeleniumPythonPageObject),
+    locators(generateSeleniumPythonLocators),
+  ],
   'puppeteer': [pageObject(generatePuppeteerPageObject), locators(generatePuppeteerLocators)],
 };
 

--- a/v3/src/generators/selenium-csharp.ts
+++ b/v3/src/generators/selenium-csharp.ts
@@ -9,6 +9,7 @@ import { byParts, type ByKind } from './selenium';
 import { classify, isImage } from './classify';
 import { underscoreCamel } from './names';
 import { doubleQuoted } from '../quote';
+import { classNameFor } from './class-name';
 
 const q = doubleQuoted;
 
@@ -111,4 +112,43 @@ export function generateSeleniumCSharpLocators(model: TabModel): string {
 
 export function generateSeleniumCSharp(model: TabModel): string {
   return model.elements.map((el) => [banner(el.name), ...methods(el)].join('\n\n')).join('\n\n');
+}
+
+/** The methods with a class around them (SPEC §17). */
+export function generateSeleniumCSharpPageObject(model: TabModel): string {
+  const buckets = new Set(model.elements.map(classify));
+  const usings = [
+    ...(buckets.has('multiSelect') ? ['System.Collections.Generic', 'System.Linq'] : []),
+    'OpenQA.Selenium',
+    ...(buckets.has('select') || buckets.has('multiSelect') ? ['OpenQA.Selenium.Support.UI'] : []),
+  ];
+  const className = classNameFor(model.url);
+
+  return [
+    ...usings.map((u) => `using ${u};`),
+    '',
+    `public class ${className}`,
+    '{',
+    '    private readonly IWebDriver driver;',
+    '',
+    `    public ${className}(IWebDriver driver)`,
+    '    {',
+    '        this.driver = driver;',
+    '    }',
+    ...model.elements.flatMap((el) => [
+      '',
+      indent(banner(el.name)),
+      ...methods(el).map(indent).join('\n\n').split('\n'),
+    ]),
+    '}',
+    '',
+  ].join('\n');
+}
+
+/** Four spaces onto every non-blank line, so the fragment sits inside a class. */
+function indent(block: string): string {
+  return block
+    .split('\n')
+    .map((line) => (line ? `    ${line}` : line))
+    .join('\n');
 }

--- a/v3/src/generators/selenium-java.ts
+++ b/v3/src/generators/selenium-java.ts
@@ -7,6 +7,7 @@ import type { LocatorCandidate } from '../engine/types';
 import { classify, isImage } from './classify';
 import { lowerCamel } from './names';
 import { doubleQuoted } from '../quote';
+import { classNameFor } from './class-name';
 
 const q = doubleQuoted;
 
@@ -133,4 +134,49 @@ export function generateSeleniumJavaLocators(model: TabModel): string {
 
 export function generateSeleniumJava(model: TabModel): string {
   return model.elements.map((el) => [banner(el.name), ...methods(el)].join('\n\n')).join('\n\n');
+}
+
+/**
+ * The methods with a class around them (SPEC §17): imports, a declaration, and
+ * a constructor taking the `driver` they otherwise reference bare.
+ *
+ * Imports are computed from what the model actually contains. An unused import
+ * is legal and harmless, but it is also the first thing a reviewer notices.
+ */
+export function generateSeleniumJavaPageObject(model: TabModel): string {
+  const buckets = new Set(model.elements.map(classify));
+  const imports = [
+    ...(buckets.has('multiSelect') ? ['java.util.List', 'java.util.stream.Collectors'] : []),
+    'org.openqa.selenium.By',
+    'org.openqa.selenium.WebDriver',
+    'org.openqa.selenium.WebElement',
+    ...(buckets.has('select') || buckets.has('multiSelect') ? ['org.openqa.selenium.support.ui.Select'] : []),
+  ];
+  const className = classNameFor(model.url);
+
+  return [
+    ...imports.map((i) => `import ${i};`),
+    '',
+    `public class ${className} {`,
+    '    private final WebDriver driver;',
+    '',
+    `    public ${className}(WebDriver driver) {`,
+    '        this.driver = driver;',
+    '    }',
+    ...model.elements.flatMap((el) => [
+      '',
+      indent(banner(el.name)),
+      ...methods(el).map(indent).join('\n\n').split('\n'),
+    ]),
+    '}',
+    '',
+  ].join('\n');
+}
+
+/** Four spaces onto every non-blank line, so the fragment sits inside a class. */
+function indent(block: string): string {
+  return block
+    .split('\n')
+    .map((line) => (line ? `    ${line}` : line))
+    .join('\n');
 }

--- a/v3/src/generators/selenium-python.ts
+++ b/v3/src/generators/selenium-python.ts
@@ -9,6 +9,7 @@ import { byParts, type ByKind } from './selenium';
 import { classify, isImage } from './classify';
 import { snake, upperSnake } from './names';
 import { doubleQuoted } from '../quote';
+import { classNameFor } from './class-name';
 
 /** Double-quoted, Black's default. */
 const q = doubleQuoted;
@@ -30,9 +31,9 @@ function byTuple(c: LocatorCandidate): string {
   return parts ? `(By.${BY[parts.kind]}, ${q(parts.value)})` : `None  # ${c.kind} is not expressible in Selenium`;
 }
 
-function find(c: LocatorCandidate): string {
+function find(c: LocatorCandidate, recv: string): string {
   const parts = byParts(c);
-  return parts ? `driver.find_element(By.${BY[parts.kind]}, ${q(parts.value)})` : byTuple(c);
+  return parts ? `${recv}driver.find_element(By.${BY[parts.kind]}, ${q(parts.value)})` : byTuple(c);
 }
 
 function banner(name: string): string {
@@ -40,66 +41,79 @@ function banner(name: string): string {
   return `${rule}\n# ${name}\n${rule}`;
 }
 
-function methods(el: ModelElement): string[] {
+/**
+ * `recv` is what a definition refers to itself through: nothing for the module
+ * functions, `self.` inside a class. Python has no implicit receiver, so this
+ * cannot be a wrapper the way it can in Java and C# — every call site changes.
+ */
+function methods(el: ModelElement, recv: string): string[] {
   const n = snake(el.name);
-  const out: string[] = [`def get_${n}_element():\n    return ${find(activeCandidate(el))}`];
+  // `def f()` at module level, `def f(self)` in a class — and `self` goes
+  // first, ahead of any real arguments.
+  const def = (sig: string) => {
+    if (!recv) return `def ${sig}`;
+    const open = sig.indexOf('(');
+    const args = sig.slice(open + 1, -1);
+    return `def ${sig.slice(0, open)}(self${args ? `, ${args}` : ''})`;
+  };
+  const out: string[] = [`${def(`get_${n}_element()`)}:\n    return ${find(activeCandidate(el), recv)}`];
 
   switch (classify(el)) {
     case 'actionable':
-      out.push(`def click_${n}():\n    get_${n}_element().click()`);
+      out.push(`${def(`click_${n}()`)}:\n    ${recv}get_${n}_element().click()`);
       break;
 
     case 'text':
       out.push(
         // get_dom_property, not get_attribute: the attribute is the INITIAL
         // value and does not change as the user types (Selenium 4.5+).
-        `def get_${n}():\n    return get_${n}_element().get_dom_property("value")`,
+        `${def(`get_${n}()`)}:\n    return ${recv}get_${n}_element().get_dom_property("value")`,
         // One function: Python has default arguments.
-        `def set_${n}(value, clear_first=True):\n    el = get_${n}_element()\n    if clear_first:\n        el.clear()\n    el.send_keys(value)`
+        `${def(`set_${n}(value, clear_first=True)`)}:\n    el = ${recv}get_${n}_element()\n    if clear_first:\n        el.clear()\n    el.send_keys(value)`
       );
       break;
 
     case 'toggle':
       out.push(
-        `def is_${n}_checked():\n    return get_${n}_element().is_selected()`,
-        `def set_${n}(checked):\n    el = get_${n}_element()\n    if el.is_selected() != checked:\n        el.click()`
+        `${def(`is_${n}_checked()`)}:\n    return ${recv}get_${n}_element().is_selected()`,
+        `${def(`set_${n}(checked)`)}:\n    el = ${recv}get_${n}_element()\n    if el.is_selected() != checked:\n        el.click()`
       );
       break;
 
     case 'radio':
       out.push(
-        `def is_${n}_selected():\n    return get_${n}_element().is_selected()`,
-        `def select_${n}():\n    el = get_${n}_element()\n    if not el.is_selected():\n        el.click()`
+        `${def(`is_${n}_selected()`)}:\n    return ${recv}get_${n}_element().is_selected()`,
+        `${def(`select_${n}()`)}:\n    el = ${recv}get_${n}_element()\n    if not el.is_selected():\n        el.click()`
       );
       break;
 
     case 'select':
       out.push(
-        `def get_${n}_select():\n    return Select(get_${n}_element())`,
-        `def get_${n}_text():\n    return get_${n}_select().first_selected_option.text`,
-        `def get_${n}_value():\n    return get_${n}_select().first_selected_option.get_dom_property("value")`,
-        `def set_${n}_by_value(value):\n    get_${n}_select().select_by_value(value)`,
-        `def set_${n}_by_text(text):\n    get_${n}_select().select_by_visible_text(text)`
+        `${def(`get_${n}_select()`)}:\n    return Select(${recv}get_${n}_element())`,
+        `${def(`get_${n}_text()`)}:\n    return ${recv}get_${n}_select().first_selected_option.text`,
+        `${def(`get_${n}_value()`)}:\n    return ${recv}get_${n}_select().first_selected_option.get_dom_property("value")`,
+        `${def(`set_${n}_by_value(value)`)}:\n    ${recv}get_${n}_select().select_by_value(value)`,
+        `${def(`set_${n}_by_text(text)`)}:\n    ${recv}get_${n}_select().select_by_visible_text(text)`
       );
       break;
 
     case 'multiSelect':
       out.push(
-        `def get_${n}_select():\n    return Select(get_${n}_element())`,
-        `def get_${n}_texts():\n    return [o.text for o in get_${n}_select().all_selected_options]`,
-        `def get_${n}_values():\n    return [o.get_dom_property("value") for o in get_${n}_select().all_selected_options]`,
+        `${def(`get_${n}_select()`)}:\n    return Select(${recv}get_${n}_element())`,
+        `${def(`get_${n}_texts()`)}:\n    return [o.text for o in ${recv}get_${n}_select().all_selected_options]`,
+        `${def(`get_${n}_values()`)}:\n    return [o.get_dom_property("value") for o in ${recv}get_${n}_select().all_selected_options]`,
         // deselect_all first, or select_by_value ADDS to the selection.
-        `def set_${n}_by_values(*values):\n    el = get_${n}_select()\n    el.deselect_all()\n    for value in values:\n        el.select_by_value(value)`,
-        `def set_${n}_by_texts(*texts):\n    el = get_${n}_select()\n    el.deselect_all()\n    for text in texts:\n        el.select_by_visible_text(text)`,
-        `def deselect_all_${n}():\n    get_${n}_select().deselect_all()`
+        `${def(`set_${n}_by_values(*values)`)}:\n    el = ${recv}get_${n}_select()\n    el.deselect_all()\n    for value in values:\n        el.select_by_value(value)`,
+        `${def(`set_${n}_by_texts(*texts)`)}:\n    el = ${recv}get_${n}_select()\n    el.deselect_all()\n    for text in texts:\n        el.select_by_visible_text(text)`,
+        `${def(`deselect_all_${n}()`)}:\n    ${recv}get_${n}_select().deselect_all()`
       );
       break;
 
     case 'static':
       out.push(
         isImage(el)
-          ? `def get_${n}_alt_text():\n    return get_${n}_element().get_dom_attribute("alt")`
-          : `def get_${n}():\n    return get_${n}_element().text`
+          ? `${def(`get_${n}_alt_text()`)}:\n    return ${recv}get_${n}_element().get_dom_attribute("alt")`
+          : `${def(`get_${n}()`)}:\n    return ${recv}get_${n}_element().text`
       );
       break;
   }
@@ -117,5 +131,36 @@ export function generateSeleniumPythonLocators(model: TabModel): string {
 
 export function generateSeleniumPython(model: TabModel): string {
   // Two blank lines between top-level definitions, per PEP 8.
-  return model.elements.map((el) => [banner(el.name), ...methods(el)].join('\n\n\n')).join('\n\n\n');
+  return model.elements.map((el) => [banner(el.name), ...methods(el, '')].join('\n\n\n')).join('\n\n\n');
+}
+
+/** The methods as a class (SPEC §17). One blank line between methods, per PEP 8. */
+export function generateSeleniumPythonPageObject(model: TabModel): string {
+  const buckets = new Set(model.elements.map(classify));
+  const imports = [
+    'from selenium.webdriver.common.by import By',
+    ...(buckets.has('select') || buckets.has('multiSelect')
+      ? ['from selenium.webdriver.support.ui import Select']
+      : []),
+  ];
+
+  return [
+    ...imports,
+    '',
+    '',
+    `class ${classNameFor(model.url)}:`,
+    '    def __init__(self, driver):',
+    '        self.driver = driver',
+    // One blank line between methods, per PEP 8 — two is for top level.
+    ...model.elements.flatMap((el) => ['', indent(banner(el.name)), ...methods(el, 'self.').map(indent).join('\n\n').split('\n')]),
+    '',
+  ].join('\n');
+}
+
+/** Four spaces onto every non-blank line, so the definitions sit in the class. */
+function indent(block: string): string {
+  return block
+    .split('\n')
+    .map((line) => (line ? `    ${line}` : line))
+    .join('\n');
 }

--- a/v3/tests/compile/csharp/Verify.csproj
+++ b/v3/tests/compile/csharp/Verify.csproj
@@ -11,6 +11,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Generated.cs" />
+    <!-- The page-object shape brings its own `using` lines, which C# requires
+         before anything else, so it cannot share a file with the fragments. -->
+    <Compile Include="GeneratedPageObject.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Selenium.WebDriver" Version="4.27.0" />

--- a/v3/tests/unit/CodeDialog.test.ts
+++ b/v3/tests/unit/CodeDialog.test.ts
@@ -75,6 +75,21 @@ describe('CodeDialog', () => {
     expect(codeText()).toContain('readonly email: Locator;');
   });
 
+  it('keeps the shape control out of the title row', async () => {
+    // Three shapes plus Copy alongside the title truncated it to "Seleniu…" in
+    // the sidebar, which has no width to share.
+    await render(modelWith('selenium-java', { name: 'Email' }));
+    const toggle = document.body.querySelector('[data-testid="code-shape"]');
+    expect(toggle).not.toBeNull();
+    expect(toggle!.closest('.dialog-header')).toBeNull();
+  });
+
+  it('offers no shape row when the framework has one shape', async () => {
+    // No framework has one today; the row must still not appear if one does.
+    await render(modelWith('selenium-java', { name: 'Email' }));
+    expect(document.body.querySelectorAll('[data-testid="code-shape"]').length).toBe(1);
+  });
+
   it('switches shape without touching the model', async () => {
     const model = modelWith('playwright-ts', { name: 'Email' });
     await render(model);

--- a/v3/tests/unit/generated-compiles.test.ts
+++ b/v3/tests/unit/generated-compiles.test.ts
@@ -3,8 +3,8 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve, join } from 'node:path';
-import { generateSeleniumJava, generateSeleniumJavaLocators } from '../../src/generators/selenium-java';
-import { generateSeleniumCSharp, generateSeleniumCSharpLocators } from '../../src/generators/selenium-csharp';
+import { generateSeleniumJava, generateSeleniumJavaLocators, generateSeleniumJavaPageObject } from '../../src/generators/selenium-java';
+import { generateSeleniumCSharp, generateSeleniumCSharpLocators, generateSeleniumCSharpPageObject } from '../../src/generators/selenium-csharp';
 import { generatePlaywrightPageObject, generatePlaywrightLocators } from '../../src/generators/playwright-ts';
 import { generatePuppeteerPageObject, generatePuppeteerLocators } from '../../src/generators/puppeteer';
 import { modelOf, everyTypeFor, ALL_BUCKETS } from './fixtures/model';
@@ -63,17 +63,22 @@ describe.skipIf(!javaReady)('the generated Java compiles against real Selenium',
       generateSeleniumJavaLocators(model('selenium-java')),
       '}',
     ].join('\n');
+    // The wrapper brings its own imports and class, so it compiles on its own.
+    const wrapper = generateSeleniumJavaPageObject(model('selenium-java'));
     const file = join(dir, 'Generated.java');
     writeFileSync(file, source);
+    // A public class must live in a file of its own name.
+    const wrapperFile = join(dir, `${wrapper.match(/public class (\w+)/)?.[1]}.java`);
+    writeFileSync(wrapperFile, wrapper);
 
     try {
-      execFileSync('javac', ['-cp', jars.map((j) => join(LIB, j)).join(':'), '-d', dir, file], {
+      execFileSync('javac', ['-cp', jars.map((j) => join(LIB, j)).join(':'), '-d', dir, file, wrapperFile], {
         stdio: ['ignore', 'pipe', 'pipe'],
         encoding: 'utf8',
       });
     } catch (e) {
       const err = e as { stderr?: string; stdout?: string };
-      fail('Java', `${err.stdout ?? ''}${err.stderr ?? ''}\n\n--- source ---\n${source}`);
+      fail('Java', `${err.stdout ?? ''}${err.stderr ?? ''}\n\n--- source ---\n${source}\n${wrapper}`);
     }
     expect(true).toBe(true);
   });
@@ -99,6 +104,8 @@ describe.skipIf(!dotnetReady)('the generated C# compiles against real Selenium',
       '}',
     ].join('\n');
     writeFileSync(join(CSPROJ, 'Generated.cs'), source);
+    const wrapper = generateSeleniumCSharpPageObject(model('selenium-csharp'));
+    writeFileSync(join(CSPROJ, 'GeneratedPageObject.cs'), wrapper);
 
     try {
       execFileSync('dotnet', ['build', '--nologo', '--no-restore', '-v', 'quiet'], {
@@ -108,7 +115,7 @@ describe.skipIf(!dotnetReady)('the generated C# compiles against real Selenium',
       });
     } catch (e) {
       const err = e as { stderr?: string; stdout?: string };
-      fail('C#', `${err.stdout ?? ''}${err.stderr ?? ''}\n\n--- source ---\n${source}`);
+      fail('C#', `${err.stdout ?? ''}${err.stderr ?? ''}\n\n--- source ---\n${source}\n${wrapper}`);
     }
     expect(true).toBe(true);
   }, 120_000);

--- a/v3/tests/unit/generated-python.test.ts
+++ b/v3/tests/unit/generated-python.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { generatePlaywrightPythonPageObject, generatePlaywrightPythonLocators } from '../../src/generators/playwright-python';
-import { generateSeleniumPython, generateSeleniumPythonLocators } from '../../src/generators/selenium-python';
+import { generateSeleniumPython, generateSeleniumPythonLocators, generateSeleniumPythonPageObject } from '../../src/generators/selenium-python';
 import { playwrightExpr, playwrightPyExpr } from '../../src/locators/display';
 import { frameworkById } from '../../src/frameworks';
 import type { LocatorCandidate } from '../../src/engine/types';
@@ -62,6 +62,9 @@ describe.skipIf(!hasPython)('the generated Python is Python', () => {
     ['playwright locators', generatePlaywrightPythonLocators(full('playwright-python'))],
     ['selenium methods', generateSeleniumPython(full('selenium-python'))],
     ['selenium locators', generateSeleniumPythonLocators(full('selenium-python'))],
+    ['selenium page object', generateSeleniumPythonPageObject(full('selenium-python'))],
+    ['selenium page object, empty', generateSeleniumPythonPageObject(modelOf('selenium-python'))],
+    ['selenium page object, awkward values', generateSeleniumPythonPageObject(modelOf('selenium-python', ...nastySelenium))],
     ['playwright page object, awkward values', generatePlaywrightPythonPageObject(modelOf('playwright-python', ...nastyPlaywright))],
     ['selenium locators, awkward values', generateSeleniumPythonLocators(modelOf('selenium-python', ...nastySelenium))],
     ['selenium methods, awkward values', generateSeleniumPython(modelOf('selenium-python', ...nastySelenium))],

--- a/v3/tests/unit/selenium-page-object.test.ts
+++ b/v3/tests/unit/selenium-page-object.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { generateSeleniumJavaPageObject } from '../../src/generators/selenium-java';
+import { generateSeleniumCSharpPageObject } from '../../src/generators/selenium-csharp';
+import { generateSeleniumPythonPageObject } from '../../src/generators/selenium-python';
+import { emptyModel } from '../../src/model';
+import { modelOf, EMAIL, SIGN_IN, COUNTRY, TOPPINGS, HEADING } from './fixtures/model';
+
+// SPEC §17. The compile checks prove these build; this is about the decisions.
+describe('the Selenium page-object shape', () => {
+  it('names the class from the URL and takes the driver in the constructor', () => {
+    expect(generateSeleniumJavaPageObject(modelOf('selenium-java', SIGN_IN))).toContain(
+      ['public class LoginPage {', '    private final WebDriver driver;', '', '    public LoginPage(WebDriver driver) {', '        this.driver = driver;', '    }'].join('\n')
+    );
+    expect(generateSeleniumCSharpPageObject(modelOf('selenium-csharp', SIGN_IN))).toContain(
+      ['public class LoginPage', '{', '    private readonly IWebDriver driver;', '', '    public LoginPage(IWebDriver driver)', '    {', '        this.driver = driver;', '    }'].join('\n')
+    );
+    expect(generateSeleniumPythonPageObject(modelOf('selenium-python', SIGN_IN))).toContain(
+      ['class LoginPage:', '    def __init__(self, driver):', '        self.driver = driver'].join('\n')
+    );
+  });
+
+  it('routes Python through self, which has no implicit receiver', () => {
+    // Java and C# wrap the fragment unchanged; Python cannot, so every call
+    // site is rewritten. That is the part that can silently go wrong.
+    const out = generateSeleniumPythonPageObject(modelOf('selenium-python', EMAIL, COUNTRY));
+    expect(out).toContain('    def get_email_address_element(self):\n        return self.driver.find_element(By.NAME, "email")');
+    expect(out).toContain('    def set_email_address(self, value, clear_first=True):');
+    expect(out).toContain('        el = self.get_email_address_element()');
+    // The definition keeps its own name; only calls take the receiver.
+    expect(out).toContain('    def get_country_select(self):\n        return Select(self.get_country_element())');
+    expect(out).not.toContain('def self.');
+  });
+
+  it('imports only what the model needs', () => {
+    const plain = generateSeleniumJavaPageObject(modelOf('selenium-java', SIGN_IN, HEADING));
+    expect(plain).not.toContain('import org.openqa.selenium.support.ui.Select;');
+    expect(plain).not.toContain('import java.util.List;');
+
+    const selects = generateSeleniumJavaPageObject(modelOf('selenium-java', COUNTRY));
+    expect(selects).toContain('import org.openqa.selenium.support.ui.Select;');
+    // A single select never streams; only the multi one needs List.
+    expect(selects).not.toContain('import java.util.List;');
+
+    expect(generateSeleniumJavaPageObject(modelOf('selenium-java', TOPPINGS))).toContain('import java.util.stream.Collectors;');
+    expect(generateSeleniumCSharpPageObject(modelOf('selenium-csharp', TOPPINGS))).toContain('using System.Linq;');
+    expect(generateSeleniumCSharpPageObject(modelOf('selenium-csharp', SIGN_IN))).not.toContain('Support.UI');
+  });
+
+  it('separates methods with a blank line', () => {
+    expect(generateSeleniumJavaPageObject(modelOf('selenium-java', EMAIL))).toContain('    }\n\n    public');
+    expect(generateSeleniumPythonPageObject(modelOf('selenium-python', EMAIL))).toMatch(/\n\n    def get_email_address\(self\):/);
+  });
+
+  it('is a usable class for an empty model', () => {
+    for (const gen of [generateSeleniumJavaPageObject, generateSeleniumCSharpPageObject, generateSeleniumPythonPageObject]) {
+      const out = gen(emptyModel('selenium-java'));
+      expect(out).toContain('GeneratedPage');
+      expect(out).toContain('driver');
+    }
+  });
+});

--- a/v3/ui/CodeDialog.vue
+++ b/v3/ui/CodeDialog.vue
@@ -3,20 +3,25 @@
     <q-card class="code-card">
       <q-toolbar class="dialog-header">
         <q-toolbar-title class="text-subtitle1">{{ frameworkLabel }}</q-toolbar-title>
-        <!-- Shapes are per-framework, so this is hidden when there is only one. -->
+        <q-btn flat dense no-caps icon="content_copy" label="Copy" data-testid="code-copy" @click="copy" />
+      </q-toolbar>
+
+      <!-- Its own row: in the sidebar there is no width to share with the
+           title, and three shapes plus Copy pushed the title to "Seleniu…".
+           Shapes are per-framework, so this is absent when there is only one. -->
+      <div v-if="shapes.length > 1" class="shape-row">
         <q-btn-toggle
-          v-if="shapes.length > 1"
           v-model="shapeId"
           :options="shapeOptions"
-          flat
+          spread
+          unelevated
           dense
           no-caps
           toggle-color="primary"
-          class="shape-toggle q-mr-sm"
+          class="shape-toggle"
           data-testid="code-shape"
         />
-        <q-btn flat dense no-caps icon="content_copy" label="Copy" data-testid="code-copy" @click="copy" />
-      </q-toolbar>
+      </div>
 
       <q-card-section class="code-body q-pa-none">
         <!-- Read-only, as in v2.5.1: the model is edited in the table, not here. -->
@@ -96,7 +101,15 @@ async function copy() {
   min-height: 44px;
 }
 
+.shape-row {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--pm-rule);
+}
+
+/* `spread` divides the row evenly, so the labels stay readable however narrow
+   the panel gets rather than truncating the widest one. */
 .shape-toggle {
+  width: 100%;
   border: 1px solid var(--pm-rule);
   border-radius: 4px;
 }

--- a/v3/ui/CodeDialog.vue
+++ b/v3/ui/CodeDialog.vue
@@ -106,10 +106,13 @@ async function copy() {
   border-bottom: 1px solid var(--pm-rule);
 }
 
-/* `spread` divides the row evenly, so the labels stay readable however narrow
-   the panel gets rather than truncating the widest one. */
+/* `spread` divides the control evenly, so labels stay readable however narrow
+   the panel gets. Capped, because at DevTools width a full-bleed segmented
+   control reads as a banner rather than a choice — it takes the width it needs
+   and no more. */
 .shape-toggle {
   width: 100%;
+  max-width: 460px;
   border: 1px solid var(--pm-rule);
   border-radius: 4px;
 }


### PR DESCRIPTION
SPEC §17 — the third shape for all three Selenium languages.

**Methods** (default) · **Page object** · **Locators only**

```java
import org.openqa.selenium.By;
import org.openqa.selenium.WebDriver;
import org.openqa.selenium.WebElement;
import org.openqa.selenium.support.ui.Select;

public class LoginPage {
    private final WebDriver driver;

    public LoginPage(WebDriver driver) {
        this.driver = driver;
    }

    /*
     * EmailAddress
     * ***************************************************************
     */
    public WebElement getEmailAddressElement() {
        return driver.findElement(By.name("email"));
    }
    ...
}
```

Methods stays the default — it's what v2.5.1 produced, and the wrapper only earns its keep once you've settled on a class per page.

Imports are computed from the buckets present: `Select` only when there's a select, `List`/`Collectors` only when there's a multi-select.

## Python isn't a wrapper

Java and C# have an implicit receiver, so the fragment drops into a class unchanged. Python doesn't — every definition needs `self`, every call site needs `self.`:

```python
class LoginPage:
    def __init__(self, driver):
        self.driver = driver

    def get_email_address_element(self):
        return self.driver.find_element(By.NAME, "email")

    def set_email_address(self, value, clear_first=True):
        el = self.get_email_address_element()
        ...
```

So that generator is now receiver-aware. Two bugs came out of that refactor, both caught here: the receiver prefix leaked onto a *definition* (`def self.get_x_select`), and the class body had no blank lines between methods (Java and C# had the same gap).

## Verification

The compile checks cover the new shape — `javac`, `dotnet build` and `python3 -m ast` all see it. 236 unit + 19 Playwright green.

Note the C# wrapper needed its own compilation unit in the test harness: `using` must precede everything else, so it can't share a file with the fragments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)