### PR TITLE
v3: frames (SPEC §16)

### DIFF
--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -677,7 +677,41 @@ extension is reloaded — which is every rebuild in dev — and the menu is then
 
 ## 16. Frames
 
-New in v3 — v2.5.1 has no frame support.
+New in v3 — v2.5.1 has no frame support. An element records its **frame path**: the frames containing
+it, outermost first, each identified by its own generated locator. **[settled]**
+
+A frame is located by the ordinary candidate machinery — the document holding an `<iframe>` is just a
+document — with one restriction: **css or xpath only**. `frameLocator` takes a *selector*, not a
+locator, and so does every other frame API in reach, so `getByTitle('Payment')` cannot address a frame
+however well it identifies one. `cssFor` already prefers a test id, then a name, then an id (§7), so
+little is lost.
+
+`window.frameElement` builds the chain, and its limit is the hard case: it is readable only when the
+parent is same-origin. Across an origin it throws, and a document cannot see what embeds it — so the
+chain stops there and is **marked opaque**. A path that starts halfway down and looks complete is worse
+than one that admits it is partial. **[settled]**
+
+### Carrying it, or admitting you cannot **[settled]**
+
+| Target | How |
+|---|---|
+| Playwright | `frameLocator(…)` chains, so the locator is self-contained — nothing to explain, nothing to switch |
+| Selenium | a `By` is frame-agnostic: a comment names the chain and says a switch is required first |
+| Puppeteer | `page.locator` is page-scoped and there is no `frameLocator`: the same comment |
+
+Without that comment a framed Selenium or Puppeteer locator is indistinguishable from a main-frame one
+and silently resolves against the wrong document.
+
+The **model table** shows the chain for the same reason — two rows differing only by frame otherwise
+read identically. The **Edit dialog** shows it too, read-only: the chain is where the element *is*, not
+part of how it is found within that frame, so editing it would be editing the page.
+
+### The eye **[settled]**
+
+Every frame hears a `HIGHLIGHT`, and exactly one must answer or a sub-frame's 0 lands on top of the real
+count. The one that answers is the frame the element was picked in: each recomputes its own path and
+compares. Before this, only the top frame answered, so anything inside a frame reported *0 elements
+match that locator* while its locator was perfectly good.
 
 ### One picker, many frames **[settled]**
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -735,6 +735,10 @@ whose locators are least likely to survive. Entering a frame is a decision, so i
 
 ### The eye **[settled]**
 
+**A new highlight clears the last one first, in every frame** — including the frames that will not
+answer, because the previous highlight may have been in one of them. Clicking a second eye inside the
+3-second window otherwise left both elements marked.
+
 Every frame hears a `HIGHLIGHT`, and exactly one must answer or a sub-frame's 0 lands on top of the real
 count. The one that answers is the frame the element was picked in: each recomputes its own path and
 compares. Before this, only the top frame answered, so anything inside a frame reported *0 elements

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -679,6 +679,18 @@ extension is reloaded — which is every rebuild in dev — and the menu is then
 
 New in v3 — v2.5.1 has no frame support.
 
+### One picker, many frames **[settled]**
+
+The content script runs in every frame, so `START_PICKING` arms every frame. Two rules follow, and
+neither can be inferred from pointer events:
+
+- **One-shot is per tab, not per frame.** Only the clicked frame stops itself; the background disarms
+  the rest. Without that, one pick on a framed page recorded three elements as the user carried on
+  clicking.
+- **One overlay at a time.** A frame announces that it has drawn and the background tells the others to
+  clear. A parent frame gets *no* `mouseout` when the pointer crosses into a child, so hovering down
+  through nested frames otherwise left a highlight and a breadcrumb in every frame on the way.
+
 ### Fixtures **[settled]**
 
 `tests/fixtures/frames.html` and `frameset.html`, exercising every shape a real page uses:

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -718,7 +718,13 @@ script accepts from another frame — isolated worlds do not isolate `postMessag
 requires that a scan is genuinely in progress and that the sender is the parent. The worst a forged
 message can then do is what the user was already doing.
 
-Scanning a *container* that happens to hold frames does not descend into them. **[open]**
+**A scan never crosses a frame boundary on its own.** Scanning a container that happens to hold frames
+gets that document's controls and stops; the frame's contents come only when you scan the frame itself,
+or something inside it. **[settled]**
+
+Descending automatically would mean scanning `<main>` on an ordinary page could sweep in an embedded
+third-party app, an ad, or a sandboxed widget nobody asked to model — and those are exactly the frames
+whose locators are least likely to survive. Entering a frame is a decision, so it takes a click.
 
 ### The eye **[settled]**
 

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -696,8 +696,28 @@ than one that admits it is partial. **[settled]**
 | Target | How |
 |---|---|
 | Playwright | `frameLocator(…)` chains, so the locator is self-contained — nothing to explain, nothing to switch |
-| Selenium | a `By` is frame-agnostic: a comment names the chain and says a switch is required first |
-| Puppeteer | `page.locator` is page-scoped and there is no `frameLocator`: the same comment |
+| Selenium | a `By` is frame-agnostic: a comment carries the `switchTo` chain, ready to uncomment |
+| Puppeteer | `page.locator` is page-scoped and there is no `frameLocator`: a comment walks down to the frame |
+
+The comment carries the **code**, not an instruction to go and write it: **[settled]**
+
+```java
+// In frame: #same-frame › #deep-frame
+// driver.switchTo().defaultContent();
+// driver.switchTo().frame(driver.findElement(By.cssSelector("#same-frame")));
+// driver.switchTo().frame(driver.findElement(By.cssSelector("#deep-frame")));
+private final By emailInput = By.name("email");
+```
+
+```js
+// In frame: #same-frame › #deep-frame
+// const frame1 = await (await page.$('#same-frame')).contentFrame();
+// const frame2 = await (await frame1.$('#deep-frame')).contentFrame();
+// Then use frame2.locator(...) in place of page.locator(...).
+```
+
+An **opaque** chain gets the warning and *no* switch to paste: half a chain would switch into the wrong
+document and look like it worked.
 
 Without that comment a framed Selenium or Puppeteer locator is indistinguishable from a main-frame one
 and silently resolves against the wrong document.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -712,15 +712,22 @@ Scanning an `<iframe>` scans **inside** it. An iframe has no descendants in its 
 content is a separate document — so the obvious reading returns nothing at all, which is what it did.
 
 The frame scans itself rather than the parent reaching in: `contentDocument` throws across an origin,
-and the frame is armed already (`START_PICKING` reaches every frame) and knows its own path, so every
-element comes out with the right chain for free. The parent asks via `postMessage`, the one message this
-script accepts from another frame — isolated worlds do not isolate `postMessage`, so the handler also
-requires that a scan is genuinely in progress and that the sender is the parent. The worst a forged
-message can then do is what the user was already doing.
+and the frame knows its own path, so every element comes out with the right chain for free. The parent
+asks via `postMessage`, the one message this script accepts from another frame.
+
+**It cascades.** Choosing a frame means choosing its page, and a page includes what it embeds — so the
+scan carries on into frames below, however deep. Each frame reports its own haul, so the model simply
+gains rows as they arrive and nothing is collected back up the tree.
+
+Authenticated by a **nonce** carried in `START_PICKING`, shared by every frame in the tab for that
+picking session. Isolated worlds do not isolate `postMessage`, so a page could otherwise forge a scan;
+a page cannot read the nonce. Not by "is this frame still armed", which was the first attempt: a
+cascading scan reaches frames after the background has disarmed everyone, and a frame that refused then
+would be a hole in the middle of the tree.
 
 **A scan never crosses a frame boundary on its own.** Scanning a container that happens to hold frames
-gets that document's controls and stops; the frame's contents come only when you scan the frame itself,
-or something inside it. **[settled]**
+gets that document's controls and stops. A frame's contents come only when the scan is rooted at that
+frame — the frame element, or its document — and then everything below it is in scope. **[settled]**
 
 Descending automatically would mean scanning `<main>` on an ordinary page could sweep in an embedded
 third-party app, an ad, or a sandboxed widget nobody asked to model — and those are exactly the frames

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -677,7 +677,27 @@ extension is reloaded — which is every rebuild in dev — and the menu is then
 
 ## 16. Frames
 
-New in v3 — v2.5.1 has no frame support. An element records the **frame path**: the ordered list of
+New in v3 — v2.5.1 has no frame support.
+
+### Fixtures **[settled]**
+
+`tests/fixtures/frames.html` and `frameset.html`, exercising every shape a real page uses:
+
+| Frame | Why it is there |
+|---|---|
+| same-origin `iframe` | the ordinary case, and it nests one deeper |
+| cross-origin `iframe` | `127.0.0.1` against `localhost` — one server, two origins, no second process |
+| `srcdoc` | same-origin with no URL at all; nothing to identify it by but the element |
+| `sandbox="allow-scripts"` | an opaque origin, which is what a third-party widget usually is |
+| two identical `iframe`s | the frame itself needs a positional locator — the case a path can get wrong |
+| `frameset` / `frame` | `frame` is a different element from `iframe`; a selector for one misses the other |
+
+**Nine buttons across the tree share the accessible name *Submit*.** Without a frame path a locator
+cannot tell them apart, which is the property every frame test leans on.
+
+The fixtures are served over http, never `file://`: Chrome gives every `file://` document an opaque
+origin, so `localhost` against `127.0.0.1` would prove nothing. `scripts/serve-fixtures.mjs` substitutes
+the cross-origin base at request time, so it follows `FIXTURES_PORT`. An element records the **frame path**: the ordered list of
 iframes containing it, each identified by its own generated locator.
 
 ### Playwright

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -696,7 +696,7 @@ than one that admits it is partial. **[settled]**
 | Target | How |
 |---|---|
 | Playwright | `frameLocator(…)` chains, so the locator is self-contained — nothing to explain, nothing to switch |
-| Selenium | a `By` is frame-agnostic: a comment carries the `switchTo` chain, ready to uncomment |
+| Selenium | methods switch in and out for themselves; the locators shape gets the `switchTo` chain as a comment |
 | Puppeteer | `page.locator` is page-scoped and there is no `frameLocator`: a comment walks down to the frame |
 
 The comment carries the **code**, not an instruction to go and write it: **[settled]**
@@ -718,6 +718,36 @@ private final By emailInput = By.name("email");
 
 An **opaque** chain gets the warning and *no* switch to paste: half a chain would switch into the wrong
 document and look like it worked.
+
+### Selenium methods switch for themselves **[settled]**
+
+`switchTo()` mutates driver state for everything after it, so a method that leaves the driver inside a
+frame breaks the next one. Every framed method switches to default content, into the chain, acts, and
+switches back **in a `finally`** — which is what makes generated methods safe to call in any order.
+
+```java
+public void clickSubmit() {
+    driver.switchTo().defaultContent();
+    driver.switchTo().frame(driver.findElement(By.cssSelector("#same-frame")));
+    driver.switchTo().frame(driver.findElement(By.cssSelector("#deep-frame")));
+    try {
+        driver.findElement(By.id("go")).click();
+    } finally {
+        driver.switchTo().defaultContent();
+    }
+}
+```
+
+**A framed element gets no `get{Name}Element()`** — nor a `Select` helper, which holds one. A
+`WebElement` goes stale the moment the driver switches away, so handing one back is handing back a
+guaranteed failure. The element is found inline instead, inside the switch.
+
+The banner carries the frame as **context only**: repeating the switch there is noise the reader has to
+check against the code below it.
+
+Two things are deliberately not wrapped: a method that never touches the driver (the convenience
+overload just calls its sibling, which switches for itself), and an element behind an **opaque** chain,
+which keeps its getter and leaves the switch to the caller — there is no correct switch to emit.
 
 Without that comment a framed Selenium or Puppeteer locator is indistinguishable from a main-frame one
 and silently resolves against the wrong document.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -706,6 +706,20 @@ The **model table** shows the chain for the same reason — two rows differing o
 read identically. The **Edit dialog** shows it too, read-only: the chain is where the element *is*, not
 part of how it is found within that frame, so editing it would be editing the page.
 
+### Scanning a frame **[settled]**
+
+Scanning an `<iframe>` scans **inside** it. An iframe has no descendants in its parent's document — its
+content is a separate document — so the obvious reading returns nothing at all, which is what it did.
+
+The frame scans itself rather than the parent reaching in: `contentDocument` throws across an origin,
+and the frame is armed already (`START_PICKING` reaches every frame) and knows its own path, so every
+element comes out with the right chain for free. The parent asks via `postMessage`, the one message this
+script accepts from another frame — isolated worlds do not isolate `postMessage`, so the handler also
+requires that a scan is genuinely in progress and that the sender is the parent. The worst a forged
+message can then do is what the user was already doing.
+
+Scanning a *container* that happens to hold frames does not descend into them. **[open]**
+
 ### The eye **[settled]**
 
 Every frame hears a `HIGHLIGHT`, and exactly one must answer or a sub-frame's 0 lands on top of the real

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -28,6 +28,15 @@ export default defineBackground(() => {
 
   const store = new ModelStore(defaultFrameworkId);
 
+  /**
+   * Disarm the picker in every frame of a tab. `tabs.sendMessage` with no
+   * `frameId` reaches all of them, and a frame that is already stopped ignores
+   * it.
+   */
+  function stopEveryFrame(tabId: number) {
+    browser.tabs.sendMessage(tabId, { type: 'STOP_PICKING' }).catch(() => {});
+  }
+
   /** Every panel gets the model; each ignores tabs that are not its own. */
   function publish(tabId: number, model: TabModel) {
     browser.runtime.sendMessage({ type: 'MODEL', tabId, model }).catch(() => {});
@@ -133,11 +142,30 @@ export default defineBackground(() => {
             }
           })
         );
-        // Picking is one-shot (SPEC §4); tell the panels so they can un-arm.
+        // Picking is one-shot (SPEC §4) per TAB, not per frame. START_PICKING
+        // is broadcast to every frame and each arms itself, but only the frame
+        // that was clicked stops itself — the rest stayed live and recorded the
+        // next click too, so one pick in a framed page added three elements.
+        stopEveryFrame(tabId);
+        // And tell the panels, so they can un-arm the toolbar.
         browser.runtime.sendMessage({ type: 'FROM_TAB', tabId, message: { type: 'PICKING_STOPPED' } }).catch(() => {});
         return;
       }
-      case 'PICKING_STOPPED':
+      case 'OVERLAY_SHOWN': {
+        const tabId = sender.tab?.id;
+        if (tabId == null) return;
+        // Every frame hears it; each clears unless the token is its own.
+        browser.tabs.sendMessage(tabId, { type: 'OVERLAY_OWNER', token: m.token }).catch(() => {});
+        return;
+      }
+      case 'PICKING_STOPPED': {
+        const tabId = sender.tab?.id;
+        if (tabId == null) return;
+        // Escape reaches only the frame with focus; the others are still armed.
+        stopEveryFrame(tabId);
+        browser.runtime.sendMessage({ type: 'FROM_TAB', tabId, message: m }).catch(() => {});
+        return;
+      }
       case 'HIGHLIGHT_RESULT': {
         const tabId = sender.tab?.id;
         if (tabId == null) return;

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -241,6 +241,33 @@ export default defineContentScript({
       highlight(el);
     };
 
+    const isFrame = (el: Element) => el.localName === 'iframe' || el.localName === 'frame';
+
+    /**
+     * Marks the one message this script accepts from another frame. Isolated
+     * worlds do not isolate postMessage, so a page could forge this — which is
+     * why the handler also requires that a scan is genuinely in progress in
+     * this frame. The worst a forgery can then do is what the user was already
+     * doing.
+     */
+    const SCAN_FRAME = '__pageModellerScanFrame';
+
+    window.addEventListener('message', (e: MessageEvent) => {
+      if (!active || mode !== 'scan') return;
+      if (typeof e.data !== 'object' || e.data === null || !(e.data as Record<string, unknown>)[SCAN_FRAME]) return;
+      // Only from the document that embeds this one.
+      if (e.source !== window.parent) return;
+      scanDocument();
+    });
+
+    /** Everything interactive in THIS document, as one haul. */
+    function scanDocument() {
+      const root = document.body ?? document.documentElement;
+      const results = collectInteractive(root, includeHidden).map(generate);
+      stop({ notify: false });
+      browser.runtime.sendMessage({ type: 'ELEMENTS_PICKED', results }).catch(() => {});
+    }
+
     /** Commit the current target. Shared by clicking and by Enter. */
     function pickCurrent() {
       if (!active || !current) return;
@@ -248,6 +275,19 @@ export default defineContentScript({
       // Both modes are one-shot (SPEC §4) — stop before reporting, so the
       // overlay is gone by the time the panel re-renders.
       stop({ notify: false });
+
+      // Scanning a frame has to be done BY that frame. An <iframe> has no
+      // descendants in this document — its content is a separate document —
+      // so collectInteractive finds nothing and the scan silently returns
+      // empty. Cross-origin it is worse than awkward: contentDocument throws.
+      //
+      // So the frame scans itself. It is already armed (START_PICKING reaches
+      // every frame) and it knows its own frame path, which is exactly what
+      // the elements need.
+      if (mode === 'scan' && isFrame(target)) {
+        (target as HTMLIFrameElement).contentWindow?.postMessage({ [SCAN_FRAME]: true }, '*');
+        return;
+      }
 
       // Scan takes the container's interactive descendants, never the container
       // itself: you are modelling what is inside the section you chose.

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -1,7 +1,9 @@
-import { generate, resolveCandidate } from '@/src/engine/candidates';
+import { framePathOf, generate, resolveCandidate } from '@/src/engine/candidates';
 import { describeBrief, describeElement } from '@/src/engine/describe';
 import { collectInteractive } from '@/src/engine/interactive';
 import { isMessage, type Message, type PickMode } from '@/src/messaging';
+import { frameSelector } from '@/src/locators/frames';
+import type { FrameStep } from '@/src/engine/types';
 
 // Inspector overlay: highlight the element under the cursor (like DevTools) and,
 // on click, run the locator engine and report the result to the side panel.
@@ -354,6 +356,18 @@ export default defineContentScript({
       if (notify) browser.runtime.sendMessage({ type: 'PICKING_STOPPED' }).catch(() => {});
     }
 
+    /**
+     * Is this frame the one the element was picked in? Compared by selector
+     * rather than by identity: the path in the model was built by this same
+     * code, so the strings line up, including the `:root` marker that stands
+     * for a cross-origin break.
+     */
+    function samePath(mine: FrameStep[], theirs: FrameStep[] | undefined): boolean {
+      const other = theirs ?? [];
+      if (mine.length !== other.length) return false;
+      return mine.every((step, i) => frameSelector(step) === frameSelector(other[i]));
+    }
+
     browser.runtime.onMessage.addListener((msg: unknown) => {
       if (!isMessage(msg)) return;
       const m = msg as Message;
@@ -373,12 +387,15 @@ export default defineContentScript({
       else if (m.type === 'MOVE_TARGET') moveTarget(m.direction);
       else if (m.type === 'PICK_TARGET') pickCurrent();
       else if (m.type === 'HIGHLIGHT') {
-        // This script runs in every frame, but only the top one answers — a
-        // sub-frame with no matches would otherwise report 0 over the top
-        // frame's real count. Decided here rather than by the panel passing
-        // frameId, so the send is shaped exactly like the ones that work on
-        // both browsers. Cross-frame highlighting arrives with SPEC §16.
-        if (window.top !== window) return;
+        // This script runs in every frame and every frame hears this, so
+        // exactly one must answer or a sub-frame's 0 lands on top of the real
+        // count. The one that answers is the frame the element was picked in:
+        // each recomputes its own path and compares (SPEC §16).
+        //
+        // Decided here rather than by the panel passing a frameId, so the send
+        // is shaped exactly like the ones that work on both browsers — a
+        // DevTools panel on Firefox has no `browser.tabs` to target one with.
+        if (!samePath(framePathOf(window), m.framePath)) return;
         const targets = resolveCandidate(document, m.candidate);
         const { hidden } = highlightAll(targets);
         // Answered as a message, not a reply — sendResponse is not portable.

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -463,6 +463,12 @@ export default defineContentScript({
         // Decided here rather than by the panel passing a frameId, so the send
         // is shaped exactly like the ones that work on both browsers — a
         // DevTools panel on Firefox has no `browser.tabs` to target one with.
+        // Every frame drops whatever it was showing, including the frames
+        // that will not answer: the previous highlight may have been in one of
+        // them, and clicking a second eye while the first was still up left
+        // both elements marked. Cleared before the path check, or only the
+        // answering frame would forget.
+        clearMarks();
         if (!samePath(framePathOf(window), m.framePath)) return;
         const targets = resolveCandidate(document, m.candidate);
         const { hidden } = highlightAll(targets);

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -15,6 +15,8 @@ export default defineContentScript({
     /** 'add' takes the element itself; 'scan' takes its interactive children. */
     let mode: PickMode = 'add';
     let includeHidden = false;
+    /** Shared by every frame in the tab for this picking session. */
+    let nonce = '';
     let box: HTMLDivElement | null = null;
     let label: HTMLDivElement | null = null;
     let current: Element | null = null;
@@ -253,19 +255,36 @@ export default defineContentScript({
     const SCAN_FRAME = '__pageModellerScanFrame';
 
     window.addEventListener('message', (e: MessageEvent) => {
-      if (!active || mode !== 'scan') return;
-      if (typeof e.data !== 'object' || e.data === null || !(e.data as Record<string, unknown>)[SCAN_FRAME]) return;
-      // Only from the document that embeds this one.
+      const data = e.data as Record<string, unknown> | null;
+      if (typeof data !== 'object' || data === null) return;
+      // Authenticated by the nonce, not by `active`: a cascading scan reaches
+      // frames after the background has already disarmed everyone, and a frame
+      // that refused then would be a hole in the middle of the tree.
+      if (!nonce || data[SCAN_FRAME] !== nonce) return;
       if (e.source !== window.parent) return;
       scanDocument();
     });
 
-    /** Everything interactive in THIS document, as one haul. */
+    /** Ask a nested frame to scan itself, and everything below it. */
+    function delegateScan(frame: Element) {
+      (frame as HTMLIFrameElement).contentWindow?.postMessage({ [SCAN_FRAME]: nonce }, '*');
+    }
+
+    /**
+     * Everything interactive in THIS document, plus everything in the frames
+     * below it. Choosing a frame means choosing its page, and a page includes
+     * what it embeds (SPEC §16) — stopping one level down was the surprise.
+     *
+     * Each frame reports its own haul, so the model simply gains rows as they
+     * arrive; nothing has to be collected back up the tree.
+     */
     function scanDocument() {
       const root = document.body ?? document.documentElement;
       const results = collectInteractive(root, includeHidden).map(generate);
+      const nested = Array.from(document.querySelectorAll('iframe, frame'));
       stop({ notify: false });
-      browser.runtime.sendMessage({ type: 'ELEMENTS_PICKED', results }).catch(() => {});
+      if (results.length > 0) browser.runtime.sendMessage({ type: 'ELEMENTS_PICKED', results }).catch(() => {});
+      for (const frame of nested) delegateScan(frame);
     }
 
     /** Commit the current target. Shared by clicking and by Enter. */
@@ -285,7 +304,15 @@ export default defineContentScript({
       // every frame) and it knows its own frame path, which is exactly what
       // the elements need.
       if (mode === 'scan' && isFrame(target)) {
-        (target as HTMLIFrameElement).contentWindow?.postMessage({ [SCAN_FRAME]: true }, '*');
+        delegateScan(target);
+        return;
+      }
+
+      // Scanning a frame's own document means the same thing as scanning the
+      // frame: everything in it, frames below included. A smaller container
+      // inside it does not, which is the boundary rule (SPEC §16).
+      if (mode === 'scan' && (target === document.body || target === document.documentElement)) {
+        scanDocument();
         return;
       }
 
@@ -414,6 +441,7 @@ export default defineContentScript({
       if (m.type === 'START_PICKING') {
         mode = m.mode;
         includeHidden = m.includeHidden;
+        nonce = m.nonce;
         start();
       }
       // notify: false — STOP_PICKING only ever comes from the panel or from the

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -21,6 +21,9 @@ export default defineContentScript({
 
     const Z = '2147483647';
 
+    /** Identifies this frame to the background; see OVERLAY_SHOWN. */
+    const frameToken = Math.random().toString(36).slice(2);
+
     function ensureOverlay() {
       if (box) return;
       box = document.createElement('div');
@@ -47,6 +50,9 @@ export default defineContentScript({
         whiteSpace: 'nowrap',
       } as CSSStyleDeclaration);
       document.documentElement.append(box, label);
+      // Only on creation, so this is one message per frame entered, not one
+      // per mousemove.
+      browser.runtime.sendMessage({ type: 'OVERLAY_SHOWN', token: frameToken }).catch(() => {});
     }
 
     function removeOverlay() {
@@ -310,10 +316,25 @@ export default defineContentScript({
       moveTarget(e.key === 'ArrowUp' ? 'up' : 'down');
     };
 
+    /**
+     * The pointer left this document — into a child frame, into the parent, or
+     * off the window. This script runs in every frame (`allFrames`), so each
+     * one draws its own overlay and, without this, leaves it behind: hovering
+     * through nested frames stacked a highlight and a breadcrumb in every frame
+     * on the way. Only the document under the pointer should show one.
+     *
+     * A null `relatedTarget` is what distinguishes leaving the document from
+     * moving between two elements inside it.
+     */
+    const onOut = (e: MouseEvent) => {
+      if (active && !e.relatedTarget) removeOverlay();
+    };
+
     function start() {
       if (active) return;
       active = true;
       document.addEventListener('mousemove', onMove, true);
+      document.addEventListener('mouseout', onOut, true);
       document.addEventListener('click', onClick, true);
       document.addEventListener('keydown', onKey, true);
     }
@@ -326,6 +347,7 @@ export default defineContentScript({
       if (!active) return;
       active = false;
       document.removeEventListener('mousemove', onMove, true);
+      document.removeEventListener('mouseout', onOut, true);
       document.removeEventListener('click', onClick, true);
       document.removeEventListener('keydown', onKey, true);
       removeOverlay();
@@ -340,7 +362,13 @@ export default defineContentScript({
         includeHidden = m.includeHidden;
         start();
       }
-      else if (m.type === 'STOP_PICKING') stop();
+      // notify: false — STOP_PICKING only ever comes from the panel or from the
+      // background disarming the other frames, and both already know.
+      else if (m.type === 'STOP_PICKING') stop({ notify: false });
+      else if (m.type === 'OVERLAY_OWNER') {
+        // Some other frame is under the pointer now.
+        if (m.token !== frameToken) removeOverlay();
+      }
       else if (m.type === 'CLEAR_HIGHLIGHT') clearMarks();
       else if (m.type === 'MOVE_TARGET') moveTarget(m.direction);
       else if (m.type === 'PICK_TARGET') pickCurrent();

--- a/v3/scripts/serve-fixtures.mjs
+++ b/v3/scripts/serve-fixtures.mjs
@@ -12,11 +12,24 @@ createServer(async (req, res) => {
   const requested = normalize(decodeURIComponent(new URL(req.url, 'http://x').pathname)).replace(/^(\.\.[/\\])+/, '');
   const path = requested === '/' ? 'login.html' : requested;
   try {
-    const body = await readFile(join(ROOT, path));
+    let body = await readFile(join(ROOT, path));
+    if (extname(path) === '.html') {
+      // frames.html embeds a genuinely cross-origin iframe. 127.0.0.1 and
+      // localhost are different origins to the browser while being the same
+      // server, so no second process is needed — and substituting here rather
+      // than hard-coding keeps it correct when FIXTURES_PORT changes.
+      body = body.toString().replaceAll('__CROSS_ORIGIN__', `http://127.0.0.1:${PORT}`);
+    }
     res.writeHead(200, { 'content-type': TYPES[extname(path)] ?? 'application/octet-stream' });
     res.end(body);
   } catch {
     res.writeHead(404, { 'content-type': 'text/plain' });
     res.end('not found');
   }
-}).listen(PORT, () => console.log(`fixtures: http://localhost:${PORT}/  (login.html, widgets.html, edgecases.html, ambiguous.html)`));
+}).listen(PORT, () => {
+  const pages = ['login', 'widgets', 'edgecases', 'ambiguous', 'frames', 'frameset'];
+  console.log(`fixtures: http://localhost:${PORT}/`);
+  for (const page of pages) console.log(`  http://localhost:${PORT}/${page}.html`);
+  console.log('\nframes.html embeds 127.0.0.1 as a cross-origin child — reach it via localhost, not 127.0.0.1,');
+  console.log('or the "cross-origin" frame will be same-origin.');
+});

--- a/v3/src/engine/candidates.ts
+++ b/v3/src/engine/candidates.ts
@@ -1,5 +1,5 @@
 import { computeAccessibleName, getRole } from 'dom-accessibility-api';
-import type { LocatorCandidate, ElementResult, RankedCandidate } from './types';
+import type { LocatorCandidate, ElementResult, FrameStep, RankedCandidate } from './types';
 import { baseName, looksGenerated } from './naming';
 
 const norm = (s: string | null | undefined): string => (s ?? '').replace(/\s+/g, ' ').trim();
@@ -267,10 +267,76 @@ export function resolveCandidate(doc: Document, c: LocatorCandidate): Element[] 
 
 // ---- candidate generation (ranked, mirrors Playwright's priority) ----
 
-export function generate(el: Element): ElementResult {
+/**
+ * The chain of frames between the main document and this element's document,
+ * outermost first (SPEC §16).
+ *
+ * Each frame is located with the ordinary candidate machinery: the document
+ * holding an `<iframe>` is just a document, and the `<iframe>` is just an
+ * element in it. So a frame gets the same testid/name/id/attribute preference
+ * as anything else, and the same uniqueness check.
+ *
+ * `window.frameElement` is the whole trick, and its limit is the whole
+ * difficulty: it is readable only when the parent is same-origin. Across an
+ * origin it throws, and a document cannot see what embeds it — so the chain
+ * stops there and says so rather than returning a path that starts halfway
+ * down and looks complete.
+ */
+export function framePathOf(win: Window | null): FrameStep[] {
+  const path: FrameStep[] = [];
+  if (!win) return path;
+  let cur: Window = win;
+
+  // A bounded walk: a malformed or hostile tree should not spin here.
+  for (let depth = 0; depth < 32 && cur !== cur.top; depth++) {
+    let el: Element | null = null;
+    try {
+      el = cur.frameElement;
+    } catch {
+      el = null; // cross-origin parent
+    }
+    if (!el) {
+      path.unshift({ frame: { kind: 'css', value: ':root' }, opaque: true });
+      break;
+    }
+    // Generated against the PARENT document, which is where the frame element
+    // lives and where it has to be unique.
+    //
+    // Restricted to css/xpath, unlike an ordinary element: `frameLocator` takes
+    // a SELECTOR, not a locator, so `getByTitle('Payment')` cannot address a
+    // frame however well it identifies one. Selenium and Puppeteer are the same
+    // — every frame API in reach speaks selectors. cssFor already prefers a
+    // test id, then name, then id, so this loses little.
+    const ranked = rankFor(el, safeRole(el), safeName(el)).filter(
+      (c) => c.candidate.kind === 'css' || c.candidate.kind === 'xpath'
+    );
+    const best = ranked[chooseFirstUnique(ranked)] ?? ranked[0];
+    if (!best) break;
+    path.unshift({ frame: best.candidate });
+    cur = cur.parent;
+  }
+
+  return path;
+}
+
+/** Index of the first predicted-unique candidate, or 0 when none is. */
+function chooseFirstUnique(ranked: RankedCandidate[]): number {
+  const i = ranked.findIndex((c) => c.predictedCount === 1);
+  return i === -1 ? 0 : i;
+}
+
+/** A selector string for a frame step, for the APIs that take one. */
+export function frameSelector(step: FrameStep): string {
+  return step.frame.kind === 'xpath' ? `xpath=${step.frame.value}` : (step.frame as { value: string }).value;
+}
+
+/**
+ * Every candidate for an element, filtered to those that actually find it and
+ * ranked by predicted uniqueness. Shared by `generate` and by `framePathOf`,
+ * which needs exactly this for an `<iframe>` in its parent document.
+ */
+function rankFor(el: Element, role: string | null, name: string): RankedCandidate[] {
   const doc = el.ownerDocument;
-  const role = safeRole(el);
-  const name = safeName(el);
   const tag = el.tagName.toLowerCase();
   const out: LocatorCandidate[] = [];
 
@@ -349,7 +415,14 @@ export function generate(el: Element): ElementResult {
     .filter(({ matches }) => matches.includes(el))
     .map(({ candidate, matches }) => ({ candidate, predictedCount: matches.length }));
 
-  const preferredIndex = candidates.findIndex((c) => c.predictedCount === 1);
+  return candidates;
+}
+
+export function generate(el: Element): ElementResult {
+  const role = safeRole(el);
+  const name = safeName(el);
+  const tag = el.tagName.toLowerCase();
+  const candidates = rankFor(el, role, name);
 
   return {
     tag,
@@ -358,6 +431,9 @@ export function generate(el: Element): ElementResult {
     suggestedName: baseName(el),
     inputType: tag === 'input' ? (el as HTMLInputElement).type : undefined,
     candidates,
-    preferredIndex,
+    preferredIndex: candidates.findIndex((c) => c.predictedCount === 1),
+    // The document this element lives in may be framed; the chain to it is as
+    // much a part of the locator as the locator (SPEC §16).
+    framePath: framePathOf(el.ownerDocument.defaultView),
   };
 }

--- a/v3/src/engine/types.ts
+++ b/v3/src/engine/types.ts
@@ -45,9 +45,21 @@ export interface ElementResult {
   candidates: RankedCandidate[];
   /** Index of the first predicted-unique candidate, or -1 if none. */
   preferredIndex: number;
+  /** Outermost first; empty for an element in the main frame (SPEC §16). */
+  framePath: FrameStep[];
 }
 
-/** A step in a frame path (Phase 1: main-frame only, so paths are empty). */
+/**
+ * One `<iframe>`/`<frame>` between the main document and the element, located
+ * the same way any other element is — the parent document is just a document.
+ */
 export interface FrameStep {
   frame: LocatorCandidate;
+  /**
+   * True when the chain could not be completed because a document in it is
+   * cross-origin, so `window.frameElement` is unreadable from inside. The
+   * locator is then relative to that frame rather than to the page, and saying
+   * so beats emitting a path that silently starts halfway down.
+   */
+  opaque?: boolean;
 }

--- a/v3/src/generators/playwright-python.ts
+++ b/v3/src/generators/playwright-python.ts
@@ -5,10 +5,12 @@
 // carries the intent and the convention carries the rest.
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import { playwrightPyExpr } from '../locators/display';
+import { playwrightPyFramePrefix } from '../locators/frames';
 import { classNameFor } from './class-name';
 import { snake } from './names';
 
-const expr = (el: ModelElement) => `page.${playwrightPyExpr(activeCandidate(el))}`;
+const expr = (el: ModelElement) =>
+  `page.${playwrightPyFramePrefix(el.framePath)}${playwrightPyExpr(activeCandidate(el))}`;
 
 export function generatePlaywrightPythonPageObject(model: TabModel): string {
   const className = classNameFor(model.url);

--- a/v3/src/generators/playwright-ts.ts
+++ b/v3/src/generators/playwright-ts.ts
@@ -4,11 +4,14 @@
 // the shape. See ts-page-object.ts for why there are no action wrappers.
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import { playwrightExpr } from '../locators/display';
+import { playwrightFramePrefix } from '../locators/frames';
 import { tsPageObject, tsLocators, type TsTarget } from './ts-page-object';
 
 const PLAYWRIGHT: TsTarget = {
   module: '@playwright/test',
-  expr: (el: ModelElement) => playwrightExpr(activeCandidate(el)),
+  // frameLocator chains, so a framed element needs no explanation and no
+  // switching — the locator is complete on its own (SPEC §16).
+  expr: (el: ModelElement) => playwrightFramePrefix(el.framePath) + playwrightExpr(activeCandidate(el)),
 };
 
 export const generatePlaywrightPageObject = (model: TabModel) => tsPageObject(model, PLAYWRIGHT);

--- a/v3/src/generators/puppeteer.ts
+++ b/v3/src/generators/puppeteer.ts
@@ -10,11 +10,16 @@
 // generated code cannot disagree about what a locator is.
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import { puppeteerExpr } from '../locators/display';
+import { frameNote } from '../locators/frames';
 import { tsPageObject, tsLocators, type TsTarget } from './ts-page-object';
 
 const PUPPETEER: TsTarget = {
   module: 'puppeteer',
   expr: (el: ModelElement) => puppeteerExpr(activeCandidate(el)),
+  // `page.locator` is page-scoped and Puppeteer has no frameLocator, so a
+  // framed element needs `page.frames()` first. Said out loud, because the
+  // locator is otherwise indistinguishable from a main-frame one (SPEC §16).
+  note: (el: ModelElement) => frameNote(el.framePath, 'line'),
   // `Locator<T>` is generic over the node it yields — `page.locator('button')`
   // is a `Locator<HTMLButtonElement>`. Element is the common supertype, and
   // widening to it is what lets one field hold any of them.

--- a/v3/src/generators/puppeteer.ts
+++ b/v3/src/generators/puppeteer.ts
@@ -10,8 +10,27 @@
 // generated code cannot disagree about what a locator is.
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import { puppeteerExpr } from '../locators/display';
-import { frameNote } from '../locators/frames';
+import { frameNote, frameSelector } from '../locators/frames';
+import type { FrameStep } from '../engine/types';
+import { singleQuoted as q } from '../quote';
 import { tsPageObject, tsLocators, type TsTarget } from './ts-page-object';
+
+/**
+ * Puppeteer reaches a frame through the element that embeds it, so the snippet
+ * walks down handle by handle and ends with the scope to use in place of
+ * `page`.
+ */
+const frameSwitch = (path: FrameStep[]) => {
+  const lines: string[] = [];
+  let scope = 'page';
+  path.forEach((step, i) => {
+    const next = `frame${i + 1}`;
+    lines.push(`const ${next} = await (await ${scope}.$(${q(frameSelector(step))})).contentFrame();`);
+    scope = next;
+  });
+  lines.push(`Then use ${scope}.locator(...) in place of page.locator(...).`);
+  return lines;
+};
 
 const PUPPETEER: TsTarget = {
   module: 'puppeteer',
@@ -19,7 +38,7 @@ const PUPPETEER: TsTarget = {
   // `page.locator` is page-scoped and Puppeteer has no frameLocator, so a
   // framed element needs `page.frames()` first. Said out loud, because the
   // locator is otherwise indistinguishable from a main-frame one (SPEC §16).
-  note: (el: ModelElement) => frameNote(el.framePath, 'line'),
+  note: (el: ModelElement) => frameNote(el.framePath, '//', frameSwitch),
   // `Locator<T>` is generic over the node it yields — `page.locator('button')`
   // is a `Locator<HTMLButtonElement>`. Element is the common supertype, and
   // widening to it is what lets one field hold any of them.

--- a/v3/src/generators/selenium-csharp.ts
+++ b/v3/src/generators/selenium-csharp.ts
@@ -10,6 +10,7 @@ import { classify, isImage } from './classify';
 import { underscoreCamel } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameFor } from './class-name';
+import { frameNote } from '../locators/frames';
 
 const q = doubleQuoted;
 
@@ -29,8 +30,11 @@ function by(c: LocatorCandidate): string {
   return parts ? `By.${BY[parts.kind]}(${q(parts.value)})` : `null /* ${c.kind} is not expressible in Selenium */`;
 }
 
-function banner(name: string): string {
-  return `/*\n * ${name}\n * ***************************************************************\n */`;
+function banner(el: ModelElement): string {
+  // The frame chain goes in the banner, where a reader is already looking to
+  // see what this block is about (SPEC §16).
+  const frames = frameNote(el.framePath, 'line').map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
+  return [`/*`, ` * ${el.name}`, ...frames, ` * ***************************************************************`, ` */`].join('\n');
 }
 
 function methods(el: ModelElement): string[] {
@@ -106,12 +110,12 @@ function methods(el: ModelElement): string[] {
 /** `By` fields to paste into your own page object. */
 export function generateSeleniumCSharpLocators(model: TabModel): string {
   return model.elements
-    .map((el) => `private readonly By ${underscoreCamel(el.name)} = ${by(activeCandidate(el))};`)
+    .flatMap((el) => [...frameNote(el.framePath, 'line'), `private readonly By ${underscoreCamel(el.name)} = ${by(activeCandidate(el))};`])
     .join('\n');
 }
 
 export function generateSeleniumCSharp(model: TabModel): string {
-  return model.elements.map((el) => [banner(el.name), ...methods(el)].join('\n\n')).join('\n\n');
+  return model.elements.map((el) => [banner(el), ...methods(el)].join('\n\n')).join('\n\n');
 }
 
 /** The methods with a class around them (SPEC §17). */
@@ -137,7 +141,7 @@ export function generateSeleniumCSharpPageObject(model: TabModel): string {
     '    }',
     ...model.elements.flatMap((el) => [
       '',
-      indent(banner(el.name)),
+      indent(banner(el)),
       ...methods(el).map(indent).join('\n\n').split('\n'),
     ]),
     '}',

--- a/v3/src/generators/selenium-csharp.ts
+++ b/v3/src/generators/selenium-csharp.ts
@@ -10,7 +10,7 @@ import { classify, isImage } from './classify';
 import { underscoreCamel } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameFor } from './class-name';
-import { frameNote } from '../locators/frames';
+import { frameContext, frameNote, isOpaque } from '../locators/frames';
 import type { FrameStep } from '../engine/types';
 
 const q = doubleQuoted;
@@ -40,78 +40,107 @@ const frameSwitch = (path: FrameStep[]) => [
 function banner(el: ModelElement): string {
   // The frame chain goes in the banner, where a reader is already looking to
   // see what this block is about (SPEC §16).
-  const frames = frameNote(el.framePath, '//', frameSwitch).map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
+  // Context only: every method below switches for itself.
+  const frames = frameContext(el.framePath, '//').map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
   return [`/*`, ` * ${el.name}`, ...frames, ` * ***************************************************************`, ` */`].join('\n');
+}
+
+/** See selenium-java.ts: switchTo mutates driver state, so the finally matters. */
+function inFrame(method: string, path: FrameStep[]): string {
+  const open = method.indexOf('{');
+  const header = method.slice(0, open + 1);
+  const body = method.slice(open + 1, method.lastIndexOf('}')).replace(/^\n+|\n+$/g, '');
+  return [
+    header,
+    ...frameSwitch(path).map((line) => `    ${line}`),
+    '    try',
+    '    {',
+    ...body.split('\n').map((line) => (line ? `    ${line}` : line)),
+    '    }',
+    '    finally',
+    '    {',
+    '        driver.SwitchTo().DefaultContent();',
+    '    }',
+    '}',
+  ].join('\n');
 }
 
 function methods(el: ModelElement): string[] {
   const n = el.name;
-  const out: string[] = [
-    `public IWebElement Get${n}Element()\n{\n    return driver.FindElement(${by(activeCandidate(el))});\n}`,
-  ];
+  const path = el.framePath ?? [];
+  const framed = path.length > 0 && !isOpaque(path);
+
+  // No element getter for a framed element: an IWebElement goes stale the
+  // moment the driver switches away (SPEC §16).
+  const elExpr = framed ? `driver.FindElement(${by(activeCandidate(el))})` : `Get${n}Element()`;
+  const selectExpr = framed ? `new SelectElement(${elExpr})` : `Get${n}Select()`;
+
+  const out: string[] = framed
+    ? []
+    : [`public IWebElement Get${n}Element()\n{\n    return driver.FindElement(${by(activeCandidate(el))});\n}`];
 
   switch (classify(el)) {
     case 'actionable':
-      out.push(`public void Click${n}()\n{\n    Get${n}Element().Click();\n}`);
+      out.push(`public void Click${n}()\n{\n    ${elExpr}.Click();\n}`);
       break;
 
     case 'text':
       out.push(
         // GetDomProperty, not GetAttribute: the attribute is the INITIAL value
         // and does not change as the user types (Selenium 4.5+).
-        `public string Get${n}()\n{\n    return Get${n}Element().GetDomProperty("value");\n}`,
+        `public string Get${n}()\n{\n    return ${elExpr}.GetDomProperty("value");\n}`,
         // One method, not Java's overload: C# has default arguments.
-        `public void Set${n}(string value, bool clearFirst = true)\n{\n    IWebElement el = Get${n}Element();\n    if (clearFirst)\n    {\n        el.Clear();\n    }\n    el.SendKeys(value);\n}`
+        `public void Set${n}(string value, bool clearFirst = true)\n{\n    IWebElement el = ${elExpr};\n    if (clearFirst)\n    {\n        el.Clear();\n    }\n    el.SendKeys(value);\n}`
       );
       break;
 
     case 'toggle':
       // `isChecked`, not `checked` — `checked` is a C# keyword.
       out.push(
-        `public bool Is${n}Checked()\n{\n    return Get${n}Element().Selected;\n}`,
-        `public void Set${n}(bool isChecked)\n{\n    IWebElement el = Get${n}Element();\n    if (el.Selected != isChecked)\n    {\n        el.Click();\n    }\n}`
+        `public bool Is${n}Checked()\n{\n    return ${elExpr}.Selected;\n}`,
+        `public void Set${n}(bool isChecked)\n{\n    IWebElement el = ${elExpr};\n    if (el.Selected != isChecked)\n    {\n        el.Click();\n    }\n}`
       );
       break;
 
     case 'radio':
       out.push(
-        `public bool Is${n}Selected()\n{\n    return Get${n}Element().Selected;\n}`,
-        `public void Select${n}()\n{\n    IWebElement el = Get${n}Element();\n    if (!el.Selected)\n    {\n        el.Click();\n    }\n}`
+        `public bool Is${n}Selected()\n{\n    return ${elExpr}.Selected;\n}`,
+        `public void Select${n}()\n{\n    IWebElement el = ${elExpr};\n    if (!el.Selected)\n    {\n        el.Click();\n    }\n}`
       );
       break;
 
     case 'select':
       out.push(
-        `public SelectElement Get${n}Select()\n{\n    return new SelectElement(Get${n}Element());\n}`,
-        `public string Get${n}Text()\n{\n    return Get${n}Select().SelectedOption.Text;\n}`,
-        `public string Get${n}Value()\n{\n    return Get${n}Select().SelectedOption.GetDomProperty("value");\n}`,
-        `public void Set${n}ByValue(string value)\n{\n    Get${n}Select().SelectByValue(value);\n}`,
-        `public void Set${n}ByText(string text)\n{\n    Get${n}Select().SelectByText(text);\n}`
+        ...(framed ? [] : [`public SelectElement ${selectExpr}\n{\n    return new SelectElement(${elExpr});\n}`]),
+        `public string Get${n}Text()\n{\n    return ${selectExpr}.SelectedOption.Text;\n}`,
+        `public string Get${n}Value()\n{\n    return ${selectExpr}.SelectedOption.GetDomProperty("value");\n}`,
+        `public void Set${n}ByValue(string value)\n{\n    ${selectExpr}.SelectByValue(value);\n}`,
+        `public void Set${n}ByText(string text)\n{\n    ${selectExpr}.SelectByText(text);\n}`
       );
       break;
 
     case 'multiSelect':
       out.push(
-        `public SelectElement Get${n}Select()\n{\n    return new SelectElement(Get${n}Element());\n}`,
-        `public IList<string> Get${n}Texts()\n{\n    return Get${n}Select().AllSelectedOptions.Select(o => o.Text).ToList();\n}`,
-        `public IList<string> Get${n}Values()\n{\n    return Get${n}Select().AllSelectedOptions.Select(o => o.GetDomProperty("value")).ToList();\n}`,
+        ...(framed ? [] : [`public SelectElement ${selectExpr}\n{\n    return new SelectElement(${elExpr});\n}`]),
+        `public IList<string> Get${n}Texts()\n{\n    return ${selectExpr}.AllSelectedOptions.Select(o => o.Text).ToList();\n}`,
+        `public IList<string> Get${n}Values()\n{\n    return ${selectExpr}.AllSelectedOptions.Select(o => o.GetDomProperty("value")).ToList();\n}`,
         // DeselectAll first, or SelectByValue ADDS to the selection.
-        `public void Set${n}ByValues(params string[] values)\n{\n    SelectElement el = Get${n}Select();\n    el.DeselectAll();\n    foreach (string value in values)\n    {\n        el.SelectByValue(value);\n    }\n}`,
-        `public void Set${n}ByTexts(params string[] texts)\n{\n    SelectElement el = Get${n}Select();\n    el.DeselectAll();\n    foreach (string text in texts)\n    {\n        el.SelectByText(text);\n    }\n}`,
-        `public void DeselectAll${n}()\n{\n    Get${n}Select().DeselectAll();\n}`
+        `public void Set${n}ByValues(params string[] values)\n{\n    SelectElement el = ${selectExpr};\n    el.DeselectAll();\n    foreach (string value in values)\n    {\n        el.SelectByValue(value);\n    }\n}`,
+        `public void Set${n}ByTexts(params string[] texts)\n{\n    SelectElement el = ${selectExpr};\n    el.DeselectAll();\n    foreach (string text in texts)\n    {\n        el.SelectByText(text);\n    }\n}`,
+        `public void DeselectAll${n}()\n{\n    ${selectExpr}.DeselectAll();\n}`
       );
       break;
 
     case 'static':
       out.push(
         isImage(el)
-          ? `public string Get${n}AltText()\n{\n    return Get${n}Element().GetDomAttribute("alt");\n}`
-          : `public string Get${n}()\n{\n    return Get${n}Element().Text;\n}`
+          ? `public string Get${n}AltText()\n{\n    return ${elExpr}.GetDomAttribute("alt");\n}`
+          : `public string Get${n}()\n{\n    return ${elExpr}.Text;\n}`
       );
       break;
   }
 
-  return out;
+  return framed ? out.map((m) => (m.includes('driver.') ? inFrame(m, path) : m)) : out;
 }
 
 /** `By` fields to paste into your own page object. */

--- a/v3/src/generators/selenium-csharp.ts
+++ b/v3/src/generators/selenium-csharp.ts
@@ -11,6 +11,7 @@ import { underscoreCamel } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameFor } from './class-name';
 import { frameNote } from '../locators/frames';
+import type { FrameStep } from '../engine/types';
 
 const q = doubleQuoted;
 
@@ -30,10 +31,16 @@ function by(c: LocatorCandidate): string {
   return parts ? `By.${BY[parts.kind]}(${q(parts.value)})` : `null /* ${c.kind} is not expressible in Selenium */`;
 }
 
+/** The switch a reader can paste, one line per level, outermost first. */
+const frameSwitch = (path: FrameStep[]) => [
+  'driver.SwitchTo().DefaultContent();',
+  ...path.map((s) => `driver.SwitchTo().Frame(driver.FindElement(${by(s.frame)}));`),
+];
+
 function banner(el: ModelElement): string {
   // The frame chain goes in the banner, where a reader is already looking to
   // see what this block is about (SPEC §16).
-  const frames = frameNote(el.framePath, 'line').map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
+  const frames = frameNote(el.framePath, '//', frameSwitch).map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
   return [`/*`, ` * ${el.name}`, ...frames, ` * ***************************************************************`, ` */`].join('\n');
 }
 
@@ -110,7 +117,7 @@ function methods(el: ModelElement): string[] {
 /** `By` fields to paste into your own page object. */
 export function generateSeleniumCSharpLocators(model: TabModel): string {
   return model.elements
-    .flatMap((el) => [...frameNote(el.framePath, 'line'), `private readonly By ${underscoreCamel(el.name)} = ${by(activeCandidate(el))};`])
+    .flatMap((el) => [...frameNote(el.framePath, '//', frameSwitch), `private readonly By ${underscoreCamel(el.name)} = ${by(activeCandidate(el))};`])
     .join('\n');
 }
 

--- a/v3/src/generators/selenium-java.ts
+++ b/v3/src/generators/selenium-java.ts
@@ -9,6 +9,7 @@ import { lowerCamel } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameFor } from './class-name';
 import { frameNote } from '../locators/frames';
+import type { FrameStep } from '../engine/types';
 
 const q = doubleQuoted;
 
@@ -38,10 +39,16 @@ function by(c: LocatorCandidate): string {
   }
 }
 
+/** The switch a reader can paste, one line per level, outermost first. */
+const frameSwitch = (path: FrameStep[]) => [
+  'driver.switchTo().defaultContent();',
+  ...path.map((s) => `driver.switchTo().frame(driver.findElement(${by(s.frame)}));`),
+];
+
 function banner(el: ModelElement): string {
   // The frame chain goes in the banner, where a reader is already looking to
   // see what this block is about (SPEC §16).
-  const frames = frameNote(el.framePath, 'line').map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
+  const frames = frameNote(el.framePath, '//', frameSwitch).map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
   return [`/*`, ` * ${el.name}`, ...frames, ` * ***************************************************************`, ` */`].join('\n');
 }
 
@@ -132,7 +139,7 @@ function methods(el: ModelElement): string[] {
  */
 export function generateSeleniumJavaLocators(model: TabModel): string {
   return model.elements
-    .flatMap((el) => [...frameNote(el.framePath, 'line'), `private final By ${lowerCamel(el.name)} = ${by(activeCandidate(el))};`])
+    .flatMap((el) => [...frameNote(el.framePath, '//', frameSwitch), `private final By ${lowerCamel(el.name)} = ${by(activeCandidate(el))};`])
     .join('\n');
 }
 

--- a/v3/src/generators/selenium-java.ts
+++ b/v3/src/generators/selenium-java.ts
@@ -8,6 +8,7 @@ import { classify, isImage } from './classify';
 import { lowerCamel } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameFor } from './class-name';
+import { frameNote } from '../locators/frames';
 
 const q = doubleQuoted;
 
@@ -37,8 +38,11 @@ function by(c: LocatorCandidate): string {
   }
 }
 
-function banner(name: string): string {
-  return `/*\n * ${name}\n * ***************************************************************\n */`;
+function banner(el: ModelElement): string {
+  // The frame chain goes in the banner, where a reader is already looking to
+  // see what this block is about (SPEC §16).
+  const frames = frameNote(el.framePath, 'line').map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
+  return [`/*`, ` * ${el.name}`, ...frames, ` * ***************************************************************`, ` */`].join('\n');
 }
 
 function methods(el: ModelElement): string[] {
@@ -128,12 +132,12 @@ function methods(el: ModelElement): string[] {
  */
 export function generateSeleniumJavaLocators(model: TabModel): string {
   return model.elements
-    .map((el) => `private final By ${lowerCamel(el.name)} = ${by(activeCandidate(el))};`)
+    .flatMap((el) => [...frameNote(el.framePath, 'line'), `private final By ${lowerCamel(el.name)} = ${by(activeCandidate(el))};`])
     .join('\n');
 }
 
 export function generateSeleniumJava(model: TabModel): string {
-  return model.elements.map((el) => [banner(el.name), ...methods(el)].join('\n\n')).join('\n\n');
+  return model.elements.map((el) => [banner(el), ...methods(el)].join('\n\n')).join('\n\n');
 }
 
 /**
@@ -165,7 +169,7 @@ export function generateSeleniumJavaPageObject(model: TabModel): string {
     '    }',
     ...model.elements.flatMap((el) => [
       '',
-      indent(banner(el.name)),
+      indent(banner(el)),
       ...methods(el).map(indent).join('\n\n').split('\n'),
     ]),
     '}',

--- a/v3/src/generators/selenium-java.ts
+++ b/v3/src/generators/selenium-java.ts
@@ -8,7 +8,7 @@ import { classify, isImage } from './classify';
 import { lowerCamel } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameFor } from './class-name';
-import { frameNote } from '../locators/frames';
+import { frameContext, frameNote, isOpaque } from '../locators/frames';
 import type { FrameStep } from '../engine/types';
 
 const q = doubleQuoted;
@@ -48,39 +48,74 @@ const frameSwitch = (path: FrameStep[]) => [
 function banner(el: ModelElement): string {
   // The frame chain goes in the banner, where a reader is already looking to
   // see what this block is about (SPEC §16).
-  const frames = frameNote(el.framePath, '//', frameSwitch).map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
+  // Context only: every method below switches for itself.
+  const frames = frameContext(el.framePath, '//').map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
   return [`/*`, ` * ${el.name}`, ...frames, ` * ***************************************************************`, ` */`].join('\n');
+}
+
+/**
+ * Wrap a method so it switches into the element's frame and back out again
+ * (SPEC §16). `switchTo` mutates driver state for everything after it, so a
+ * method that leaves the driver inside a frame breaks the next one — the
+ * `finally` is what makes these safe to call in any order.
+ */
+function inFrame(method: string, path: FrameStep[]): string {
+  const open = method.indexOf('{');
+  const header = method.slice(0, open + 1);
+  const body = method.slice(open + 1, method.lastIndexOf('}')).replace(/^\n+|\n+$/g, '');
+  return [
+    header,
+    ...frameSwitch(path).map((line) => `    ${line}`),
+    '    try {',
+    ...body.split('\n').map((line) => (line ? `    ${line}` : line)),
+    '    } finally {',
+    '        driver.switchTo().defaultContent();',
+    '    }',
+    '}',
+  ].join('\n');
 }
 
 function methods(el: ModelElement): string[] {
   const n = el.name;
-  const out: string[] = [
-    `public WebElement get${n}Element() {\n    return driver.findElement(${by(activeCandidate(el))});\n}`,
-  ];
+  const path = el.framePath ?? [];
+  // Only a complete chain can be switched into. An opaque one leaves the
+  // methods acting on whatever document the driver is already in, which is
+  // what the banner warns about.
+  const framed = path.length > 0 && !isOpaque(path);
+
+  // No element getter for a framed element: a WebElement goes stale the moment
+  // the driver switches away, so handing one back is handing back a guaranteed
+  // failure (SPEC §16). Same for the Select wrapper, which holds one.
+  const elExpr = framed ? `driver.findElement(${by(activeCandidate(el))})` : `get${n}Element()`;
+  const selectExpr = framed ? `new Select(${elExpr})` : `get${n}Select()`;
+
+  const out: string[] = framed
+    ? []
+    : [`public WebElement get${n}Element() {\n    return driver.findElement(${by(activeCandidate(el))});\n}`];
 
   switch (classify(el)) {
     case 'actionable':
-      out.push(`public void click${n}() {\n    get${n}Element().click();\n}`);
+      out.push(`public void click${n}() {\n    ${elExpr}.click();\n}`);
       break;
 
     case 'text':
       out.push(
         // getDomProperty, not getAttribute: the attribute is the INITIAL value
         // and does not change as the user types (Selenium 4.5+).
-        `public String get${n}() {\n    return get${n}Element().getDomProperty("value");\n}`,
+        `public String get${n}() {\n    return ${elExpr}.getDomProperty("value");\n}`,
         // Clearing is the default, because v2.5.1's setter appended and almost
         // nobody wanted that. An overload keeps appending available rather than
         // trading one hard-coded behaviour for the other — Java has no default
         // arguments, so it is two methods.
         `public void set${n}(String value) {\n    set${n}(value, true);\n}`,
-        `public void set${n}(String value, boolean clearFirst) {\n    WebElement el = get${n}Element();\n    if (clearFirst) {\n        el.clear();\n    }\n    el.sendKeys(value);\n}`
+        `public void set${n}(String value, boolean clearFirst) {\n    WebElement el = ${elExpr};\n    if (clearFirst) {\n        el.clear();\n    }\n    el.sendKeys(value);\n}`
       );
       break;
 
     case 'toggle':
       out.push(
-        `public boolean is${n}Checked() {\n    return get${n}Element().isSelected();\n}`,
-        `public void set${n}(boolean checked) {\n    WebElement el = get${n}Element();\n    if (el.isSelected() != checked) {\n        el.click();\n    }\n}`
+        `public boolean is${n}Checked() {\n    return ${elExpr}.isSelected();\n}`,
+        `public void set${n}(boolean checked) {\n    WebElement el = ${elExpr};\n    if (el.isSelected() != checked) {\n        el.click();\n    }\n}`
       );
       break;
 
@@ -88,35 +123,35 @@ function methods(el: ModelElement): string[] {
       // No set(false): clicking a checked radio does not uncheck it, so
       // v2.5.1's setter silently did nothing. Selecting is the only real verb.
       out.push(
-        `public boolean is${n}Selected() {\n    return get${n}Element().isSelected();\n}`,
-        `public void select${n}() {\n    WebElement el = get${n}Element();\n    if (!el.isSelected()) {\n        el.click();\n    }\n}`
+        `public boolean is${n}Selected() {\n    return ${elExpr}.isSelected();\n}`,
+        `public void select${n}() {\n    WebElement el = ${elExpr};\n    if (!el.isSelected()) {\n        el.click();\n    }\n}`
       );
       break;
 
     case 'select':
       out.push(
-        `public Select get${n}Select() {\n    return new Select(get${n}Element());\n}`,
-        `public String get${n}Text() {\n    return get${n}Select().getFirstSelectedOption().getText();\n}`,
-        `public String get${n}Value() {\n    return get${n}Select().getFirstSelectedOption().getDomProperty("value");\n}`,
-        `public void set${n}ByValue(String value) {\n    get${n}Select().selectByValue(value);\n}`,
-        `public void set${n}ByText(String text) {\n    get${n}Select().selectByVisibleText(text);\n}`
+        ...(framed ? [] : [`public Select get${n}Select() {\n    return new Select(${elExpr});\n}`]),
+        `public String get${n}Text() {\n    return ${selectExpr}.getFirstSelectedOption().getText();\n}`,
+        `public String get${n}Value() {\n    return ${selectExpr}.getFirstSelectedOption().getDomProperty("value");\n}`,
+        `public void set${n}ByValue(String value) {\n    ${selectExpr}.selectByValue(value);\n}`,
+        `public void set${n}ByText(String text) {\n    ${selectExpr}.selectByVisibleText(text);\n}`
       );
       break;
 
     case 'multiSelect':
       out.push(
-        `public Select get${n}Select() {\n    return new Select(get${n}Element());\n}`,
+        ...(framed ? [] : [`public Select get${n}Select() {\n    return new Select(${elExpr});\n}`]),
         // getAllSelectedOptions, not getFirstSelectedOption: the first of N is
         // not the answer to "what is selected".
-        `public List<String> get${n}Texts() {\n    return get${n}Select().getAllSelectedOptions().stream()\n        .map(WebElement::getText)\n        .collect(Collectors.toList());\n}`,
-        `public List<String> get${n}Values() {\n    return get${n}Select().getAllSelectedOptions().stream()\n        .map(o -> o.getDomProperty("value"))\n        .collect(Collectors.toList());\n}`,
+        `public List<String> get${n}Texts() {\n    return ${selectExpr}.getAllSelectedOptions().stream()\n        .map(WebElement::getText)\n        .collect(Collectors.toList());\n}`,
+        `public List<String> get${n}Values() {\n    return ${selectExpr}.getAllSelectedOptions().stream()\n        .map(o -> o.getDomProperty("value"))\n        .collect(Collectors.toList());\n}`,
         // deselectAll first, or selectByValue ADDS to the selection and `set`
         // does not mean set.
-        `public void set${n}ByValues(String... values) {\n    Select el = get${n}Select();\n    el.deselectAll();\n    for (String value : values) {\n        el.selectByValue(value);\n    }\n}`,
-        `public void set${n}ByTexts(String... texts) {\n    Select el = get${n}Select();\n    el.deselectAll();\n    for (String text : texts) {\n        el.selectByVisibleText(text);\n    }\n}`,
+        `public void set${n}ByValues(String... values) {\n    Select el = ${selectExpr};\n    el.deselectAll();\n    for (String value : values) {\n        el.selectByValue(value);\n    }\n}`,
+        `public void set${n}ByTexts(String... texts) {\n    Select el = ${selectExpr};\n    el.deselectAll();\n    for (String text : texts) {\n        el.selectByVisibleText(text);\n    }\n}`,
         // Only for a multi-select: deselectAll throws
         // UnsupportedOperationException on a single one.
-        `public void deselectAll${n}() {\n    get${n}Select().deselectAll();\n}`
+        `public void deselectAll${n}() {\n    ${selectExpr}.deselectAll();\n}`
       );
       break;
 
@@ -124,13 +159,15 @@ function methods(el: ModelElement): string[] {
       out.push(
         isImage(el)
           ? // getText() on an <img> returns an empty string; alt is the text.
-            `public String get${n}AltText() {\n    return get${n}Element().getDomAttribute("alt");\n}`
-          : `public String get${n}() {\n    return get${n}Element().getText();\n}`
+            `public String get${n}AltText() {\n    return ${elExpr}.getDomAttribute("alt");\n}`
+          : `public String get${n}() {\n    return ${elExpr}.getText();\n}`
       );
       break;
   }
 
-  return out;
+  // A method that never touches the driver has nothing to switch for — the
+  // convenience overload just calls its sibling, which switches for itself.
+  return framed ? out.map((m) => (m.includes('driver.') ? inFrame(m, path) : m)) : out;
 }
 
 /**

--- a/v3/src/generators/selenium-python.ts
+++ b/v3/src/generators/selenium-python.ts
@@ -11,6 +11,7 @@ import { snake, upperSnake } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameFor } from './class-name';
 import { frameNote } from '../locators/frames';
+import type { FrameStep } from '../engine/types';
 
 /** Double-quoted, Black's default. */
 const q = doubleQuoted;
@@ -37,9 +38,18 @@ function find(c: LocatorCandidate, recv: string): string {
   return parts ? `${recv}driver.find_element(By.${BY[parts.kind]}, ${q(parts.value)})` : byTuple(c);
 }
 
+/** The switch a reader can paste, one line per level, outermost first. */
+const frameSwitch = (path: FrameStep[]) => [
+  'driver.switch_to.default_content()',
+  ...path.map((s) => {
+    const parts = byParts(s.frame);
+    return `driver.switch_to.frame(driver.find_element(By.${BY[parts!.kind]}, ${q(parts!.value)}))`;
+  }),
+];
+
 function banner(el: ModelElement): string {
   const rule = '#'.repeat(63);
-  return [rule, `# ${el.name}`, ...frameNote(el.framePath, 'hash'), rule].join('\n');
+  return [rule, `# ${el.name}`, ...frameNote(el.framePath, '#', frameSwitch), rule].join('\n');
 }
 
 /**
@@ -128,7 +138,7 @@ function methods(el: ModelElement, recv: string): string[] {
  */
 export function generateSeleniumPythonLocators(model: TabModel): string {
   return model.elements
-    .flatMap((el) => [...frameNote(el.framePath, 'hash'), `${upperSnake(el.name)} = ${byTuple(activeCandidate(el))}`])
+    .flatMap((el) => [...frameNote(el.framePath, '#', frameSwitch), `${upperSnake(el.name)} = ${byTuple(activeCandidate(el))}`])
     .join('\n');
 }
 

--- a/v3/src/generators/selenium-python.ts
+++ b/v3/src/generators/selenium-python.ts
@@ -10,7 +10,7 @@ import { classify, isImage } from './classify';
 import { snake, upperSnake } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameFor } from './class-name';
-import { frameNote } from '../locators/frames';
+import { frameContext, frameNote, isOpaque } from '../locators/frames';
 import type { FrameStep } from '../engine/types';
 
 /** Double-quoted, Black's default. */
@@ -33,23 +33,27 @@ function byTuple(c: LocatorCandidate): string {
   return parts ? `(By.${BY[parts.kind]}, ${q(parts.value)})` : `None  # ${c.kind} is not expressible in Selenium`;
 }
 
+/** `By.X, "value"` — the arguments find_element and switch_to.frame share. */
+function findArgs(c: LocatorCandidate): string {
+  const parts = byParts(c);
+  return parts ? `By.${BY[parts.kind]}, ${q(parts.value)}` : 'None';
+}
+
 function find(c: LocatorCandidate, recv: string): string {
   const parts = byParts(c);
-  return parts ? `${recv}driver.find_element(By.${BY[parts.kind]}, ${q(parts.value)})` : byTuple(c);
+  return parts ? `${recv}driver.find_element(${findArgs(c)})` : byTuple(c);
 }
 
 /** The switch a reader can paste, one line per level, outermost first. */
-const frameSwitch = (path: FrameStep[]) => [
-  'driver.switch_to.default_content()',
-  ...path.map((s) => {
-    const parts = byParts(s.frame);
-    return `driver.switch_to.frame(driver.find_element(By.${BY[parts!.kind]}, ${q(parts!.value)}))`;
-  }),
+const frameSwitch = (path: FrameStep[], recv = '') => [
+  `${recv}driver.switch_to.default_content()`,
+  ...path.map((s) => `${recv}driver.switch_to.frame(${recv}driver.find_element(${findArgs(s.frame)}))`),
 ];
 
 function banner(el: ModelElement): string {
   const rule = '#'.repeat(63);
-  return [rule, `# ${el.name}`, ...frameNote(el.framePath, '#', frameSwitch), rule].join('\n');
+  // Context only: every definition below switches for itself.
+  return [rule, `# ${el.name}`, ...frameContext(el.framePath, '#'), rule].join('\n');
 }
 
 /**
@@ -57,8 +61,32 @@ function banner(el: ModelElement): string {
  * functions, `self.` inside a class. Python has no implicit receiver, so this
  * cannot be a wrapper the way it can in Java and C# — every call site changes.
  */
+/** See selenium-java.ts: switch_to mutates driver state, so the finally matters. */
+function inFrame(method: string, path: FrameStep[], recv: string): string {
+  const colon = method.indexOf(':\n');
+  const header = method.slice(0, colon + 1);
+  const body = method.slice(colon + 2);
+  return [
+    header,
+    ...frameSwitch(path, recv).map((line) => `    ${line}`),
+    '    try:',
+    ...body.split('\n').map((line) => (line ? `    ${line}` : line)),
+    '    finally:',
+    `        ${recv}driver.switch_to.default_content()`,
+  ].join('\n');
+}
+
 function methods(el: ModelElement, recv: string): string[] {
   const n = snake(el.name);
+  const path = el.framePath ?? [];
+  const framed = path.length > 0 && !isOpaque(path);
+
+  // No element getter for a framed element: the WebElement goes stale the
+  // moment the driver switches away (SPEC §16).
+  const elExpr = framed
+    ? `${recv}driver.find_element(${findArgs(activeCandidate(el))})`
+    : `${recv}get_${n}_element()`;
+  const selectExpr = framed ? `Select(${elExpr})` : `${recv}get_${n}_select()`;
   // `def f()` at module level, `def f(self)` in a class — and `self` goes
   // first, ahead of any real arguments.
   const def = (sig: string) => {
@@ -67,69 +95,71 @@ function methods(el: ModelElement, recv: string): string[] {
     const args = sig.slice(open + 1, -1);
     return `def ${sig.slice(0, open)}(self${args ? `, ${args}` : ''})`;
   };
-  const out: string[] = [`${def(`get_${n}_element()`)}:\n    return ${find(activeCandidate(el), recv)}`];
+  const out: string[] = framed
+    ? []
+    : [`${def(`get_${n}_element()`)}:\n    return ${find(activeCandidate(el), recv)}`];
 
   switch (classify(el)) {
     case 'actionable':
-      out.push(`${def(`click_${n}()`)}:\n    ${recv}get_${n}_element().click()`);
+      out.push(`${def(`click_${n}()`)}:\n    ${elExpr}.click()`);
       break;
 
     case 'text':
       out.push(
         // get_dom_property, not get_attribute: the attribute is the INITIAL
         // value and does not change as the user types (Selenium 4.5+).
-        `${def(`get_${n}()`)}:\n    return ${recv}get_${n}_element().get_dom_property("value")`,
+        `${def(`get_${n}()`)}:\n    return ${elExpr}.get_dom_property("value")`,
         // One function: Python has default arguments.
-        `${def(`set_${n}(value, clear_first=True)`)}:\n    el = ${recv}get_${n}_element()\n    if clear_first:\n        el.clear()\n    el.send_keys(value)`
+        `${def(`set_${n}(value, clear_first=True)`)}:\n    el = ${elExpr}\n    if clear_first:\n        el.clear()\n    el.send_keys(value)`
       );
       break;
 
     case 'toggle':
       out.push(
-        `${def(`is_${n}_checked()`)}:\n    return ${recv}get_${n}_element().is_selected()`,
-        `${def(`set_${n}(checked)`)}:\n    el = ${recv}get_${n}_element()\n    if el.is_selected() != checked:\n        el.click()`
+        `${def(`is_${n}_checked()`)}:\n    return ${elExpr}.is_selected()`,
+        `${def(`set_${n}(checked)`)}:\n    el = ${elExpr}\n    if el.is_selected() != checked:\n        el.click()`
       );
       break;
 
     case 'radio':
       out.push(
-        `${def(`is_${n}_selected()`)}:\n    return ${recv}get_${n}_element().is_selected()`,
-        `${def(`select_${n}()`)}:\n    el = ${recv}get_${n}_element()\n    if not el.is_selected():\n        el.click()`
+        `${def(`is_${n}_selected()`)}:\n    return ${elExpr}.is_selected()`,
+        `${def(`select_${n}()`)}:\n    el = ${elExpr}\n    if not el.is_selected():\n        el.click()`
       );
       break;
 
     case 'select':
       out.push(
-        `${def(`get_${n}_select()`)}:\n    return Select(${recv}get_${n}_element())`,
-        `${def(`get_${n}_text()`)}:\n    return ${recv}get_${n}_select().first_selected_option.text`,
-        `${def(`get_${n}_value()`)}:\n    return ${recv}get_${n}_select().first_selected_option.get_dom_property("value")`,
-        `${def(`set_${n}_by_value(value)`)}:\n    ${recv}get_${n}_select().select_by_value(value)`,
-        `${def(`set_${n}_by_text(text)`)}:\n    ${recv}get_${n}_select().select_by_visible_text(text)`
+        ...(framed ? [] : [`${def(`get_${n}_select()`)}:\n    return Select(${elExpr})`]),
+        `${def(`get_${n}_text()`)}:\n    return ${selectExpr}.first_selected_option.text`,
+        `${def(`get_${n}_value()`)}:\n    return ${selectExpr}.first_selected_option.get_dom_property("value")`,
+        `${def(`set_${n}_by_value(value)`)}:\n    ${selectExpr}.select_by_value(value)`,
+        `${def(`set_${n}_by_text(text)`)}:\n    ${selectExpr}.select_by_visible_text(text)`
       );
       break;
 
     case 'multiSelect':
       out.push(
-        `${def(`get_${n}_select()`)}:\n    return Select(${recv}get_${n}_element())`,
-        `${def(`get_${n}_texts()`)}:\n    return [o.text for o in ${recv}get_${n}_select().all_selected_options]`,
-        `${def(`get_${n}_values()`)}:\n    return [o.get_dom_property("value") for o in ${recv}get_${n}_select().all_selected_options]`,
+        ...(framed ? [] : [`${def(`get_${n}_select()`)}:\n    return Select(${elExpr})`]),
+        `${def(`get_${n}_texts()`)}:\n    return [o.text for o in ${selectExpr}.all_selected_options]`,
+        `${def(`get_${n}_values()`)}:\n    return [o.get_dom_property("value") for o in ${selectExpr}.all_selected_options]`,
         // deselect_all first, or select_by_value ADDS to the selection.
-        `${def(`set_${n}_by_values(*values)`)}:\n    el = ${recv}get_${n}_select()\n    el.deselect_all()\n    for value in values:\n        el.select_by_value(value)`,
-        `${def(`set_${n}_by_texts(*texts)`)}:\n    el = ${recv}get_${n}_select()\n    el.deselect_all()\n    for text in texts:\n        el.select_by_visible_text(text)`,
-        `${def(`deselect_all_${n}()`)}:\n    ${recv}get_${n}_select().deselect_all()`
+        `${def(`set_${n}_by_values(*values)`)}:\n    el = ${selectExpr}\n    el.deselect_all()\n    for value in values:\n        el.select_by_value(value)`,
+        `${def(`set_${n}_by_texts(*texts)`)}:\n    el = ${selectExpr}\n    el.deselect_all()\n    for text in texts:\n        el.select_by_visible_text(text)`,
+        `${def(`deselect_all_${n}()`)}:\n    ${selectExpr}.deselect_all()`
       );
       break;
 
     case 'static':
       out.push(
         isImage(el)
-          ? `${def(`get_${n}_alt_text()`)}:\n    return ${recv}get_${n}_element().get_dom_attribute("alt")`
-          : `${def(`get_${n}()`)}:\n    return ${recv}get_${n}_element().text`
+          ? `${def(`get_${n}_alt_text()`)}:\n    return ${elExpr}.get_dom_attribute("alt")`
+          : `${def(`get_${n}()`)}:\n    return ${elExpr}.text`
       );
       break;
   }
 
-  return out;
+  return framed ? out.map((m) => (m.includes('driver.') ? inFrame(m, path, recv) : m)) : out;
 }
 
 /**

--- a/v3/src/generators/selenium-python.ts
+++ b/v3/src/generators/selenium-python.ts
@@ -10,6 +10,7 @@ import { classify, isImage } from './classify';
 import { snake, upperSnake } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameFor } from './class-name';
+import { frameNote } from '../locators/frames';
 
 /** Double-quoted, Black's default. */
 const q = doubleQuoted;
@@ -36,9 +37,9 @@ function find(c: LocatorCandidate, recv: string): string {
   return parts ? `${recv}driver.find_element(By.${BY[parts.kind]}, ${q(parts.value)})` : byTuple(c);
 }
 
-function banner(name: string): string {
+function banner(el: ModelElement): string {
   const rule = '#'.repeat(63);
-  return `${rule}\n# ${name}\n${rule}`;
+  return [rule, `# ${el.name}`, ...frameNote(el.framePath, 'hash'), rule].join('\n');
 }
 
 /**
@@ -126,12 +127,14 @@ function methods(el: ModelElement, recv: string): string[] {
  * `driver.find_element(*EMAIL_ADDRESS)` at the call site.
  */
 export function generateSeleniumPythonLocators(model: TabModel): string {
-  return model.elements.map((el) => `${upperSnake(el.name)} = ${byTuple(activeCandidate(el))}`).join('\n');
+  return model.elements
+    .flatMap((el) => [...frameNote(el.framePath, 'hash'), `${upperSnake(el.name)} = ${byTuple(activeCandidate(el))}`])
+    .join('\n');
 }
 
 export function generateSeleniumPython(model: TabModel): string {
   // Two blank lines between top-level definitions, per PEP 8.
-  return model.elements.map((el) => [banner(el.name), ...methods(el, '')].join('\n\n\n')).join('\n\n\n');
+  return model.elements.map((el) => [banner(el), ...methods(el, '')].join('\n\n\n')).join('\n\n\n');
 }
 
 /** The methods as a class (SPEC §17). One blank line between methods, per PEP 8. */
@@ -152,7 +155,7 @@ export function generateSeleniumPythonPageObject(model: TabModel): string {
     '    def __init__(self, driver):',
     '        self.driver = driver',
     // One blank line between methods, per PEP 8 — two is for top level.
-    ...model.elements.flatMap((el) => ['', indent(banner(el.name)), ...methods(el, 'self.').map(indent).join('\n\n').split('\n')]),
+    ...model.elements.flatMap((el) => ['', indent(banner(el)), ...methods(el, 'self.').map(indent).join('\n\n').split('\n')]),
     '',
   ].join('\n');
 }

--- a/v3/src/generators/ts-page-object.ts
+++ b/v3/src/generators/ts-page-object.ts
@@ -14,6 +14,8 @@ export interface TsTarget {
   module: string;
   /** The call, without the leading `page.` */
   expr: (el: ModelElement) => string;
+  /** Comment lines to place above an element, when it needs any. */
+  note?: (el: ModelElement) => string[];
   /**
    * How to write the field's type. Playwright's `Locator` is plain; Puppeteer's
    * is generic over the node it yields, so a bare `Locator` does not compile.
@@ -44,7 +46,10 @@ export function tsPageObject(model: TabModel, target: TsTarget): string {
     // Assignment reads the constructor PARAMETER, not `this.page`: a parameter
     // property is not assigned until the constructor body completes.
     '  constructor(private readonly page: Page) {',
-    ...model.elements.map((el) => `    this.${lowerCamel(el.name)} = page.${target.expr(el)};`),
+    ...model.elements.flatMap((el) => [
+      ...(target.note?.(el) ?? []).map((line) => `    ${line}`),
+      `    this.${lowerCamel(el.name)} = page.${target.expr(el)};`,
+    ]),
     '  }',
     '}',
     '',
@@ -53,5 +58,7 @@ export function tsPageObject(model: TabModel, target: TsTarget): string {
 
 /** Locators only — no class, and the types are inferred. */
 export function tsLocators(model: TabModel, target: TsTarget): string {
-  return model.elements.map((el) => `const ${lowerCamel(el.name)} = page.${target.expr(el)};`).join('\n');
+  return model.elements
+    .flatMap((el) => [...(target.note?.(el) ?? []), `const ${lowerCamel(el.name)} = page.${target.expr(el)};`])
+    .join('\n');
 }

--- a/v3/src/locators/display.ts
+++ b/v3/src/locators/display.ts
@@ -5,6 +5,8 @@
 // name, so there is no single value to put after a colon.
 import type { LocatorCandidate } from '../engine/types';
 import { singleQuoted, doubleQuoted } from '../quote';
+import type { FrameStep } from '../engine/types';
+import { frameSelector, playwrightFramePrefix, playwrightPyFramePrefix } from './frames';
 
 const q = singleQuoted;
 const qq = doubleQuoted;
@@ -129,6 +131,22 @@ export function typeValue(c: LocatorCandidate): string {
     case 'partialLinkText':
       return `${c.kind}: ${c.text}`;
   }
+}
+
+/**
+ * What the table shows for an element, frame chain included (SPEC §6, §16).
+ *
+ * Playwright carries the chain in the expression. The others cannot, so they
+ * get a `frame › frame ›` prefix: shorter than a comment and it stops two rows
+ * looking identical when only their frame differs — which is exactly what
+ * happened before this existed.
+ */
+export function displayElementLocator(c: LocatorCandidate, frameworkId: string, framePath?: FrameStep[]): string {
+  if (!framePath || framePath.length === 0) return displayLocator(c, frameworkId);
+  if (frameworkId === 'playwright-python') return playwrightPyFramePrefix(framePath) + playwrightPyExpr(c);
+  if (frameworkId.startsWith('playwright')) return playwrightFramePrefix(framePath) + playwrightExpr(c);
+  const chain = framePath.map(frameSelector).join(' › ');
+  return `${chain} › ${displayLocator(c, frameworkId)}`;
 }
 
 export function displayLocator(c: LocatorCandidate, frameworkId: string): string {

--- a/v3/src/locators/frames.ts
+++ b/v3/src/locators/frames.ts
@@ -33,18 +33,30 @@ export function playwrightPyFramePrefix(path: Path): string {
   return (path ?? []).map((s) => `frame_locator(${doubleQuoted(frameSelector(s))}).`).join('');
 }
 
+/** How a step reads to a person: no Playwright `xpath=` prefix in prose. */
+export function describeStep(step: FrameStep): string {
+  if (step.opaque) return 'a cross-origin frame';
+  return step.frame.kind === 'xpath' ? `xpath ${step.frame.value}` : (step.frame as { value: string }).value;
+}
+
 /**
- * The note that has to accompany a frame-bound locator in a target that cannot
- * express the chain. Without it the locator looks like every other one and
- * quietly resolves against the wrong document.
+ * The comment that has to accompany a frame-bound locator in a target that
+ * cannot express the chain. Without it the locator looks like every other one
+ * and quietly resolves against the wrong document.
+ *
+ * It carries the switch itself, commented out, rather than an instruction to
+ * go and write one: the reader can paste it. `switchTo` is supplied by the
+ * generator, so each language spells its own API and its own `By`.
  */
-export function frameNote(path: Path, style: 'line' | 'hash'): string[] {
+export function frameNote(path: Path, comment: string, switchTo: (path: FrameStep[]) => string[]): string[] {
   if (!path || path.length === 0) return [];
-  const mark = style === 'hash' ? '#' : '//';
-  const chain = path.map((s) => frameSelector(s)).join(' › ');
-  const lines = [`${mark} In frame: ${chain}`, `${mark} Switch to it before using this locator.`];
+  const lines = [`In frame: ${path.map(describeStep).join(' \u203a ')}`];
   if (isOpaque(path)) {
-    lines.push(`${mark} The chain is incomplete: a frame above this one is cross-origin.`);
+    // Half a chain is worse than none: pasting it would switch into the wrong
+    // document and look like it worked.
+    lines.push('A frame above this one is cross-origin, so the chain is incomplete.');
+  } else {
+    lines.push(...switchTo(path));
   }
-  return lines;
+  return lines.map((line) => `${comment} ${line}`);
 }

--- a/v3/src/locators/frames.ts
+++ b/v3/src/locators/frames.ts
@@ -48,6 +48,18 @@ export function describeStep(step: FrameStep): string {
  * go and write one: the reader can paste it. `switchTo` is supplied by the
  * generator, so each language spells its own API and its own `By`.
  */
+/**
+ * Just where the element is. For shapes whose methods switch for themselves —
+ * repeating the switch in the banner is noise the reader has to check against
+ * the code below it.
+ */
+export function frameContext(path: Path, comment: string): string[] {
+  if (!path || path.length === 0) return [];
+  const lines = [`In frame: ${path.map(describeStep).join(' \u203a ')}`];
+  if (isOpaque(path)) lines.push('A frame above this one is cross-origin: switch into it yourself first.');
+  return lines.map((line) => `${comment} ${line}`);
+}
+
 export function frameNote(path: Path, comment: string, switchTo: (path: FrameStep[]) => string[]): string[] {
   if (!path || path.length === 0) return [];
   const lines = [`In frame: ${path.map(describeStep).join(' \u203a ')}`];

--- a/v3/src/locators/frames.ts
+++ b/v3/src/locators/frames.ts
@@ -1,0 +1,50 @@
+// How a frame path reads in each target (SPEC §16).
+//
+// The split that matters: Playwright can carry the chain inside the locator, so
+// its output stays self-contained. Selenium and Puppeteer cannot — a `By` is
+// frame-agnostic and `page.locator` is page-scoped — so their output has to say
+// out loud that a switch is required first, or it silently addresses the wrong
+// document.
+import type { FrameStep } from '../engine/types';
+import { singleQuoted, doubleQuoted } from '../quote';
+
+/** The selector string for one step; every frame API in reach takes one. */
+export function frameSelector(step: FrameStep): string {
+  return step.frame.kind === 'xpath' ? `xpath=${step.frame.value}` : (step.frame as { value: string }).value;
+}
+
+/**
+ * Paths are optional throughout because a model can outlive the version that
+ * wrote it: `storage.session` survives an extension reload, so elements
+ * captured before frame support existed still arrive without one.
+ */
+type Path = FrameStep[] | undefined;
+
+/** True when the chain is incomplete because a document in it is cross-origin. */
+export const isOpaque = (path: Path) => (path ?? []).some((s) => s.opaque);
+
+/** `frameLocator('#a').frameLocator('#b').`, or '' for the main frame. */
+export function playwrightFramePrefix(path: Path): string {
+  return (path ?? []).map((s) => `frameLocator(${singleQuoted(frameSelector(s))}).`).join('');
+}
+
+/** The Python spelling of the same chain. */
+export function playwrightPyFramePrefix(path: Path): string {
+  return (path ?? []).map((s) => `frame_locator(${doubleQuoted(frameSelector(s))}).`).join('');
+}
+
+/**
+ * The note that has to accompany a frame-bound locator in a target that cannot
+ * express the chain. Without it the locator looks like every other one and
+ * quietly resolves against the wrong document.
+ */
+export function frameNote(path: Path, style: 'line' | 'hash'): string[] {
+  if (!path || path.length === 0) return [];
+  const mark = style === 'hash' ? '#' : '//';
+  const chain = path.map((s) => frameSelector(s)).join(' › ');
+  const lines = [`${mark} In frame: ${chain}`, `${mark} Switch to it before using this locator.`];
+  if (isOpaque(path)) {
+    lines.push(`${mark} The chain is incomplete: a frame above this one is cross-origin.`);
+  }
+  return lines;
+}

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -13,6 +13,14 @@ export type PanelToContent =
   // script reading storage would need its own access level.
   | { type: 'START_PICKING'; mode: PickMode; includeHidden: boolean }
   | { type: 'STOP_PICKING' }
+  // Overlay ownership. The content script runs in every frame and each draws
+  // its own overlay; without a single owner, hovering down through nested
+  // frames leaves a highlight and a breadcrumb in every frame on the way.
+  // Pointer events cannot decide it — a parent frame gets no mouseout when the
+  // pointer crosses into a child — so a frame announces that it has drawn and
+  // the background tells the others to clear.
+  | { type: 'OVERLAY_SHOWN'; token: string }
+  | { type: 'OVERLAY_OWNER'; token: string }
   // Walk the pick target up or down the DOM (SPEC §4). Sent by the panel
   // because focus is there after clicking Add Element, so the page never sees
   // the keydown — the same reason the panel also handles Escape.

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -11,7 +11,12 @@ export type PanelToContent =
   // `includeHidden` is the modelHiddenElements setting (SPEC §14), passed in
   // rather than read in the page: the panel already has it, and a content
   // script reading storage would need its own access level.
-  | { type: 'START_PICKING'; mode: PickMode; includeHidden: boolean }
+  // `nonce` is shared by every frame in the tab for this picking session, and
+  // is how a frame recognises a scan request from its parent as ours. A page
+  // cannot read it — content scripts run in an isolated world — and it does not
+  // depend on the receiving frame still being armed, which a cascading scan
+  // cannot guarantee (SPEC §16).
+  | { type: 'START_PICKING'; mode: PickMode; includeHidden: boolean; nonce: string }
   | { type: 'STOP_PICKING' }
   // Overlay ownership. The content script runs in every frame and each draws
   // its own overlay; without a single owner, hovering down through nested

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -1,4 +1,4 @@
-import type { ElementResult, LocatorCandidate } from './engine/types';
+import type { ElementResult, FrameStep, LocatorCandidate } from './engine/types';
 import type { TabModel } from './model';
 
 // Messages panel → content (sent via browser.tabs.sendMessage to the active tab).
@@ -29,7 +29,9 @@ export type PanelToContent =
   | { type: 'PICK_TARGET' }
   // View Matched Elements (SPEC §8). Answered by HIGHLIGHT_RESULT, not by a
   // reply — see the note on ContentToPanel below.
-  | { type: 'HIGHLIGHT'; candidate: LocatorCandidate }
+  // framePath says WHICH document to resolve in: every frame hears this, and
+  // the one whose own path matches is the one that answers (SPEC §16).
+  | { type: 'HIGHLIGHT'; candidate: LocatorCandidate; framePath?: FrameStep[] }
   // Clear the highlight early — the user dismissed the match count.
   | { type: 'CLEAR_HIGHLIGHT' };
 

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -333,6 +333,47 @@ test('the eye finds a framed element, and only its own frame answers (SPEC §16)
   expect((await results())[0].count).toBe(1);
 });
 
+test('scanning a frame scans inside it, with the chain on every element (SPEC §16)', async () => {
+  // An <iframe> has no descendants in its parent's document, so scanning one
+  // used to return nothing at all.
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'frame-scan', 'frames.html');
+  await page.waitForLoadState('networkidle');
+  await collectMessages(sw as never);
+
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'scan' }), tabId);
+
+  // The frame element itself has to be the target, which means hitting its
+  // BORDER: a click inside the box is routed to the child document, where the
+  // child's own picker handles it. Playwright's `position` is relative to the
+  // PADDING box, so it can never land there — raw coordinates can.
+  const box = (await page.locator('#same-frame').boundingBox())!;
+  await page.mouse.move(box.x + 1, box.y + 1);
+  await page.mouse.down();
+  await page.mouse.up();
+
+  await expect
+    .poll(async () => (await sw.evaluate(() => (globalThis as unknown as { __picks: { type: string }[] }).__picks))
+      .filter((m) => m.type === 'ELEMENTS_PICKED').length)
+    .toBe(1);
+
+  const picks = await sw.evaluate(() => (globalThis as unknown as { __picks: Record<string, unknown>[] }).__picks);
+  const haul = (picks.find((m) => m.type === 'ELEMENTS_PICKED') as {
+    results: { suggestedName: string; framePath: { frame: { value: string } }[] }[];
+  }).results;
+
+  // The frame's own controls: an email field and a Submit.
+  expect(haul.length, haul.map((r) => r.suggestedName).join(', ')).toBeGreaterThanOrEqual(2);
+  // Every one of them carries the chain to the frame it was found in — the
+  // scan ran inside the frame, so the paths come out right for free.
+  for (const r of haul) {
+    expect(r.framePath.map((s) => s.frame.value)[0], r.suggestedName).toBe('#same-frame');
+  }
+  expect(haul.map((r) => r.suggestedName)).toContain('Submit');
+});
+
 test('the background relays panel messages, and reports an unreachable tab', async () => {
   let [sw] = context.serviceWorkers();
   if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -343,7 +343,10 @@ test('scanning a frame scans inside it, with the chain on every element (SPEC §
   await page.waitForLoadState('networkidle');
   await collectMessages(sw as never);
 
-  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'scan' }), tabId);
+  await sw.evaluate(
+    (id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'scan', nonce: 'test-nonce' }),
+    tabId
+  );
 
   // The frame element itself has to be the target, which means hitting its
   // BORDER: a click inside the box is routed to the child document, where the
@@ -354,24 +357,33 @@ test('scanning a frame scans inside it, with the chain on every element (SPEC §
   await page.mouse.down();
   await page.mouse.up();
 
-  await expect
-    .poll(async () => (await sw.evaluate(() => (globalThis as unknown as { __picks: { type: string }[] }).__picks))
-      .filter((m) => m.type === 'ELEMENTS_PICKED').length)
-    .toBe(1);
+  // Each frame reports its own haul, so two land: the frame and its child.
+  const hauls = async () => {
+    const all = await sw.evaluate(
+      () => (globalThis as unknown as { __picks: { type: string; results?: unknown[] }[] }).__picks
+    );
+    return all.filter((m) => m.type === 'ELEMENTS_PICKED');
+  };
+  await expect.poll(async () => (await hauls()).length, { message: 'the nested frame reports too' }).toBe(2);
 
-  const picks = await sw.evaluate(() => (globalThis as unknown as { __picks: Record<string, unknown>[] }).__picks);
-  const haul = (picks.find((m) => m.type === 'ELEMENTS_PICKED') as {
-    results: { suggestedName: string; framePath: { frame: { value: string } }[] }[];
-  }).results;
+  const results = (await hauls()).flatMap(
+    (m) => (m as { results: { suggestedName: string; framePath: { frame: { value: string } }[] }[] }).results
+  );
+  const paths = results.map((r) => r.framePath.map((s) => s.frame.value).join(' › '));
 
-  // The frame's own controls: an email field and a Submit.
-  expect(haul.length, haul.map((r) => r.suggestedName).join(', ')).toBeGreaterThanOrEqual(2);
-  // Every one of them carries the chain to the frame it was found in — the
-  // scan ran inside the frame, so the paths come out right for free.
-  for (const r of haul) {
-    expect(r.framePath.map((s) => s.frame.value)[0], r.suggestedName).toBe('#same-frame');
-  }
-  expect(haul.map((r) => r.suggestedName)).toContain('Submit');
+  // Choosing a frame means choosing its page, and a page includes what it
+  // embeds — so the grandchild's controls come too, two steps deep.
+  expect(paths, results.map((r) => r.suggestedName).join(', ')).toContain('#same-frame');
+  expect(paths).toContain('#same-frame › #deep-frame');
+
+  // The CVV field lives only in the deepest frame.
+  const cvv = results.find((r) => r.suggestedName === 'CVV');
+  expect(cvv, results.map((r) => r.suggestedName).join(', ')).toBeDefined();
+  expect(cvv!.framePath.map((s) => s.frame.value)).toEqual(['#same-frame', '#deep-frame']);
+
+  // And nothing from the main frame or a sibling: the scan started at a frame,
+  // it did not sweep the tab.
+  expect(paths.every((p) => p.startsWith('#same-frame'))).toBe(true);
 });
 
 test('the background relays panel messages, and reports an unreachable tab', async () => {

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -58,7 +58,11 @@ async function collectMessages(sw: { evaluate: (fn: never, arg?: unknown) => Pro
     g.__picks = [];
     if (g.__collecting) return;
     g.__collecting = true;
-    chrome.runtime.onMessage.addListener((m) => g.__picks.push(m));
+    // OVERLAY_SHOWN is plumbing — a frame telling the background it drew, so
+    // the other frames can clear. The panel ignores it and so does this.
+    chrome.runtime.onMessage.addListener((m) => {
+      if ((m as { type?: string })?.type !== 'OVERLAY_SHOWN') g.__picks.push(m);
+    });
   });
 }
 
@@ -92,6 +96,74 @@ test('picking is one-shot and reports a named element', async () => {
   await page.waitForTimeout(500);
   const after = await sw.evaluate(() => (globalThis as unknown as { __picks: unknown[] }).__picks.length);
   expect(after, 'picking stopped itself after one element').toBe(1);
+});
+
+test('one-shot means one pick per TAB, not one per frame', async () => {
+  // The content script runs in every frame, so START_PICKING arms every frame.
+  // Only the clicked frame used to stop itself, leaving the rest live: one pick
+  // in a framed page recorded three elements as the user carried on clicking.
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'frames-oneshot', 'frames.html');
+  await page.waitForLoadState('networkidle');
+  expect(page.frames().length, 'the fixture really is framed').toBeGreaterThan(3);
+  await collectMessages(sw as never);
+
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
+
+  // Hover the top frame first, so it draws an overlay of its own, then pick
+  // inside a child frame.
+  await page.getByRole('heading', { name: 'Frames', exact: true }).hover();
+  const child = page.frameLocator('#same-frame');
+  await child.getByRole('button', { name: 'Submit', exact: true }).hover();
+  await child.getByRole('button', { name: 'Submit', exact: true }).click();
+
+  await expect
+    .poll(async () => (await sw.evaluate(() => (globalThis as unknown as { __picks: unknown[] }).__picks)).length)
+    .toBe(1);
+
+  // Clicking on in other frames must add nothing: they were disarmed too.
+  await page.getByRole('button', { name: 'Submit', exact: true }).click();
+  await page.frameLocator('#same-frame').frameLocator('#deep-frame').getByRole('button', { name: 'Submit', exact: true }).click();
+  await page.waitForTimeout(500);
+  const after = await sw.evaluate(() => (globalThis as unknown as { __picks: unknown[] }).__picks.length);
+  expect(after, 'every frame disarmed after the first pick').toBe(1);
+
+  // And no frame is left wearing an overlay.
+  for (const frame of page.frames()) {
+    const left = await frame.locator('[data-page-modeller="label"]').count().catch(() => 0);
+    expect(left, `overlay left behind in ${frame.url()}`).toBe(0);
+  }
+});
+
+test('only the frame under the pointer wears an overlay', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'frames-overlay', 'frames.html');
+  await page.waitForLoadState('networkidle');
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
+
+  const labels = async () => {
+    let n = 0;
+    for (const frame of page.frames()) n += await frame.locator('[data-page-modeller="label"]').count().catch(() => 0);
+    return n;
+  };
+
+  await page.getByRole('heading', { name: 'Frames', exact: true }).hover();
+  await expect.poll(labels).toBe(1);
+
+  // Moving into a child frame must hand the overlay over, not add a second.
+  await page.frameLocator('#same-frame').getByRole('heading', { name: 'Payment' }).hover();
+  await expect.poll(labels, { message: 'the parent kept its overlay' }).toBe(1);
+
+  // And two deep.
+  await page.frameLocator('#same-frame').frameLocator('#deep-frame').getByRole('button', { name: 'Submit', exact: true }).hover();
+  await expect.poll(labels, { message: 'an ancestor frame kept its overlay' }).toBe(1);
+
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'STOP_PICKING' }), tabId);
+  await expect.poll(labels).toBe(0);
 });
 
 test('highlighting reports its count as a message, and Close clears it', async () => {
@@ -560,7 +632,11 @@ test('arrow keys walk the target up and down the DOM', async () => {
     g.__picks = [];
     if (g.__collecting) return;
     g.__collecting = true;
-    chrome.runtime.onMessage.addListener((m) => g.__picks.push(m));
+    // OVERLAY_SHOWN is plumbing — a frame telling the background it drew, so
+    // the other frames can clear. The panel ignores it and so does this.
+    chrome.runtime.onMessage.addListener((m) => {
+      if ((m as { type?: string })?.type !== 'OVERLAY_SHOWN') g.__picks.push(m);
+    });
   });
   await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
 

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -166,6 +166,87 @@ test('only the frame under the pointer wears an overlay', async () => {
   await expect.poll(labels).toBe(0);
 });
 
+test('a pick inside a frame carries the chain, and the chain resolves (SPEC §16)', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'frame-path', 'frames.html');
+  await page.waitForLoadState('networkidle');
+  await collectMessages(sw as never);
+
+  // Two frames deep, and its accessible name is shared with eight other
+  // buttons across the tree — so the path is the only thing that can separate
+  // them, which is what makes this worth asserting.
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
+  const deep = page.frameLocator('#same-frame').frameLocator('#deep-frame');
+  await deep.getByRole('button', { name: 'Submit', exact: true }).hover();
+  await deep.getByRole('button', { name: 'Submit', exact: true }).click();
+
+  await expect
+    .poll(async () => (await sw.evaluate(() => (globalThis as unknown as { __picks: unknown[] }).__picks)).length)
+    .toBe(1);
+
+  const picks = await sw.evaluate(() => (globalThis as unknown as { __picks: Record<string, unknown>[] }).__picks);
+  const result = picks[0].result as { framePath: { frame: { value: string }; opaque?: boolean }[] };
+
+  expect(result.framePath.map((s) => s.frame.value), 'outermost first').toEqual(['#same-frame', '#deep-frame']);
+  expect(result.framePath.some((s) => s.opaque), 'same-origin, so the chain is complete').toBe(false);
+
+  // The whole point: rebuild the locator the generator would emit and check
+  // Playwright lands on the element that was clicked, not one of the eight
+  // others with the same name.
+  let chain = page.frameLocator(result.framePath[0].frame.value);
+  for (const step of result.framePath.slice(1)) chain = chain.frameLocator(step.frame.value);
+  const resolved = chain.getByRole('button', { name: 'Submit', exact: true });
+  await expect(resolved).toHaveCount(1);
+  await expect(resolved).toHaveAttribute('data-spike', 'deep-submit');
+});
+
+test('a pick in the main frame still has no chain', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'frame-path-main', 'frames.html');
+  await page.waitForLoadState('networkidle');
+  await collectMessages(sw as never);
+
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
+  await page.getByRole('button', { name: 'Submit', exact: true }).hover();
+  await page.getByRole('button', { name: 'Submit', exact: true }).click();
+
+  await expect
+    .poll(async () => (await sw.evaluate(() => (globalThis as unknown as { __picks: unknown[] }).__picks)).length)
+    .toBe(1);
+  const picks = await sw.evaluate(() => (globalThis as unknown as { __picks: Record<string, unknown>[] }).__picks);
+  expect((picks[0].result as { framePath: unknown[] }).framePath).toEqual([]);
+});
+
+test('a pick in a cross-origin frame declares the break rather than lying', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'frame-path-cross', 'frames.html');
+  await page.waitForLoadState('networkidle');
+  await collectMessages(sw as never);
+
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add' }), tabId);
+  const cross = page.frameLocator('#cross-frame');
+  await cross.getByRole('button', { name: 'Submit', exact: true }).hover();
+  await cross.getByRole('button', { name: 'Submit', exact: true }).click();
+
+  await expect
+    .poll(async () => (await sw.evaluate(() => (globalThis as unknown as { __picks: unknown[] }).__picks)).length)
+    .toBe(1);
+  const picks = await sw.evaluate(() => (globalThis as unknown as { __picks: Record<string, unknown>[] }).__picks);
+  const result = picks[0].result as { framePath: { opaque?: boolean }[] };
+
+  // window.frameElement is unreadable across an origin, so the chain cannot be
+  // completed from inside. Saying so beats a path that starts halfway down and
+  // looks complete.
+  expect(result.framePath.length).toBeGreaterThan(0);
+  expect(result.framePath.some((s) => s.opaque), 'the break is declared').toBe(true);
+});
+
 test('highlighting reports its count as a message, and Close clears it', async () => {
   let [sw] = context.serviceWorkers();
   if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
@@ -202,6 +283,54 @@ test('highlighting reports its count as a message, and Close clears it', async (
   // Close dismisses the highlight, not just the message.
   await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'CLEAR_HIGHLIGHT' }), tabId);
   await expect(marks).toHaveCount(0);
+});
+
+test('the eye finds a framed element, and only its own frame answers (SPEC §16)', async () => {
+  // Before this, only the top frame answered a HIGHLIGHT, so anything inside a
+  // frame reported "0 elements match that locator" while its locator was fine.
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'frame-eye', 'frames.html');
+  await page.waitForLoadState('networkidle');
+  await collectMessages(sw as never);
+
+  const results = async () =>
+    (await sw.evaluate(
+      () => (globalThis as unknown as { __picks: { type: string; count?: number }[] }).__picks
+    )).filter((m) => m.type === 'HIGHLIGHT_RESULT');
+
+  // Two frames deep. `#deep-cvv` exists only there.
+  await sw.evaluate(
+    (id) =>
+      chrome.tabs.sendMessage(id, {
+        type: 'HIGHLIGHT',
+        candidate: { kind: 'css', value: '#deep-cvv' },
+        framePath: [{ frame: { kind: 'css', value: '#same-frame' } }, { frame: { kind: 'css', value: '#deep-frame' } }],
+      }),
+    tabId
+  );
+  await expect.poll(async () => (await results()).length, { message: 'exactly one frame answers' }).toBe(1);
+  expect((await results())[0].count).toBe(1);
+
+  // The same locator with no path is a main-frame question, and the main frame
+  // has no #deep-cvv — 0 is the right answer, from one frame only.
+  await sw.evaluate(() => ((globalThis as unknown as { __picks: unknown[] }).__picks = []));
+  await sw.evaluate(
+    (id) => chrome.tabs.sendMessage(id, { type: 'HIGHLIGHT', candidate: { kind: 'css', value: '#deep-cvv' } }),
+    tabId
+  );
+  await expect.poll(async () => (await results()).length).toBe(1);
+  expect((await results())[0].count).toBe(0);
+
+  // And a main-frame element still works, which is the regression to fear.
+  await sw.evaluate(() => ((globalThis as unknown as { __picks: unknown[] }).__picks = []));
+  await sw.evaluate(
+    (id) => chrome.tabs.sendMessage(id, { type: 'HIGHLIGHT', candidate: { kind: 'css', value: '[data-spike=\"top-heading\"]' }, framePath: [] }),
+    tabId
+  );
+  await expect.poll(async () => (await results()).length).toBe(1);
+  expect((await results())[0].count).toBe(1);
 });
 
 test('the background relays panel messages, and reports an unreachable tab', async () => {

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -386,6 +386,47 @@ test('scanning a frame scans inside it, with the chain on every element (SPEC §
   expect(paths.every((p) => p.startsWith('#same-frame'))).toBe(true);
 });
 
+test('a new highlight clears the last one, in whichever frame it was', async () => {
+  // Highlights last ~3s. Clicking a second eye inside that window left both
+  // elements marked — and across frames, the stale one was in a document the
+  // answering frame could not reach.
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'highlight-clears', 'frames.html');
+  await page.waitForLoadState('networkidle');
+
+  const marked = async () => {
+    let n = 0;
+    for (const f of page.frames()) n += await f.locator('[data-page-modeller="highlight"]').count().catch(() => 0);
+    return n;
+  };
+
+  // First: something in the main frame.
+  await sw.evaluate(
+    (id) => chrome.tabs.sendMessage(id, { type: 'HIGHLIGHT', candidate: { kind: 'css', value: '[data-spike="top-submit"]' }, framePath: [] }),
+    tabId
+  );
+  await expect.poll(marked).toBe(1);
+
+  // Then, well within the 3s window, something two frames deep.
+  await sw.evaluate(
+    (id) =>
+      chrome.tabs.sendMessage(id, {
+        type: 'HIGHLIGHT',
+        candidate: { kind: 'css', value: '#deep-cvv' },
+        framePath: [{ frame: { kind: 'css', value: '#same-frame' } }, { frame: { kind: 'css', value: '#deep-frame' } }],
+      }),
+    tabId
+  );
+  // Wait for the NEW mark to appear, then count once, immediately. Polling for
+  // the total to fall to 1 would pass without the fix by simply outlasting the
+  // stale mark's own 3s timer — which is exactly what it did.
+  const deep = page.frameLocator('#same-frame').frameLocator('#deep-frame');
+  await expect(deep.locator('[data-page-modeller="highlight"]')).toHaveCount(1, { timeout: 2000 });
+  expect(await marked(), 'a frame that did not answer kept its mark').toBe(1);
+});
+
 test('the background relays panel messages, and reports an unreachable tab', async () => {
   let [sw] = context.serviceWorkers();
   if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });

--- a/v3/tests/compile/csharp/Generated.cs
+++ b/v3/tests/compile/csharp/Generated.cs
@@ -235,6 +235,388 @@ public void SetPasswordEl(string value, bool clearFirst = true)
 }
 
 /*
+ * FramedActionableEl
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public void ClickFramedActionableEl()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        driver.FindElement(By.CssSelector("button.pay")).Click();
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
+ * FramedTextEl
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public string GetFramedTextEl()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return driver.FindElement(By.CssSelector("input.email")).GetDomProperty("value");
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public void SetFramedTextEl(string value, bool clearFirst = true)
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        IWebElement el = driver.FindElement(By.CssSelector("input.email"));
+        if (clearFirst)
+        {
+            el.Clear();
+        }
+        el.SendKeys(value);
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
+ * FramedToggleEl
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public bool IsFramedToggleElChecked()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return driver.FindElement(By.CssSelector("input.remember")).Selected;
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public void SetFramedToggleEl(bool isChecked)
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        IWebElement el = driver.FindElement(By.CssSelector("input.remember"));
+        if (el.Selected != isChecked)
+        {
+            el.Click();
+        }
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
+ * FramedRadioEl
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public bool IsFramedRadioElSelected()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return driver.FindElement(By.CssSelector("input.plan")).Selected;
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public void SelectFramedRadioEl()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        IWebElement el = driver.FindElement(By.CssSelector("input.plan"));
+        if (!el.Selected)
+        {
+            el.Click();
+        }
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
+ * FramedSelectEl
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public string GetFramedSelectElText()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return new SelectElement(driver.FindElement(By.CssSelector("select.country"))).SelectedOption.Text;
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public string GetFramedSelectElValue()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return new SelectElement(driver.FindElement(By.CssSelector("select.country"))).SelectedOption.GetDomProperty("value");
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public void SetFramedSelectElByValue(string value)
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        new SelectElement(driver.FindElement(By.CssSelector("select.country"))).SelectByValue(value);
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public void SetFramedSelectElByText(string text)
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        new SelectElement(driver.FindElement(By.CssSelector("select.country"))).SelectByText(text);
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
+ * FramedMultiSelectEl
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public IList<string> GetFramedMultiSelectElTexts()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return new SelectElement(driver.FindElement(By.CssSelector("select.toppings"))).AllSelectedOptions.Select(o => o.Text).ToList();
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public IList<string> GetFramedMultiSelectElValues()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return new SelectElement(driver.FindElement(By.CssSelector("select.toppings"))).AllSelectedOptions.Select(o => o.GetDomProperty("value")).ToList();
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public void SetFramedMultiSelectElByValues(params string[] values)
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        SelectElement el = new SelectElement(driver.FindElement(By.CssSelector("select.toppings")));
+        el.DeselectAll();
+        foreach (string value in values)
+        {
+            el.SelectByValue(value);
+        }
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public void SetFramedMultiSelectElByTexts(params string[] texts)
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        SelectElement el = new SelectElement(driver.FindElement(By.CssSelector("select.toppings")));
+        el.DeselectAll();
+        foreach (string text in texts)
+        {
+            el.SelectByText(text);
+        }
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public void DeselectAllFramedMultiSelectEl()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        new SelectElement(driver.FindElement(By.CssSelector("select.toppings"))).DeselectAll();
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
+ * FramedStaticEl
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public string GetFramedStaticEl()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return driver.FindElement(By.CssSelector("h1")).Text;
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
+ * FramedImageEl
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public string GetFramedImageElAltText()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return driver.FindElement(By.CssSelector("img.logo")).GetDomAttribute("alt");
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
+ * FramedPasswordEl
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public string GetFramedPasswordEl()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return driver.FindElement(By.CssSelector("input.pass")).GetDomProperty("value");
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public void SetFramedPasswordEl(string value, bool clearFirst = true)
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        IWebElement el = driver.FindElement(By.CssSelector("input.pass"));
+        if (clearFirst)
+        {
+            el.Clear();
+        }
+        el.SendKeys(value);
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
  * ById
  * ***************************************************************
  */
@@ -376,6 +758,51 @@ private readonly By _multiSelectEl = By.CssSelector("select.toppings");
 private readonly By _staticEl = By.CssSelector("h1");
 private readonly By _imageEl = By.CssSelector("img.logo");
 private readonly By _passwordEl = By.CssSelector("input.pass");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedActionableEl = By.CssSelector("button.pay");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedTextEl = By.CssSelector("input.email");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedToggleEl = By.CssSelector("input.remember");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedRadioEl = By.CssSelector("input.plan");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedSelectEl = By.CssSelector("select.country");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedMultiSelectEl = By.CssSelector("select.toppings");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedStaticEl = By.CssSelector("h1");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedImageEl = By.CssSelector("img.logo");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedPasswordEl = By.CssSelector("input.pass");
 private readonly By _byId = By.Id("go");
 private readonly By _byName = By.Name("email");
 private readonly By _byClassName = By.ClassName("row");

--- a/v3/tests/fixtures/ambiguous.html
+++ b/v3/tests/fixtures/ambiguous.html
@@ -7,7 +7,7 @@
        labelled with filenames so no link text can collide with a tagged
        element's accessible name. -->
   <nav aria-label="Fixtures" style="font: 12px/1.6 ui-monospace, monospace; padding: 6px 8px; border-bottom: 1px solid #ddd; margin-bottom: 12px">
-    fixtures: <a href="login.html">login</a> · <a href="widgets.html">widgets</a> · <a href="edgecases.html">edgecases</a> · <strong>ambiguous</strong>
+    fixtures: <a href="login.html">login</a> · <a href="widgets.html">widgets</a> · <a href="edgecases.html">edgecases</a> · <strong>ambiguous</strong> · <a href="frames.html">frames</a> · <a href="frameset.html">frameset</a>
   </nav>
   <main>
     <!-- Two buttons with the SAME accessible name: role+name is NOT unique here.

--- a/v3/tests/fixtures/edgecases.html
+++ b/v3/tests/fixtures/edgecases.html
@@ -16,7 +16,7 @@
        labelled with filenames so no link text can collide with a tagged
        element's accessible name. -->
   <nav aria-label="Fixtures" style="font: 12px/1.6 ui-monospace, monospace; padding: 6px 8px; border-bottom: 1px solid #ddd; margin-bottom: 12px">
-    fixtures: <a href="login.html">login</a> · <a href="widgets.html">widgets</a> · <strong>edgecases</strong> · <a href="ambiguous.html">ambiguous</a>
+    fixtures: <a href="login.html">login</a> · <a href="widgets.html">widgets</a> · <strong>edgecases</strong> · <a href="ambiguous.html">ambiguous</a> · <a href="frames.html">frames</a> · <a href="frameset.html">frameset</a>
   </nav>
   <main>
     <!-- 1. aria-label overrides emoji/content -->

--- a/v3/tests/fixtures/frames-child.html
+++ b/v3/tests/fixtures/frames-child.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Frame child</title></head>
+<body style="font: 14px/1.5 system-ui, sans-serif">
+  <h2 data-spike="child-heading">Payment</h2>
+
+  <label for="child-email">Email</label>
+  <input id="child-email" name="email" data-spike="child-email" />
+
+  <!-- Deliberately the same accessible name as the Submit in the top frame and
+       in the grandchild: the frame path is the only thing that separates them. -->
+  <button data-spike="child-submit">Submit</button>
+
+  <!-- Nested one level deeper, so its contents need a two-step frame path. -->
+  <iframe id="deep-frame" title="Deep" src="frames-grandchild.html" width="380" height="110"></iframe>
+</body>
+</html>

--- a/v3/tests/fixtures/frames-grandchild.html
+++ b/v3/tests/fixtures/frames-grandchild.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Frame grandchild</title></head>
+<body style="font: 14px/1.5 system-ui, sans-serif">
+  <p data-spike="deep-text">Deepest frame.</p>
+  <input id="deep-cvv" name="cvv" placeholder="CVV" data-spike="deep-cvv" />
+  <button data-spike="deep-submit">Submit</button>
+</body>
+</html>

--- a/v3/tests/fixtures/frames.html
+++ b/v3/tests/fixtures/frames.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Frames</title></head>
+<body>
+  <nav aria-label="Fixtures" style="font: 12px/1.6 ui-monospace, monospace; padding: 6px 8px; border-bottom: 1px solid #ddd; margin-bottom: 12px">
+    fixtures: <a href="login.html">login</a> · <a href="widgets.html">widgets</a> · <a href="edgecases.html">edgecases</a> ·
+    <a href="ambiguous.html">ambiguous</a> · <strong>frames</strong> · <a href="frameset.html">frameset</a>
+  </nav>
+  <main style="font: 14px/1.5 system-ui, sans-serif; padding: 0 8px">
+    <h1 data-spike="top-heading">Frames</h1>
+
+    <!-- The control: same accessible name as the Submit in every frame below,
+         so a locator without a frame path is ambiguous and one with it is not. -->
+    <button data-spike="top-submit">Submit</button>
+
+    <h2>Same-origin iframe</h2>
+    <!-- Nothing exotic. Also contains a nested iframe, so the deepest elements
+         need a two-step path. -->
+    <iframe id="same-frame" title="Same origin" src="frames-child.html" width="460" height="230"></iframe>
+
+    <h2>Cross-origin iframe</h2>
+    <!-- 127.0.0.1 and localhost are different origins to the browser while
+         being the same server, so this is genuinely cross-origin without a
+         second process. The server substitutes __CROSS_ORIGIN__ at request
+         time, so it follows FIXTURES_PORT. -->
+    <iframe id="cross-frame" title="Cross origin" src="__CROSS_ORIGIN__/frames-child.html" width="460" height="230"></iframe>
+
+    <h2>srcdoc iframe</h2>
+    <!-- No URL at all: same-origin, but nothing to identify it by except the
+         element itself. Common in widget embeds. -->
+    <iframe
+      id="srcdoc-frame"
+      title="Srcdoc"
+      width="460"
+      height="90"
+      srcdoc="&lt;body style=&quot;font:14px system-ui&quot;&gt;&lt;label&gt;Coupon &lt;input name=&quot;coupon&quot; data-spike=&quot;srcdoc-coupon&quot;&gt;&lt;/label&gt; &lt;button data-spike=&quot;srcdoc-submit&quot;&gt;Submit&lt;/button&gt;&lt;/body&gt;"
+    ></iframe>
+
+    <h2>Sandboxed iframe</h2>
+    <!-- An opaque origin, which is what an ad or a third-party widget usually
+         is. Scripts allowed, so a content script still runs inside. -->
+    <iframe
+      id="sandboxed-frame"
+      title="Sandboxed"
+      sandbox="allow-scripts"
+      width="460"
+      height="90"
+      srcdoc="&lt;body style=&quot;font:14px system-ui&quot;&gt;&lt;button data-spike=&quot;sandbox-submit&quot;&gt;Submit&lt;/button&gt;&lt;/body&gt;"
+    ></iframe>
+
+    <h2>Two frames that look alike</h2>
+    <!-- Identical src and no id: the frame itself needs a positional or
+         structural locator, which is the case a frame path can get wrong. -->
+    <iframe class="twin" title="Twin one" src="frames-grandchild.html" width="220" height="120"></iframe>
+    <iframe class="twin" title="Twin two" src="frames-grandchild.html" width="220" height="120"></iframe>
+  </main>
+</body>
+</html>

--- a/v3/tests/fixtures/frameset.html
+++ b/v3/tests/fixtures/frameset.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<!-- The legacy shape: <frameset> replaces <body> entirely, and its children are
+     <frame>, not <iframe>. Still rendered by every current browser, and still
+     present in enterprise apps of the era this tool was first written for.
+     Worth a fixture because `frame` and `iframe` are different elements, so a
+     selector written for one does not find the other. -->
+<html lang="en">
+<head><meta charset="utf-8"><title>Frameset</title></head>
+<frameset cols="40%,60%">
+  <frame name="nav" title="Nav" src="frames-child.html" />
+  <frameset rows="50%,50%">
+    <frame name="upper" title="Upper" src="frames-grandchild.html" />
+    <frame name="lower" title="Lower" src="frames-grandchild.html" />
+  </frameset>
+  <noframes><body>This page needs frames.</body></noframes>
+</frameset>
+</html>

--- a/v3/tests/fixtures/login.html
+++ b/v3/tests/fixtures/login.html
@@ -7,7 +7,7 @@
        labelled with filenames so no link text can collide with a tagged
        element's accessible name. -->
   <nav aria-label="Fixtures" style="font: 12px/1.6 ui-monospace, monospace; padding: 6px 8px; border-bottom: 1px solid #ddd; margin-bottom: 12px">
-    fixtures: <strong>login</strong> · <a href="widgets.html">widgets</a> · <a href="edgecases.html">edgecases</a> · <a href="ambiguous.html">ambiguous</a>
+    fixtures: <strong>login</strong> · <a href="widgets.html">widgets</a> · <a href="edgecases.html">edgecases</a> · <a href="ambiguous.html">ambiguous</a> · <a href="frames.html">frames</a> · <a href="frameset.html">frameset</a>
   </nav>
   <header>
     <nav aria-label="Primary">

--- a/v3/tests/fixtures/widgets.html
+++ b/v3/tests/fixtures/widgets.html
@@ -7,7 +7,7 @@
        labelled with filenames so no link text can collide with a tagged
        element's accessible name. -->
   <nav aria-label="Fixtures" style="font: 12px/1.6 ui-monospace, monospace; padding: 6px 8px; border-bottom: 1px solid #ddd; margin-bottom: 12px">
-    fixtures: <a href="login.html">login</a> · <strong>widgets</strong> · <a href="edgecases.html">edgecases</a> · <a href="ambiguous.html">ambiguous</a>
+    fixtures: <a href="login.html">login</a> · <strong>widgets</strong> · <a href="edgecases.html">edgecases</a> · <a href="ambiguous.html">ambiguous</a> · <a href="frames.html">frames</a> · <a href="frameset.html">frameset</a>
   </nav>
   <main>
     <h2 data-spike="section-heading">Account settings</h2>

--- a/v3/tests/frames.fixtures.spec.ts
+++ b/v3/tests/frames.fixtures.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { resolve } from 'node:path';
+
+// The frame fixtures are only useful if the browser really builds the tree they
+// describe — a cross-origin child that turns out same-origin, or a srcdoc that
+// never loads, would make every frame test that follows quietly meaningless.
+//
+// Served over http, not file://: Chrome gives every file:// document an opaque
+// origin, so `localhost` vs `127.0.0.1` would prove nothing.
+const PORT = 5288;
+const BASE = `http://localhost:${PORT}`;
+
+let server: ChildProcess;
+
+test.beforeAll(async () => {
+  server = spawn('node', [resolve('scripts/serve-fixtures.mjs')], {
+    env: { ...process.env, FIXTURES_PORT: String(PORT) },
+    stdio: 'ignore',
+  });
+  // Poll rather than sleep: the server is ready when it answers.
+  for (let i = 0; i < 100; i++) {
+    try {
+      if ((await fetch(`${BASE}/login.html`)).ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error('fixtures server did not start');
+});
+
+test.afterAll(() => server?.kill());
+
+test('frames.html builds the frame tree the fixture describes', async ({ page }) => {
+  await page.goto(`${BASE}/frames.html`);
+  await page.waitForLoadState('networkidle');
+
+  const urls = page.frames().map((f) => f.url());
+  // main + same + cross + deep×2 (one under same, one under cross) + srcdoc +
+  // sandboxed + twin×2
+  expect(page.frames().length, urls.join('\n')).toBe(9);
+
+  // Genuinely cross-origin: a different origin string, not just a different path.
+  const cross = page.frames().find((f) => f.url().startsWith('http://127.0.0.1:'));
+  expect(cross, urls.join('\n')).toBeDefined();
+  await expect(cross!.locator('[data-spike="child-submit"]')).toHaveText('Submit');
+
+  // And the browser agrees it is cross-origin: reaching into it from the parent
+  // throws, which is exactly what makes frame-path assembly hard.
+  const reachable = await page.evaluate(() => {
+    const el = document.querySelector('#cross-frame') as HTMLIFrameElement;
+    try {
+      return el.contentDocument !== null;
+    } catch {
+      return false;
+    }
+  });
+  expect(reachable, '#cross-frame must be opaque to its parent').toBe(false);
+
+  // Nested two deep, under the same-origin child.
+  const deep = page.frameLocator('#same-frame').frameLocator('#deep-frame');
+  await expect(deep.locator('[data-spike="deep-cvv"]')).toBeVisible();
+
+  // srcdoc and sandbox both load and hold their controls.
+  await expect(page.frameLocator('#srcdoc-frame').locator('[data-spike="srcdoc-coupon"]')).toBeVisible();
+  await expect(page.frameLocator('#sandboxed-frame').locator('[data-spike="sandbox-submit"]')).toBeVisible();
+});
+
+test('the Submit buttons collide, so only a frame path separates them', async ({ page }) => {
+  await page.goto(`${BASE}/frames.html`);
+  await page.waitForLoadState('networkidle');
+
+  // The point of the fixture: one accessible name, many elements, each in a
+  // different frame. getByRole in the main frame sees only its own.
+  await expect(page.getByRole('button', { name: 'Submit', exact: true })).toHaveCount(1);
+  for (const scope of ['#same-frame', '#cross-frame', '#srcdoc-frame', '#sandboxed-frame']) {
+    await expect(page.frameLocator(scope).getByRole('button', { name: 'Submit', exact: true })).toHaveCount(1);
+  }
+  // Nine in total across the tree — main, both children, both grandchildren,
+  // srcdoc, sandbox and both twins — every one of them indistinguishable from
+  // the others to a locator with no frame path.
+  const submits = await Promise.all(
+    page.frames().map((f) => f.locator('button', { hasText: /^Submit$/ }).count())
+  );
+  expect(submits.reduce((a, b) => a + b, 0)).toBe(9);
+});
+
+test('frameset.html uses frame elements, not iframe', async ({ page }) => {
+  await page.goto(`${BASE}/frameset.html`);
+  await page.waitForLoadState('networkidle');
+
+  // `frame` and `iframe` are different elements: a selector for one misses the
+  // other, which is the whole reason this fixture exists.
+  expect(await page.locator('frame').count()).toBe(3);
+  expect(await page.locator('iframe').count()).toBe(0);
+
+  // Named frames, the way switchTo().frame("nav") addresses them.
+  await expect(page.frameLocator('frame[name="nav"]').locator('[data-spike="child-heading"]')).toHaveText('Payment');
+  await expect(page.frameLocator('frame[name="lower"]').locator('[data-spike="deep-submit"]')).toHaveText('Submit');
+});

--- a/v3/tests/unit/fixtures/model.ts
+++ b/v3/tests/unit/fixtures/model.ts
@@ -16,6 +16,7 @@ export function modelOf(frameworkId: string, ...elements: TestElement[]): TabMod
     selectedIndex: 0,
     preferredIndex: 0,
     candidates: [{ candidate, predictedCount: 1 }],
+    framePath: [],
     ...el,
   })) as ModelElement[];
   return m;

--- a/v3/tests/unit/fixtures/model.ts
+++ b/v3/tests/unit/fixtures/model.ts
@@ -145,3 +145,13 @@ export const ALL_BUCKETS: TestElement[] = [
   { name: 'ImageEl', role: 'img', tag: 'img', candidate: { kind: 'css', value: 'img.logo' } },
   { name: 'PasswordEl', role: null, tag: 'input', inputType: 'password', candidate: { kind: 'css', value: 'input.pass' } },
 ];
+
+/** The same buckets, but two frames deep — so the switching code is compiled. */
+export const FRAMED_BUCKETS: TestElement[] = ALL_BUCKETS.map((el) => ({
+  ...el,
+  name: `Framed${el.name}`,
+  framePath: [
+    { frame: { kind: 'css', value: '#same-frame' } },
+    { frame: { kind: 'css', value: '#deep-frame' } },
+  ],
+}));

--- a/v3/tests/unit/frame-path.test.ts
+++ b/v3/tests/unit/frame-path.test.ts
@@ -3,6 +3,7 @@ import { generatePlaywrightPageObject, generatePlaywrightLocators } from '../../
 import { generatePlaywrightPythonLocators } from '../../src/generators/playwright-python';
 import { generatePuppeteerLocators } from '../../src/generators/puppeteer';
 import { generateSeleniumJavaLocators, generateSeleniumJava } from '../../src/generators/selenium-java';
+import { generateSeleniumCSharpLocators } from '../../src/generators/selenium-csharp';
 import { generateSeleniumPythonLocators } from '../../src/generators/selenium-python';
 import { displayElementLocator } from '../../src/locators/display';
 import type { FrameStep } from '../../src/engine/types';
@@ -55,27 +56,42 @@ describe('Playwright carries the chain inside the locator', () => {
 });
 
 describe('the targets that cannot carry it say so', () => {
-  it('warns in Selenium, where a By is frame-agnostic', () => {
+  it('gives Selenium the switch itself, ready to paste', () => {
+    // Not an instruction to go and write one — the reader can uncomment this.
     const out = generateSeleniumJavaLocators(modelOf('selenium-java', framed(PATH, idSubmit)));
     expect(out).toBe(
       [
         '// In frame: #same-frame › #deep-frame',
-        '// Switch to it before using this locator.',
+        '// driver.switchTo().defaultContent();',
+        '// driver.switchTo().frame(driver.findElement(By.cssSelector("#same-frame")));',
+        '// driver.switchTo().frame(driver.findElement(By.cssSelector("#deep-frame")));',
         'private final By submit = By.id("go");',
       ].join('\n')
     );
   });
 
+  it('spells the switch each language’s own way', () => {
+    expect(generateSeleniumCSharpLocators(modelOf('selenium-csharp', framed(PATH, idSubmit)))).toContain(
+      '// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));'
+    );
+    expect(generateSeleniumPythonLocators(modelOf('selenium-python', framed(PATH, idSubmit)))).toContain(
+      '# driver.switch_to.frame(driver.find_element(By.CSS_SELECTOR, "#same-frame"))'
+    );
+    // Puppeteer has no switch: it walks down to the frame and hands you a new
+    // scope to use in place of `page`.
+    const pup = generatePuppeteerLocators(modelOf('puppeteer', framed(PATH, cssSubmit)));
+    expect(pup).toContain("// const frame1 = await (await page.$('#same-frame')).contentFrame();");
+    expect(pup).toContain("// const frame2 = await (await frame1.$('#deep-frame')).contentFrame();");
+    expect(pup).toContain('// Then use frame2.locator(...) in place of page.locator(...).');
+  });
+
   it('puts it in the banner for the methods shape', () => {
     const out = generateSeleniumJava(modelOf('selenium-java', framed(PATH, idSubmit)));
     expect(out).toContain(' * Submit\n * In frame: #same-frame › #deep-frame');
+    expect(out).toContain(' * driver.switchTo().frame(driver.findElement(By.cssSelector("#same-frame")));');
   });
 
-  it('uses a hash comment in Python', () => {
-    expect(generateSeleniumPythonLocators(modelOf('selenium-python', framed(PATH, idSubmit)))).toContain(
-      '# In frame: #same-frame › #deep-frame'
-    );
-  });
+
 
   it('warns in Puppeteer, which is page-scoped', () => {
     const out = generatePuppeteerLocators(modelOf('puppeteer', framed(PATH, cssSubmit)));
@@ -91,9 +107,11 @@ describe('the targets that cannot carry it say so', () => {
 });
 
 describe('an incomplete chain is declared, not hidden', () => {
-  it('names the cross-origin break', () => {
+  it('names the break, and offers no switch to paste', () => {
     const out = generateSeleniumJavaLocators(modelOf('selenium-java', framed(OPAQUE, idSubmit)));
-    expect(out).toContain('a frame above this one is cross-origin');
+    expect(out).toContain('// A frame above this one is cross-origin, so the chain is incomplete.');
+    // Half a chain would switch into the wrong document and look like it worked.
+    expect(out).not.toContain('switchTo().frame');
   });
 });
 

--- a/v3/tests/unit/frame-path.test.ts
+++ b/v3/tests/unit/frame-path.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { generatePlaywrightPageObject, generatePlaywrightLocators } from '../../src/generators/playwright-ts';
+import { generatePlaywrightPythonLocators } from '../../src/generators/playwright-python';
+import { generatePuppeteerLocators } from '../../src/generators/puppeteer';
+import { generateSeleniumJavaLocators, generateSeleniumJava } from '../../src/generators/selenium-java';
+import { generateSeleniumPythonLocators } from '../../src/generators/selenium-python';
+import { displayElementLocator } from '../../src/locators/display';
+import type { FrameStep } from '../../src/engine/types';
+import { modelOf, type TestElement } from './fixtures/model';
+
+const PATH: FrameStep[] = [
+  { frame: { kind: 'css', value: '#same-frame' } },
+  { frame: { kind: 'css', value: '#deep-frame' } },
+];
+const OPAQUE: FrameStep[] = [{ frame: { kind: 'css', value: ':root' }, opaque: true }];
+
+const framed = (framePath: FrameStep[], candidate: TestElement['candidate']): TestElement => ({
+  name: 'Submit',
+  role: 'button',
+  tag: 'button',
+  framePath,
+  candidate,
+});
+const pwSubmit = { kind: 'role', role: 'button', name: 'Submit', exact: true } as const;
+const cssSubmit = { kind: 'css', value: 'button' } as const;
+const idSubmit = { kind: 'id', value: 'go' } as const;
+
+describe('Playwright carries the chain inside the locator', () => {
+  it('chains frameLocator, outermost first', () => {
+    expect(generatePlaywrightLocators(modelOf('playwright-ts', framed(PATH, pwSubmit)))).toBe(
+      "const submit = page.frameLocator('#same-frame').frameLocator('#deep-frame')" +
+        ".getByRole('button', { name: 'Submit', exact: true });"
+    );
+  });
+
+  it('does the same inside a page object, and adds no comment', () => {
+    const out = generatePlaywrightPageObject(modelOf('playwright-ts', framed(PATH, pwSubmit)));
+    expect(out).toContain("this.submit = page.frameLocator('#same-frame').frameLocator('#deep-frame').getByRole(");
+    // Self-contained: nothing to explain, so nothing is explained.
+    expect(out).not.toContain('//');
+  });
+
+  it('spells it the Python way', () => {
+    expect(generatePlaywrightPythonLocators(modelOf('playwright-python', framed(PATH, pwSubmit)))).toBe(
+      'submit = page.frame_locator("#same-frame").frame_locator("#deep-frame")' +
+        '.get_by_role("button", name="Submit", exact=True)'
+    );
+  });
+
+  it('leaves a main-frame element exactly as it was', () => {
+    expect(generatePlaywrightLocators(modelOf('playwright-ts', framed([], pwSubmit)))).toBe(
+      "const submit = page.getByRole('button', { name: 'Submit', exact: true });"
+    );
+  });
+});
+
+describe('the targets that cannot carry it say so', () => {
+  it('warns in Selenium, where a By is frame-agnostic', () => {
+    const out = generateSeleniumJavaLocators(modelOf('selenium-java', framed(PATH, idSubmit)));
+    expect(out).toBe(
+      [
+        '// In frame: #same-frame › #deep-frame',
+        '// Switch to it before using this locator.',
+        'private final By submit = By.id("go");',
+      ].join('\n')
+    );
+  });
+
+  it('puts it in the banner for the methods shape', () => {
+    const out = generateSeleniumJava(modelOf('selenium-java', framed(PATH, idSubmit)));
+    expect(out).toContain(' * Submit\n * In frame: #same-frame › #deep-frame');
+  });
+
+  it('uses a hash comment in Python', () => {
+    expect(generateSeleniumPythonLocators(modelOf('selenium-python', framed(PATH, idSubmit)))).toContain(
+      '# In frame: #same-frame › #deep-frame'
+    );
+  });
+
+  it('warns in Puppeteer, which is page-scoped', () => {
+    const out = generatePuppeteerLocators(modelOf('puppeteer', framed(PATH, cssSubmit)));
+    expect(out).toContain('// In frame: #same-frame › #deep-frame');
+    expect(out).toContain("const submit = page.locator('button');");
+  });
+
+  it('says nothing at all for a main-frame element', () => {
+    expect(generateSeleniumJavaLocators(modelOf('selenium-java', framed([], idSubmit)))).toBe(
+      'private final By submit = By.id("go");'
+    );
+  });
+});
+
+describe('an incomplete chain is declared, not hidden', () => {
+  it('names the cross-origin break', () => {
+    const out = generateSeleniumJavaLocators(modelOf('selenium-java', framed(OPAQUE, idSubmit)));
+    expect(out).toContain('a frame above this one is cross-origin');
+  });
+});
+
+describe('the table shows the chain', () => {
+  it('as the expression for Playwright, as a prefix elsewhere', () => {
+    expect(displayElementLocator(pwSubmit, 'playwright-ts', PATH)).toBe(
+      "frameLocator('#same-frame').frameLocator('#deep-frame').getByRole('button', { name: 'Submit', exact: true })"
+    );
+    // Two rows that differ only by frame must not read identically — the bug
+    // that started this: SubmitButton and SubmitButton2, same text, one wrong.
+    expect(displayElementLocator(idSubmit, 'selenium-java', PATH)).toBe('#same-frame › #deep-frame › id: go');
+    expect(displayElementLocator(idSubmit, 'selenium-java', [])).toBe('id: go');
+  });
+});

--- a/v3/tests/unit/frame-path.test.ts
+++ b/v3/tests/unit/frame-path.test.ts
@@ -85,10 +85,57 @@ describe('the targets that cannot carry it say so', () => {
     expect(pup).toContain('// Then use frame2.locator(...) in place of page.locator(...).');
   });
 
-  it('puts it in the banner for the methods shape', () => {
+  it('puts the frame in the banner as context, not as a switch to paste', () => {
+    // The methods below switch for themselves, so repeating it in the banner
+    // is noise the reader has to check against the code under it.
     const out = generateSeleniumJava(modelOf('selenium-java', framed(PATH, idSubmit)));
     expect(out).toContain(' * Submit\n * In frame: #same-frame › #deep-frame');
-    expect(out).toContain(' * driver.switchTo().frame(driver.findElement(By.cssSelector("#same-frame")));');
+    expect(out).not.toContain(' * driver.switchTo()');
+  });
+
+  it('makes each framed method switch in and out on its own', () => {
+    const out = generateSeleniumJava(modelOf('selenium-java', framed(PATH, idSubmit)));
+    expect(out).toBe(
+      [
+        '/*',
+        ' * Submit',
+        ' * In frame: #same-frame › #deep-frame',
+        ' * ***************************************************************',
+        ' */',
+        '',
+        'public void clickSubmit() {',
+        '    driver.switchTo().defaultContent();',
+        '    driver.switchTo().frame(driver.findElement(By.cssSelector("#same-frame")));',
+        '    driver.switchTo().frame(driver.findElement(By.cssSelector("#deep-frame")));',
+        '    try {',
+        '        driver.findElement(By.id("go")).click();',
+        '    } finally {',
+        // Or the next method starts inside this frame. That is what makes
+        // generated methods safe to call in any order (SPEC §16).
+        '        driver.switchTo().defaultContent();',
+        '    }',
+        '}',
+      ].join('\n')
+    );
+  });
+
+  it('gives a framed element no element getter', () => {
+    // A WebElement goes stale the moment the driver switches away, so handing
+    // one back is handing back a guaranteed failure.
+    const out = generateSeleniumJava(modelOf('selenium-java', framed(PATH, idSubmit)));
+    expect(out).not.toContain('getSubmitElement');
+    // Unframed, it is still there.
+    expect(generateSeleniumJava(modelOf('selenium-java', framed([], idSubmit)))).toContain(
+      'public WebElement getSubmitElement()'
+    );
+  });
+
+  it('leaves an opaque chain to the caller rather than switching wrongly', () => {
+    // Half a chain would switch into the wrong document and look like it worked.
+    const out = generateSeleniumJava(modelOf('selenium-java', framed(OPAQUE, idSubmit)));
+    expect(out).toContain('switch into it yourself first');
+    expect(out).not.toContain('switchTo()');
+    expect(out).toContain('public WebElement getSubmitElement()');
   });
 
 

--- a/v3/tests/unit/generated-compiles.test.ts
+++ b/v3/tests/unit/generated-compiles.test.ts
@@ -8,7 +8,7 @@ import { generateSeleniumJava, generateSeleniumJavaLocators, generateSeleniumJav
 import { generateSeleniumCSharp, generateSeleniumCSharpLocators, generateSeleniumCSharpPageObject } from '../../src/generators/selenium-csharp';
 import { generatePlaywrightPageObject, generatePlaywrightLocators } from '../../src/generators/playwright-ts';
 import { generatePuppeteerPageObject, generatePuppeteerLocators } from '../../src/generators/puppeteer';
-import { modelOf, everyTypeFor, ALL_BUCKETS } from './fixtures/model';
+import { modelOf, everyTypeFor, ALL_BUCKETS, FRAMED_BUCKETS } from './fixtures/model';
 
 // Compiling the generated Selenium against the real Selenium API — the only
 // check that can tell us GetDomProperty exists, that C# spells it SelectByText
@@ -37,7 +37,7 @@ const dotnetReady = has('dotnet', ['--version']) && existsSync(join(CSPROJ, 'obj
 // Every bucket AND every locator type: the buckets decide which methods are
 // emitted, the types decide which API calls appear inside them. Miss either and
 // the check passes on a subset of the surface.
-const model = (id: string) => modelOf(id, ...ALL_BUCKETS, ...everyTypeFor(id));
+const model = (id: string) => modelOf(id, ...ALL_BUCKETS, ...FRAMED_BUCKETS, ...everyTypeFor(id));
 
 function fail(what: string, output: string): never {
   throw new Error(`${what} did not compile:\n${output}`);

--- a/v3/tests/unit/generated-python.test.ts
+++ b/v3/tests/unit/generated-python.test.ts
@@ -6,7 +6,7 @@ import { generateSeleniumPython, generateSeleniumPythonLocators, generateSeleniu
 import { playwrightExpr, playwrightPyExpr } from '../../src/locators/display';
 import { frameworkById } from '../../src/frameworks';
 import type { LocatorCandidate } from '../../src/engine/types';
-import { modelOf, everyTypeFor, ALL_BUCKETS } from './fixtures/model';
+import { modelOf, everyTypeFor, ALL_BUCKETS, FRAMED_BUCKETS } from './fixtures/model';
 
 const hasPython = (() => {
   try {
@@ -54,7 +54,7 @@ const nastyPlaywright = [
 ];
 
 /** Every method bucket and every locator type the framework offers. */
-const full = (id: string) => modelOf(id, ...ALL_BUCKETS, ...everyTypeFor(id));
+const full = (id: string) => modelOf(id, ...ALL_BUCKETS, ...FRAMED_BUCKETS, ...everyTypeFor(id));
 
 describe.skipIf(!hasPython)('the generated Python is Python', () => {
   const cases: Array<[string, string]> = [

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -142,6 +142,9 @@ function send(target: number, msg: PanelToContent) {
 const isPicking = () => isScanning.value || isAdding.value;
 
 function stopPicking() {
+  // Un-arm here rather than waiting for a PICKING_STOPPED echo: the frames no
+  // longer send one, because the panel asking to stop already knows.
+  isAdding.value = isScanning.value = false;
   if (tabId.value != null) send(tabId.value, { type: 'STOP_PICKING' });
   isAdding.value = isScanning.value = false;
 }
@@ -264,7 +267,10 @@ onBeforeUnmount(() => {
 });
 
 host.onTabChanged((next) => {
-  if (isPicking() && tabId.value != null) send(tabId.value, { type: 'STOP_PICKING' });
+  if (isPicking() && tabId.value != null) {
+    isAdding.value = isScanning.value = false;
+    send(tabId.value, { type: 'STOP_PICKING' });
+  }
   isScanning.value = isAdding.value = false;
   tabId.value = next;
   reportViewing();

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -282,7 +282,13 @@ async function startPicking(mode: PickMode) {
   const target = tabId.value ?? (await host.getTabId());
   tabId.value = target;
   if (target == null) return;
-  send(target, { type: 'START_PICKING', mode, includeHidden: settings.value.modelHiddenElements });
+  // One nonce per picking session, shared by every frame in the tab.
+  send(target, {
+    type: 'START_PICKING',
+    mode,
+    includeHidden: settings.value.modelHiddenElements,
+    nonce: Math.random().toString(36).slice(2),
+  });
   // Optimistic: TAB_UNREACHABLE resets it if the page cannot be reached.
   if (mode === 'scan') isScanning.value = true;
   else isAdding.value = true;

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -47,7 +47,7 @@
           :framework-id="model.frameworkId"
           :taken-names="model.elements.filter((e) => e.id !== editing!.id).map((e) => e.name)"
           @close="editing = undefined"
-          @highlight="highlightCandidate"
+          @highlight="highlightEdited"
           @save="saveEdit"
         />
       </q-page>
@@ -64,12 +64,12 @@ import ModelTable, { type ModelRow } from './ModelTable.vue';
 import EditElementDialog from './EditElementDialog.vue';
 import CodeDialog from './CodeDialog.vue';
 import { defaultFrameworkId } from '@/src/frameworks';
-import { displayLocator } from '@/src/locators/display';
+import { displayElementLocator } from '@/src/locators/display';
 import { activeCandidate, emptyModel, type ModelElement, type TabModel } from '@/src/model';
 import { isMessage, PANEL_PORT, type BackgroundToPanel, type PanelToBackground, type PanelToContent, type PickMode } from '@/src/messaging';
 import { hostKey } from '@/host/types';
 import { applyTheme } from './theme';
-import type { LocatorCandidate } from '@/src/engine/types';
+import type { FrameStep, LocatorCandidate } from '@/src/engine/types';
 import { defaultSettings, loadSettings, watchSettings } from '@/src/settings';
 
 // The panel is a VIEW. The background owns the model, one per tab (SPEC §5), so
@@ -95,7 +95,7 @@ const rows = computed<ModelRow[]>(() =>
   model.value.elements.map((el) => ({
     id: el.id,
     name: el.name,
-    locator: displayLocator(activeCandidate(el), model.value.frameworkId),
+    locator: displayElementLocator(activeCandidate(el), model.value.frameworkId, el.framePath),
   }))
 );
 
@@ -309,21 +309,31 @@ function setFramework(frameworkId: string) {
 
 function clearHighlight() {
   if (tabId.value == null) return;
-  // Every frame may clear; only the top one ever draws.
+  // Every frame may clear; any one of them may have drawn (SPEC §16).
   send(tabId.value, { type: 'CLEAR_HIGHLIGHT' });
 }
 
 function highlight(id: string) {
   const el = model.value.elements.find((e) => e.id === id);
   if (!el) return;
-  highlightCandidate(activeCandidate(el));
+  highlightCandidate(activeCandidate(el), el.framePath);
 }
 
-/** Also used by the Edit dialog, which tests what is typed, not what is saved. */
-function highlightCandidate(candidate: LocatorCandidate) {
+/** The dialog tests a candidate against the element's own frame. */
+function highlightEdited(candidate: LocatorCandidate) {
+  highlightCandidate(candidate, editing.value?.framePath);
+}
+
+/**
+ * Also used by the Edit dialog, which tests what is typed, not what is saved.
+ * The frame path comes with it either way: a locator is resolved in the
+ * document the element lives in, and testing it anywhere else answers a
+ * different question (SPEC §16).
+ */
+function highlightCandidate(candidate: LocatorCandidate, framePath?: FrameStep[]) {
   if (tabId.value == null) return;
   // Fire and forget; the count arrives as HIGHLIGHT_RESULT.
-  send(tabId.value, { type: 'HIGHLIGHT', candidate });
+  send(tabId.value, { type: 'HIGHLIGHT', candidate, framePath });
 }
 
 function openEditor(id: string) {

--- a/v3/ui/EditElementDialog.vue
+++ b/v3/ui/EditElementDialog.vue
@@ -17,6 +17,23 @@
           @keydown.enter="save"
         />
 
+        <!-- Read-only: the frame chain is where the element IS, not part of how
+             it is found within that frame. Editing it would be editing the
+             page. Shown because two elements can otherwise look identical
+             (SPEC §16). -->
+        <div v-if="framePath.length" class="frame-row" data-testid="edit-frame">
+          <span class="frame-label">Frame</span>
+          <span class="frame-chain">
+            <template v-for="(step, i) in framePath" :key="i">
+              <span v-if="i > 0" class="frame-sep">›</span>
+              <code>{{ step }}</code>
+            </template>
+          </span>
+        </div>
+        <div v-if="frameOpaque" class="frame-warn" data-testid="edit-frame-opaque">
+          A frame above this one is cross-origin, so the chain starts inside it.
+        </div>
+
         <div class="locator-row">
           <q-select
             v-model="kind"
@@ -78,6 +95,7 @@ import { frameworkById } from '@/src/frameworks';
 import { activeCandidate, type ModelElement } from '@/src/model';
 import { buildCandidate, fieldsFor, isComplete, valuesOf, type LocatorKind } from '@/src/locators/fields';
 import type { LocatorCandidate } from '@/src/engine/types';
+import { frameSelector, isOpaque } from '@/src/locators/frames';
 
 const props = defineProps<{
   element: ModelElement;
@@ -100,6 +118,13 @@ const kind = ref<LocatorKind>(current.kind);
 const values = ref<Record<string, string>>(valuesOf(current));
 
 /** The full framework list, not just what was generated (SPEC §7). */
+// The chain as selector strings; `:root` stands for a cross-origin break, so
+// it is reported as prose rather than shown as a selector nobody typed.
+const framePath = computed(() =>
+  (props.element.framePath ?? []).filter((s) => !s.opaque).map((s) => frameSelector(s))
+);
+const frameOpaque = computed(() => isOpaque(props.element.framePath));
+
 const typeOptions = computed(() => frameworkById(props.frameworkId).locatorTypes.map((t) => ({ label: t, value: t })));
 
 const fields = computed(() => fieldsFor(kind.value));
@@ -147,6 +172,31 @@ function save() {
 </script>
 
 <style scoped>
+.frame-row {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 12px;
+}
+
+.frame-label {
+  color: var(--pm-muted);
+}
+
+.frame-chain code {
+  font: 12px/1.5 ui-monospace, SFMono-Regular, monospace;
+}
+
+.frame-sep {
+  margin: 0 4px;
+  color: var(--pm-muted);
+}
+
+.frame-warn {
+  font-size: 12px;
+  color: var(--pm-warn, #d29922);
+}
+
 .edit-card {
   width: 100%;
   max-width: 720px;


### PR DESCRIPTION
Frame support: fixtures, the picker bugs they exposed, and frame paths end to end.

## The reported symptom

Two elements, one in the main frame and one two frames deep, generated **identical** locators:

```ts
this.submitButton  = page.getByRole('button', { name: 'Submit', exact: true });
this.submitButton2 = page.getByRole('button', { name: 'Submit', exact: true });
```

Now:

```ts
this.submitButton  = page.getByRole('button', { name: 'Submit', exact: true });
this.submitButton2 = page.frameLocator('#same-frame').frameLocator('#deep-frame')
  .getByRole('button', { name: 'Submit', exact: true });
```

## How a frame is located

By the ordinary candidate machinery — the document holding an `<iframe>` is just a document — with one restriction: **css or xpath only**. `frameLocator` takes a *selector*, not a locator, so `getByTitle('Payment')` can't address a frame however well it identifies one.

`window.frameElement` builds the chain, and its limit is the hard case: readable only when the parent is same-origin. Across an origin it throws, so the chain **stops and is marked opaque**. A path that starts halfway down and looks complete is worse than one that admits it's partial.

## Carrying it, or admitting you can't

| Target | How |
|---|---|
| Playwright | `frameLocator(…)` chains — self-contained, nothing to explain |
| Selenium | a `By` is frame-agnostic: a comment names the chain and says a switch is required |
| Puppeteer | `page.locator` is page-scoped, no `frameLocator`: same comment |

```java
// In frame: #same-frame › #deep-frame
// Switch to it before using this locator.
private final By submit = By.id("go");
```

The table and the Edit dialog both show the chain — the dialog read-only, since the chain is where the element *is*, not how it's found within that frame.

## The eye

Answers from the frame that owns the element, not the top one. That was the visible half: a framed element reported *0 elements match that locator* while its locator was fine.

## Two picker bugs the fixtures found immediately

- **One-shot was per frame, not per tab.** Every frame arms on `START_PICKING`; only the clicked one stopped. One pick recorded three elements.
- **Every frame drew its own overlay** and kept it. Pointer events can't fix this — a parent gets no `mouseout` when the pointer crosses into a child, which the E2E confirmed by accumulating one overlay per frame descended. A frame now announces it has drawn and the background clears the rest.

## Verification

251 unit + 28 Playwright. Every new test verified non-vacuous by reverting its fix: 3 picks without the disarm, 2 overlays without the ownership, `0` from the eye with the top-frame-only rule.

The fixtures have their own spec, because a "cross-origin" child that quietly turned out same-origin would make all of this pass while proving nothing.

## Not in this PR

Selenium `switchTo` emission (§16's self-contained-methods rule), the cross-origin handshake that would complete an opaque chain, and frames in Scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)