### PR TITLE
v3: hold Cmd/Ctrl to add several elements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,12 @@ change.** v3 work goes on the `v3-rewrite` branch, inside `v3/`.
 Note the branch is `v3-rewrite`, not `v3` — a branch named `v3` would be ambiguous with the `v3/`
 directory in every revision argument (`git log v3`, `git show v3:file`).
 
+**Branch from `v3-rewrite`, not from the branch you happen to be on.** PRs here are squash-merged, so a
+branch cut from another branch carries commits that land again under a different identity — and every
+file both touched then conflicts, even though the content is identical. Recovery is
+`git rebase --onto origin/v3-rewrite <last commit of the parent branch> <your branch>`, which replays
+only your own commits.
+
 **Always `gh pr create --base v3-rewrite`.** `gh` defaults the base to the repo's default branch,
 `master`. A v3 branch PR'd that way does not carry one commit — squash-merging it collapses the whole
 `v3-rewrite`..branch difference into `master` (97 files the one time it happened, #75/#76).

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -127,15 +127,23 @@ nothing; only the *name* shown to the user is platform-specific.
 
 Scan is unaffected: it already takes many elements at once.
 
-The panel shows what the mode can do while picking is armed — a strip under the toolbar, not a toast,
-because it is advice for the whole time you are picking rather than an event. Key/action pairs rather
-than a sentence: the panel is as narrow as a sidebar, and walking the DOM and adding several are the two
-things nothing else in the UI reveals, so prose long enough to explain both does not fit. **[settled]**
+### Saying how picking works **[settled]**
 
-```
-Add    Click add · ↑↓ walk · ⌘+Click many · Esc stop
-Scan   Click a container · ↑↓ walk · Esc stop
-```
+Walking the DOM with the arrows, holding the modifier to add several, and Escape are all
+undiscoverable: nothing else in the UI reveals any of them. But this is something you learn once, and a
+permanent strip in the panel is furniture for a lesson — it also shifted the table every time picking
+armed.
+
+So: a **dialog on first use of each mode**, with *Don't show this again*, and a **?** in the toolbar
+that opens the same guidance whenever it is wanted. Per mode, because Add and Scan teach different
+things and meeting the second one is a separate first time.
+
+The dialog opens *with* picking rather than before it. It lives in the panel and the page stays
+clickable behind it, so what it describes can be tried while reading it.
+
+`Don't show this again` is offered only when the dialog opened by itself: having asked to see it, you
+are not asking to be rid of it. The two flags live in settings but are not shown on the options page —
+they are dismissal state, not a preference, and the **?** already brings the guidance back.
 
 The strip is **always in the layout** and only made invisible when idle. A row that appears and
 disappears shifts the whole table under the pointer at the moment you are aiming at it. **[settled]**

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -115,6 +115,22 @@ included).
 
 Over-inclusion is cheap to correct: rows can be deleted after a scan.
 
+### Adding several without re-arming **[settled]**
+
+Add is one-shot, which is right for the common case and tiresome for a run of ten. Holding **⌘** (or
+**Ctrl**) while clicking keeps it armed for the next click; releasing it makes the last click behave as
+it always did.
+
+Read from the click event rather than remembered, so it is decided per click — hold it through a run,
+let go on the final element. Either modifier is accepted whatever the platform, because that costs
+nothing; only the *name* shown to the user is platform-specific.
+
+Scan is unaffected: it already takes many elements at once.
+
+The panel says so while Add is armed — a strip under the toolbar, not a toast, because it is advice for
+the whole time you are picking rather than an event: *Click an element to add it. Hold ⌘ to add
+several.*
+
 ## 5. Model lifetime
 
 v2.5.1 never had to decide this — a DevTools panel is inherently per-tab, its model lived in panel

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -127,9 +127,15 @@ nothing; only the *name* shown to the user is platform-specific.
 
 Scan is unaffected: it already takes many elements at once.
 
-The panel says so while Add is armed — a strip under the toolbar, not a toast, because it is advice for
-the whole time you are picking rather than an event: *Click an element to add it. Hold ⌘ to add
-several.*
+The panel shows what the mode can do while picking is armed — a strip under the toolbar, not a toast,
+because it is advice for the whole time you are picking rather than an event. Key/action pairs rather
+than a sentence: the panel is as narrow as a sidebar, and walking the DOM and adding several are the two
+things nothing else in the UI reveals, so prose long enough to explain both does not fit. **[settled]**
+
+```
+Add    ⌖  Click add · ↑↓ walk · ⌘+Click many · Esc stop
+Scan   ⌖  Click a container · ↑↓ walk · Esc stop
+```
 
 The strip is **always in the layout** and only made invisible when idle. A row that appears and
 disappears shifts the whole table under the pointer at the moment you are aiming at it. **[settled]**

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -133,8 +133,8 @@ than a sentence: the panel is as narrow as a sidebar, and walking the DOM and ad
 things nothing else in the UI reveals, so prose long enough to explain both does not fit. **[settled]**
 
 ```
-Add    ⌖  Click add · ↑↓ walk · ⌘+Click many · Esc stop
-Scan   ⌖  Click a container · ↑↓ walk · Esc stop
+Add    Click add · ↑↓ walk · ⌘+Click many · Esc stop
+Scan   Click a container · ↑↓ walk · Esc stop
 ```
 
 The strip is **always in the layout** and only made invisible when idle. A row that appears and

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -142,7 +142,12 @@ The dialog opens *with* picking rather than before it. It lives in the panel and
 clickable behind it, so what it describes can be tried while reading it.
 
 `Don't show this again` is offered only when the dialog opened by itself: having asked to see it, you
-are not asking to be rid of it. The two flags live in settings but are not shown on the options page —
+are not asking to be rid of it.
+
+**An unreachable page withdraws it**, and does not count it as seen — teaching someone to scan a page
+that cannot be scanned is noise stacked on an error, and the lesson is still owed the first time picking
+actually starts. Only guidance that opened by itself: one opened from the **?** was asked for, and an
+unrelated failure is no reason to take it away. **[settled]** The two flags live in settings but are not shown on the options page —
 they are dismissal state, not a preference, and the **?** already brings the guidance back.
 
 The strip is **always in the layout** and only made invisible when idle. A row that appears and

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -131,6 +131,9 @@ The panel says so while Add is armed — a strip under the toolbar, not a toast,
 the whole time you are picking rather than an event: *Click an element to add it. Hold ⌘ to add
 several.*
 
+The strip is **always in the layout** and only made invisible when idle. A row that appears and
+disappears shifts the whole table under the pointer at the moment you are aiming at it. **[settled]**
+
 ## 5. Model lifetime
 
 v2.5.1 never had to decide this — a DevTools panel is inherently per-tab, its model lived in panel

--- a/v3/entrypoints/background.ts
+++ b/v3/entrypoints/background.ts
@@ -142,6 +142,10 @@ export default defineBackground(() => {
             }
           })
         );
+        // Held the modifier: Add stays armed, so neither the frames nor the
+        // toolbar should be told it is over (SPEC §4).
+        if (m.type === 'ELEMENT_PICKED' && m.keepPicking) return;
+
         // Picking is one-shot (SPEC §4) per TAB, not per frame. START_PICKING
         // is broadcast to every frame and each arms itself, but only the frame
         // that was clicked stops itself — the rest stayed live and recorded the

--- a/v3/entrypoints/content/index.ts
+++ b/v3/entrypoints/content/index.ts
@@ -480,13 +480,20 @@ export default defineContentScript({
       for (const frame of nested) delegateScan(frame);
     }
 
-    /** Commit the current target. Shared by clicking and by Enter. */
-    function pickCurrent() {
+    /**
+     * Commit the current target. Shared by clicking and by Enter.
+     *
+     * `keepPicking` holds Add open for the next click (SPEC §4). Read from the
+     * event rather than remembered, so it is decided per click: hold it for a
+     * run of elements, let go for the last one.
+     */
+    function pickCurrent(keepPicking = false) {
       if (!active || !current) return;
       const target = current;
-      // Both modes are one-shot (SPEC §4) — stop before reporting, so the
-      // overlay is gone by the time the panel re-renders.
-      stop({ notify: false });
+      // One-shot unless the modifier says otherwise — and stop BEFORE
+      // reporting, so the overlay is gone by the time the panel re-renders.
+      if (!keepPicking) stop({ notify: false });
+      else removeOverlay();
 
       // Scanning a frame has to be done BY that frame. An <iframe> has no
       // descendants in this document — its content is a separate document —
@@ -514,7 +521,7 @@ export default defineContentScript({
       const message =
         mode === 'scan'
           ? { type: 'ELEMENTS_PICKED', results: collectInteractive(target, includeHidden).map((el) => generate(el, myPath)) }
-          : { type: 'ELEMENT_PICKED', result: generate(target, myPath) };
+          : { type: 'ELEMENT_PICKED', result: generate(target, myPath), keepPicking };
 
       // Rejects when no panel is open; that's fine, drop it.
       browser.runtime.sendMessage(message).catch(() => {});
@@ -527,7 +534,10 @@ export default defineContentScript({
       // The CURRENT target, not e.target: the arrows may have walked away from
       // the element under the cursor, and that is the whole point of them.
       if (!current) current = e.target as Element;
-      pickCurrent();
+      // Either modifier, whatever the platform: Cmd is the one people reach for
+      // on a Mac and Ctrl everywhere else, and accepting both costs nothing.
+      // Scan is already many elements, so this only means anything for Add.
+      pickCurrent(mode === 'add' && (e.metaKey || e.ctrlKey));
     };
 
     /** The child of `of` that contains `hovered`, for walking back down. */
@@ -566,7 +576,7 @@ export default defineContentScript({
         // Hands are already on the arrows; Enter is the obvious commit.
         e.preventDefault();
         e.stopPropagation();
-        return pickCurrent();
+        return pickCurrent(mode === 'add' && (e.metaKey || e.ctrlKey));
       }
 
       if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;

--- a/v3/src/messaging.ts
+++ b/v3/src/messaging.ts
@@ -52,7 +52,9 @@ export type PanelToContent =
 // Firefox — which surfaced as "can't reach this page" for a tab that was
 // plainly reachable.
 export type ContentToPanel =
-  | { type: 'ELEMENT_PICKED'; result: ElementResult }
+  // `keepPicking` when the modifier was held: Add stays armed for the next
+  // click instead of stopping after one (SPEC §4).
+  | { type: 'ELEMENT_PICKED'; result: ElementResult; keepPicking?: boolean }
   // A scan's haul, in one message rather than N: the background adds them in a
   // single model update, so the table does not animate in row by row.
   | { type: 'ELEMENTS_PICKED'; results: ElementResult[] }

--- a/v3/src/settings.ts
+++ b/v3/src/settings.ts
@@ -16,6 +16,13 @@ export interface Settings {
   clickTableRowsToViewMatchedElements: boolean;
   /** Append the element's type to its derived name: `About` → `AboutLink`. */
   appendTypeToName: boolean;
+  /**
+   * First-use guidance, dismissed with "Don't show this again" (SPEC §4).
+   * Per mode, because Add and Scan teach different things and meeting the
+   * second one is a separate first time.
+   */
+  seenAddHelp: boolean;
+  seenScanHelp: boolean;
 }
 
 export const defaultSettings: Settings = {
@@ -24,6 +31,8 @@ export const defaultSettings: Settings = {
   modelHiddenElements: false,
   clickTableRowsToViewMatchedElements: false,
   appendTypeToName: false,
+  seenAddHelp: false,
+  seenScanHelp: false,
 };
 
 const KEY = 'options';

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -311,6 +311,34 @@ test('a sandboxed frame gets a real chain too', async () => {
   expect(JSON.stringify(result.framePath)).not.toContain(':root');
 });
 
+test('an unreachable tab does not close guidance the user asked for', async () => {
+  // First-use guidance is withdrawn when the page turns out to be unreachable —
+  // teaching someone to scan a page that cannot be scanned is noise stacked on
+  // an error. Guidance opened from the toolbar is a different thing: it was
+  // asked for, and an unrelated failure is no reason to take it away.
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  const panel = await context.newPage();
+  await panel.goto(`chrome-extension://${extId}/sidepanel.html`);
+  await panel.getByTestId('btn-help').click();
+  await expect(panel.getByTestId('help-ok')).toBeVisible();
+
+  // The message the panel would get if its page could not be reached. Sent
+  // from the service worker, not the panel: runtime.sendMessage never delivers
+  // to its own sender. Addressed to the tab the panel is watching, since panels
+  // ignore anything naming a different one.
+  const watched = await panel.evaluate(
+    async () => (await chrome.tabs.query({ active: true, currentWindow: true }))[0]?.id
+  );
+  await sw.evaluate((id) => chrome.runtime.sendMessage({ type: 'TAB_UNREACHABLE', tabId: id }), watched);
+  await expect(panel.getByText("can’t reach this page")).toBeVisible();
+  await expect(panel.getByTestId('help-ok'), 'still open — it was asked for').toBeVisible();
+
+  await panel.close();
+});
+
 test('holding the modifier keeps Add armed for the next click (SPEC §4)', async () => {
   let [sw] = context.serviceWorkers();
   if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });

--- a/v3/tests/capture.e2e.spec.ts
+++ b/v3/tests/capture.e2e.spec.ts
@@ -311,6 +311,45 @@ test('a sandboxed frame gets a real chain too', async () => {
   expect(JSON.stringify(result.framePath)).not.toContain(':root');
 });
 
+test('holding the modifier keeps Add armed for the next click (SPEC §4)', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+
+  const { page, tabId } = await openFixture(sw as never, 'multi-add');
+  await collectMessages(sw as never);
+  await sw.evaluate((id) => chrome.tabs.sendMessage(id, { type: 'START_PICKING', mode: 'add', nonce: 'n' }), tabId);
+
+  const picks = async () =>
+    (await sw.evaluate(() => (globalThis as unknown as { __picks: { type: string }[] }).__picks)).filter(
+      (m) => m.type === 'ELEMENT_PICKED'
+    );
+
+  // Two picks in a row, modifier held: without it the first would disarm the
+  // tab and the second click would do nothing.
+  const email = page.getByLabel('Email address');
+  await email.hover();
+  await email.click({ modifiers: ['ControlOrMeta'] });
+  await expect.poll(async () => (await picks()).length).toBe(1);
+
+  const password = page.getByLabel('Password');
+  await password.hover();
+  await password.click({ modifiers: ['ControlOrMeta'] });
+  await expect.poll(async () => (await picks()).length).toBe(2);
+
+  // Let go for the last one and it behaves as it always did.
+  const remember = page.getByRole('checkbox');
+  await remember.hover();
+  await remember.click();
+  await expect.poll(async () => (await picks()).length).toBe(3);
+  // Releasing it restores one-shot: a further click adds nothing. (The panel
+  // learns this through a FROM_TAB broadcast, which the service worker cannot
+  // observe — runtime.sendMessage does not deliver to its own sender — so the
+  // proof is behavioural.)
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForTimeout(400);
+  expect((await picks()).length, 'one-shot again once released').toBe(3);
+});
+
 test('highlighting reports its count as a message, and Close clears it', async () => {
   let [sw] = context.serviceWorkers();
   if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });

--- a/v3/tests/extension.e2e.spec.ts
+++ b/v3/tests/extension.e2e.spec.ts
@@ -84,17 +84,15 @@ test('built extension loads and every panel surface renders', async () => {
         await expect(page.getByTestId('framework-selector')).toContainText('Playwright');
         await expect(page.getByTestId('empty-state')).toBeVisible();
 
-        // The Add hint holds its space when idle. A row that appears and
-        // disappears shifts the whole table under the pointer, while you are
-        // aiming at it — so it is hidden, never removed. (Arming it needs a
-        // real tab, which a bare panel page does not have.)
-        const hint = page.getByTestId('picking-hint');
-        await expect(hint).toHaveAttribute('data-idle', '');
-        expect(
-          await hint.evaluate((el) => getComputedStyle(el).visibility),
-          'hidden, not display:none, or the row would collapse'
-        ).toBe('hidden');
-        expect((await hint.boundingBox())?.height, 'and it still occupies its row').toBeGreaterThan(0);
+        // Guidance is a dialog now, reachable whenever it is wanted rather
+        // than a row that shifts the table under the pointer.
+        await expect(page.getByTestId('btn-help')).toBeEnabled();
+        await page.getByTestId('btn-help').click();
+        await expect(page.getByTestId('help-ok')).toBeVisible();
+        // Asked for, so not offered as something to be rid of.
+        await expect(page.getByTestId('help-dont-show')).toHaveCount(0);
+        await page.getByTestId('help-ok').click();
+        await expect(page.getByTestId('help-ok')).toHaveCount(0);
 
         // Enablement with no model: scan and add live, the rest disabled.
         await expect(page.getByTestId('btn-delete-model')).toBeDisabled();

--- a/v3/tests/extension.e2e.spec.ts
+++ b/v3/tests/extension.e2e.spec.ts
@@ -84,6 +84,18 @@ test('built extension loads and every panel surface renders', async () => {
         await expect(page.getByTestId('framework-selector')).toContainText('Playwright');
         await expect(page.getByTestId('empty-state')).toBeVisible();
 
+        // The Add hint holds its space when idle. A row that appears and
+        // disappears shifts the whole table under the pointer, while you are
+        // aiming at it — so it is hidden, never removed. (Arming it needs a
+        // real tab, which a bare panel page does not have.)
+        const hint = page.getByTestId('add-hint');
+        await expect(hint).toHaveAttribute('data-idle', '');
+        expect(
+          await hint.evaluate((el) => getComputedStyle(el).visibility),
+          'hidden, not display:none, or the row would collapse'
+        ).toBe('hidden');
+        expect((await hint.boundingBox())?.height, 'and it still occupies its row').toBeGreaterThan(0);
+
         // Enablement with no model: scan and add live, the rest disabled.
         await expect(page.getByTestId('btn-delete-model')).toBeDisabled();
         await expect(page.getByTestId('btn-generate')).toBeDisabled();

--- a/v3/tests/extension.e2e.spec.ts
+++ b/v3/tests/extension.e2e.spec.ts
@@ -88,7 +88,7 @@ test('built extension loads and every panel surface renders', async () => {
         // disappears shifts the whole table under the pointer, while you are
         // aiming at it — so it is hidden, never removed. (Arming it needs a
         // real tab, which a bare panel page does not have.)
-        const hint = page.getByTestId('add-hint');
+        const hint = page.getByTestId('picking-hint');
         await expect(hint).toHaveAttribute('data-idle', '');
         expect(
           await hint.evaluate((el) => getComputedStyle(el).visibility),

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -133,8 +133,15 @@ const multiKey = (() => {
  */
 const helpMode = ref<'add' | 'scan' | 'all' | null>(null);
 
-/** Show the guidance for a mode the first time that mode is used (SPEC §4). */
+/**
+ * Show the guidance for a mode the first time that mode is used (SPEC §4).
+ *
+ * Opened optimistically, because whether the page can be picked at all is only
+ * known once the relay to it fails — there is no reply to wait for, so the
+ * panel finds out from TAB_UNREACHABLE, which withdraws this again.
+ */
 function helpOnFirstUse(mode: 'add' | 'scan') {
+  if (tabId.value == null) return;
   const seen = mode === 'add' ? settings.value.seenAddHelp : settings.value.seenScanHelp;
   if (!seen) helpMode.value = mode;
 }
@@ -243,6 +250,13 @@ function onRuntimeMessage(msg: unknown) {
     model.value = incoming.model;
   } else if (incoming.type === 'TAB_UNREACHABLE') {
     isAdding.value = isScanning.value = false;
+    // Teaching someone to scan a page that cannot be scanned is noise on top
+    // of an error. Withdrawn rather than left standing — and not counted as
+    // seen, so it still appears the first time picking actually starts.
+    //
+    // Only the guidance that opened itself. One opened from the toolbar was
+    // asked for, and an unrelated failure is no reason to take it away.
+    if (helpMode.value !== 'all') helpMode.value = null;
     notice('unreachable', {
       message: 'Page Modeller can\u2019t reach this page. Reload the tab, or try a normal http(s) page.',
       icon: 'block',

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -17,14 +17,23 @@
 
     <q-page-container>
       <q-page>
-        <!-- Advice for the whole time Add is armed, so a strip rather than a
-             toast. Always in the layout and only made invisible, because a row
-             that appears and disappears shifts the whole table under the
-             pointer — while you are aiming at it. Scan does not need it: it
-             already takes many elements at once. -->
-        <div class="hint-strip" :aria-hidden="!isAdding" :data-idle="isAdding ? undefined : ''" data-testid="add-hint">
+        <!-- Advice for the whole time picking is armed, so a strip rather than
+             a toast. Always in the layout and only made invisible, because a
+             row that appears and disappears shifts the whole table under the
+             pointer — while you are aiming at it.
+             Key/action pairs rather than a sentence: walking the DOM and
+             adding several are the two things nothing else in the UI reveals,
+             and prose long enough to explain both does not fit a sidebar. -->
+        <div
+          class="hint-strip"
+          :aria-hidden="!isPickingNow"
+          :data-idle="isPickingNow ? undefined : ''"
+          data-testid="picking-hint"
+        >
           <q-icon name="ads_click" size="16px" />
-          <span>Click an element to add it. Hold <kbd>{{ multiKey }}</kbd> to add several.</span>
+          <span v-for="hint in hints" :key="hint.label" class="hint">
+            <kbd>{{ hint.key }}</kbd> {{ hint.label }}
+          </span>
         </div>
 
         <!-- SPEC §5: a model is kept across a navigation, so it can end up
@@ -125,6 +134,30 @@ const multiKey = (() => {
   const platform = nav.userAgentData?.platform ?? navigator.platform ?? '';
   return /mac/i.test(platform) ? '\u2318' : 'Ctrl';
 })();
+
+const isPickingNow = computed(() => isAdding.value || isScanning.value);
+
+/**
+ * What each mode can do, as key/action pairs. Terse on purpose: the panel is
+ * as narrow as a sidebar, and the arrows and the modifier are undiscoverable
+ * anywhere else, so leaving either out would mean nobody finds it.
+ */
+const hints = computed(() =>
+  isScanning.value
+    ? [
+        // Scan models everything inside what you pick, so the noun matters
+        // more than the verb here.
+        { key: 'Click', label: 'a container' },
+        { key: '\u2191\u2193', label: 'walk' },
+        { key: 'Esc', label: 'stop' },
+      ]
+    : [
+        { key: 'Click', label: 'add' },
+        { key: '\u2191\u2193', label: 'walk' },
+        { key: `${multiKey}+Click`, label: 'many' },
+        { key: 'Esc', label: 'stop' },
+      ]
+);
 
 const openNotices: Record<string, (() => void) | undefined> = {};
 let noticeSeq = 0;
@@ -448,6 +481,7 @@ function notYet(what: string) {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
   padding: 6px 12px;
   font-size: 12px;
   color: var(--pm-muted);
@@ -457,6 +491,21 @@ function notYet(what: string) {
 /* Invisible, not absent: the space stays reserved so nothing below it moves. */
 .hint-strip[data-idle] {
   visibility: hidden;
+}
+
+.hint {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+/* A separator that belongs to the gap rather than to either neighbour, so the
+   row wraps cleanly when the panel is too narrow for one line. */
+.hint + .hint::before {
+  content: '\00b7';
+  margin-right: 4px;
+  opacity: 0.5;
 }
 
 .hint-strip kbd {

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -30,7 +30,6 @@
           :data-idle="isPickingNow ? undefined : ''"
           data-testid="picking-hint"
         >
-          <q-icon name="ads_click" size="16px" />
           <span v-for="hint in hints" :key="hint.label" class="hint">
             <kbd>{{ hint.key }}</kbd> {{ hint.label }}
           </span>

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -17,6 +17,15 @@
 
     <q-page-container>
       <q-page>
+        <!-- Shown only while Add is armed, and only there: Scan already takes
+             many elements, so the modifier means nothing to it. A strip rather
+             than a toast — it is advice for the whole time you are picking,
+             not an event. -->
+        <div v-if="isAdding" class="hint-strip" data-testid="add-hint">
+          <q-icon name="ads_click" size="16px" />
+          <span>Click an element to add it. Hold <kbd>{{ multiKey }}</kbd> to add several.</span>
+        </div>
+
         <!-- SPEC §5: a model is kept across a navigation, so it can end up
              describing a page that is no longer loaded. Say so, rather than
              leaving the user to wonder why the eye reports 0 for every row. -->
@@ -103,6 +112,19 @@ const rows = computed<ModelRow[]>(() =>
  * Quasar groups identical notifications and badges a count. Each kind of notice
  * keeps one slot and replaces it.
  */
+/**
+ * The modifier that holds Add open. Either works (see the content script); this
+ * is only what to call it, and calling it Ctrl on a Mac would be wrong.
+ *
+ * `userAgentData.platform` where it exists, `platform` where it does not —
+ * deprecated, but Firefox has no replacement for it.
+ */
+const multiKey = (() => {
+  const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
+  const platform = nav.userAgentData?.platform ?? navigator.platform ?? '';
+  return /mac/i.test(platform) ? '\u2318' : 'Ctrl';
+})();
+
 const openNotices: Record<string, (() => void) | undefined> = {};
 let noticeSeq = 0;
 
@@ -421,6 +443,24 @@ function notYet(what: string) {
 </script>
 
 <style scoped>
+.hint-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--pm-muted);
+  border-bottom: 1px solid var(--pm-rule);
+}
+
+.hint-strip kbd {
+  font: 11px/1.4 ui-monospace, SFMono-Regular, monospace;
+  border: 1px solid var(--pm-rule);
+  border-radius: 3px;
+  padding: 0 4px;
+  color: var(--pm-text);
+}
+
 .stale-banner {
   display: flex;
   align-items: center;

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -12,29 +12,12 @@
         @add="toggleAdd"
         @delete-model="deleteModel"
         @generate="showCode = true"
+        @help="helpMode = 'all'"
       />
     </q-header>
 
     <q-page-container>
       <q-page>
-        <!-- Advice for the whole time picking is armed, so a strip rather than
-             a toast. Always in the layout and only made invisible, because a
-             row that appears and disappears shifts the whole table under the
-             pointer — while you are aiming at it.
-             Key/action pairs rather than a sentence: walking the DOM and
-             adding several are the two things nothing else in the UI reveals,
-             and prose long enough to explain both does not fit a sidebar. -->
-        <div
-          class="hint-strip"
-          :aria-hidden="!isPickingNow"
-          :data-idle="isPickingNow ? undefined : ''"
-          data-testid="picking-hint"
-        >
-          <span v-for="hint in hints" :key="hint.label" class="hint">
-            <kbd>{{ hint.key }}</kbd> {{ hint.label }}
-          </span>
-        </div>
-
         <!-- SPEC §5: a model is kept across a navigation, so it can end up
              describing a page that is no longer loaded. Say so, rather than
              leaving the user to wonder why the eye reports 0 for every row. -->
@@ -57,6 +40,15 @@
         />
 
         <CodeDialog v-if="showCode" :model="model" @close="showCode = false" />
+
+        <PickingHelpDialog
+          v-if="helpMode"
+          :key="helpMode"
+          :mode="helpMode"
+          :multi-key="multiKey"
+          @dismiss="dismissHelp"
+          @close="helpMode = null"
+        />
 
         <EditElementDialog
           v-if="editing"
@@ -81,6 +73,7 @@ import AppToolbar from './AppToolbar.vue';
 import ModelTable, { type ModelRow } from './ModelTable.vue';
 import EditElementDialog from './EditElementDialog.vue';
 import CodeDialog from './CodeDialog.vue';
+import PickingHelpDialog from './PickingHelpDialog.vue';
 import { defaultFrameworkId } from '@/src/frameworks';
 import { displayElementLocator } from '@/src/locators/display';
 import { activeCandidate, emptyModel, type ModelElement, type TabModel } from '@/src/model';
@@ -88,7 +81,7 @@ import { isMessage, PANEL_PORT, type BackgroundToPanel, type PanelToBackground, 
 import { hostKey } from '@/host/types';
 import { applyTheme } from './theme';
 import type { FrameStep, LocatorCandidate } from '@/src/engine/types';
-import { defaultSettings, loadSettings, watchSettings } from '@/src/settings';
+import { defaultSettings, loadSettings, saveSettings, watchSettings } from '@/src/settings';
 
 // The panel is a VIEW. The background owns the model, one per tab (SPEC §5), so
 // a sidebar and a DevTools panel on the same tab show the same rows and a pick
@@ -134,29 +127,24 @@ const multiKey = (() => {
   return /mac/i.test(platform) ? '\u2318' : 'Ctrl';
 })();
 
-const isPickingNow = computed(() => isAdding.value || isScanning.value);
-
 /**
- * What each mode can do, as key/action pairs. Terse on purpose: the panel is
- * as narrow as a sidebar, and the arrows and the modifier are undiscoverable
- * anywhere else, so leaving either out would mean nobody finds it.
+ * Which guidance is on screen: a single mode when it opened itself on first
+ * use, `all` when the toolbar asked for it, null when nothing is showing.
  */
-const hints = computed(() =>
-  isScanning.value
-    ? [
-        // Scan models everything inside what you pick, so the noun matters
-        // more than the verb here.
-        { key: 'Click', label: 'a container' },
-        { key: '\u2191\u2193', label: 'walk' },
-        { key: 'Esc', label: 'stop' },
-      ]
-    : [
-        { key: 'Click', label: 'add' },
-        { key: '\u2191\u2193', label: 'walk' },
-        { key: `${multiKey}+Click`, label: 'many' },
-        { key: 'Esc', label: 'stop' },
-      ]
-);
+const helpMode = ref<'add' | 'scan' | 'all' | null>(null);
+
+/** Show the guidance for a mode the first time that mode is used (SPEC §4). */
+function helpOnFirstUse(mode: 'add' | 'scan') {
+  const seen = mode === 'add' ? settings.value.seenAddHelp : settings.value.seenScanHelp;
+  if (!seen) helpMode.value = mode;
+}
+
+/** Ticking "don't show this again" is the only thing that stops it coming back. */
+function dismissHelp(modes: ('add' | 'scan')[]) {
+  const patch = Object.fromEntries(modes.map((m) => [m === 'add' ? 'seenAddHelp' : 'seenScanHelp', true]));
+  settings.value = { ...settings.value, ...patch };
+  void saveSettings(settings.value);
+}
 
 const openNotices: Record<string, (() => void) | undefined> = {};
 let noticeSeq = 0;
@@ -360,6 +348,10 @@ async function startPicking(mode: PickMode) {
 
 async function toggleAdd() {
   if (isAdding.value) return stopPicking();
+  // Guidance and picking together, not one then the other: the dialog lives in
+  // the panel and the page stays clickable behind it, so you can try what it
+  // describes while reading it.
+  helpOnFirstUse('add');
   await startPicking('add');
 }
 
@@ -369,6 +361,7 @@ async function toggleAdd() {
  */
 async function toggleScan() {
   if (isScanning.value) return stopPicking();
+  helpOnFirstUse('scan');
   await startPicking('scan');
 }
 

--- a/v3/ui/App.vue
+++ b/v3/ui/App.vue
@@ -17,11 +17,12 @@
 
     <q-page-container>
       <q-page>
-        <!-- Shown only while Add is armed, and only there: Scan already takes
-             many elements, so the modifier means nothing to it. A strip rather
-             than a toast — it is advice for the whole time you are picking,
-             not an event. -->
-        <div v-if="isAdding" class="hint-strip" data-testid="add-hint">
+        <!-- Advice for the whole time Add is armed, so a strip rather than a
+             toast. Always in the layout and only made invisible, because a row
+             that appears and disappears shifts the whole table under the
+             pointer — while you are aiming at it. Scan does not need it: it
+             already takes many elements at once. -->
+        <div class="hint-strip" :aria-hidden="!isAdding" :data-idle="isAdding ? undefined : ''" data-testid="add-hint">
           <q-icon name="ads_click" size="16px" />
           <span>Click an element to add it. Hold <kbd>{{ multiKey }}</kbd> to add several.</span>
         </div>
@@ -451,6 +452,11 @@ function notYet(what: string) {
   font-size: 12px;
   color: var(--pm-muted);
   border-bottom: 1px solid var(--pm-rule);
+}
+
+/* Invisible, not absent: the space stays reserved so nothing below it moves. */
+.hint-strip[data-idle] {
+  visibility: hidden;
 }
 
 .hint-strip kbd {

--- a/v3/ui/AppToolbar.vue
+++ b/v3/ui/AppToolbar.vue
@@ -37,6 +37,12 @@
       <q-tooltip v-if="showTooltips">Add Element</q-tooltip>
     </q-btn>
 
+    <!-- Never disabled: the one control whose whole job is to explain the
+         others is no use only when everything is already clear. -->
+    <q-btn flat dense round icon="help_outline" data-testid="btn-help" @click="$emit('help')">
+      <q-tooltip v-if="showTooltips">How picking works</q-tooltip>
+    </q-btn>
+
     <q-btn flat dense round icon="code" :disable="!hasModel || isPicking" data-testid="btn-generate" @click="$emit('generate')">
       <q-tooltip v-if="showTooltips">Generate Code</q-tooltip>
     </q-btn>
@@ -60,6 +66,7 @@ defineEmits<{
   add: [];
   deleteModel: [];
   generate: [];
+  help: [];
   'update:frameworkId': [id: string];
 }>();
 

--- a/v3/ui/PickingHelpDialog.vue
+++ b/v3/ui/PickingHelpDialog.vue
@@ -53,7 +53,7 @@ const ADD = (multiKey: string) => ({
   title: 'Adding elements',
   lead: 'Click any element on the page to add it to the model.',
   keys: [
-    { key: '↑↓', what: 'walk the DOM while hovering, for a precise pick' },
+    { key: '↑↓', what: 'walk the DOM while hovering, to select the exact element' },
     { key: `${multiKey}+Click`, what: 'keep adding multiple elements' },
     { key: 'Esc', what: 'stop' },
   ],

--- a/v3/ui/PickingHelpDialog.vue
+++ b/v3/ui/PickingHelpDialog.vue
@@ -49,11 +49,14 @@ const open = ref(true);
 const dontShowAgain = ref(false);
 const dismissable = computed(() => props.mode !== 'all');
 
+/** The arrows do the same thing in both modes, so they say the same thing. */
+const WALK = 'walk the DOM while hovering, to select the exact element';
+
 const ADD = (multiKey: string) => ({
   title: 'Adding elements',
   lead: 'Click any element on the page to add it to the model.',
   keys: [
-    { key: '↑↓', what: 'walk the DOM while hovering, to select the exact element' },
+    { key: '↑↓', what: WALK },
     { key: `${multiKey}+CLICK`, what: 'keep adding multiple elements' },
     { key: 'ESC', what: 'stop' },
   ],
@@ -61,9 +64,9 @@ const ADD = (multiKey: string) => ({
 
 const SCAN = {
   title: 'Scanning a page',
-  lead: 'Click a container and everything interactive inside it is modelled at once — a form, a panel, or the page itself.',
+  lead: 'Click any element on the page to use as the model container. All interactive child elements will be included.',
   keys: [
-    { key: '↑↓', what: 'walk the DOM to widen or narrow what you are about to scan' },
+    { key: '↑↓', what: WALK },
     { key: 'ESC', what: 'stop' },
   ],
 };

--- a/v3/ui/PickingHelpDialog.vue
+++ b/v3/ui/PickingHelpDialog.vue
@@ -54,8 +54,8 @@ const ADD = (multiKey: string) => ({
   lead: 'Click any element on the page to add it to the model.',
   keys: [
     { key: '↑↓', what: 'walk the DOM while hovering, to select the exact element' },
-    { key: `${multiKey}+Click`, what: 'keep adding multiple elements' },
-    { key: 'Esc', what: 'stop' },
+    { key: `${multiKey}+CLICK`, what: 'keep adding multiple elements' },
+    { key: 'ESC', what: 'stop' },
   ],
 });
 
@@ -64,7 +64,7 @@ const SCAN = {
   lead: 'Click a container and everything interactive inside it is modelled at once — a form, a panel, or the page itself.',
   keys: [
     { key: '↑↓', what: 'walk the DOM to widen or narrow what you are about to scan' },
-    { key: 'Esc', what: 'stop' },
+    { key: 'ESC', what: 'stop' },
   ],
 };
 
@@ -135,8 +135,11 @@ function onHide() {
   line-height: 1.5;
 }
 
+/* The UI font, not a monospace one: ⌘ and the arrows are drawn small and thin
+   in most monospace faces, and these are labels rather than code. */
 kbd {
-  font: 11px/1.4 ui-monospace, SFMono-Regular, monospace;
+  font: 600 11px/1.4 system-ui, -apple-system, 'Segoe UI', sans-serif;
+  letter-spacing: 0.04em;
   border: 1px solid var(--pm-rule);
   border-radius: 3px;
   padding: 1px 5px;

--- a/v3/ui/PickingHelpDialog.vue
+++ b/v3/ui/PickingHelpDialog.vue
@@ -53,7 +53,7 @@ const ADD = (multiKey: string) => ({
   title: 'Adding elements',
   lead: 'Click any element on the page to add it to the model.',
   keys: [
-    { key: '↑↓', what: 'walk up and down the DOM while hovering, for a precise pick' },
+    { key: '↑↓', what: 'walk the DOM while hovering, for a precise pick' },
     { key: `${multiKey}+Click`, what: 'keep adding without arming Add again' },
     { key: 'Esc', what: 'stop' },
   ],
@@ -63,7 +63,7 @@ const SCAN = {
   title: 'Scanning a page',
   lead: 'Click a container and everything interactive inside it is modelled at once — a form, a panel, or the page itself.',
   keys: [
-    { key: '↑↓', what: 'walk up and down the DOM to widen or narrow what you are about to scan' },
+    { key: '↑↓', what: 'walk the DOM to widen or narrow what you are about to scan' },
     { key: 'Esc', what: 'stop' },
   ],
 };

--- a/v3/ui/PickingHelpDialog.vue
+++ b/v3/ui/PickingHelpDialog.vue
@@ -1,0 +1,149 @@
+<template>
+  <q-dialog v-model="open" @hide="onHide">
+    <q-card class="help-card">
+      <q-toolbar class="dialog-header">
+        <q-toolbar-title class="text-subtitle1">{{ title }}</q-toolbar-title>
+      </q-toolbar>
+
+      <q-card-section v-for="section in sections" :key="section.title" class="section">
+        <div v-if="sections.length > 1" class="section-title">{{ section.title }}</div>
+        <p class="lead">{{ section.lead }}</p>
+        <dl class="keys">
+          <template v-for="row in section.keys" :key="row.key">
+            <dt><kbd>{{ row.key }}</kbd></dt>
+            <dd>{{ row.what }}</dd>
+          </template>
+        </dl>
+      </q-card-section>
+
+      <q-card-actions align="between" class="actions">
+        <!-- Only offered when this opened by itself. Asked to see it, you are
+             not asking to be rid of it. -->
+        <q-checkbox
+          v-if="dismissable"
+          v-model="dontShowAgain"
+          dense
+          size="sm"
+          label="Don’t show this again"
+          data-testid="help-dont-show"
+        />
+        <span v-else />
+        <q-btn v-close-popup flat no-caps label="Got it" data-testid="help-ok" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+
+const props = defineProps<{
+  /** `all` when opened from the toolbar; a single mode on first use. */
+  mode: 'add' | 'scan' | 'all';
+  /** The multi-add modifier, named for this platform. */
+  multiKey: string;
+}>();
+const emit = defineEmits<{ close: []; dismiss: [modes: ('add' | 'scan')[]] }>();
+
+const open = ref(true);
+const dontShowAgain = ref(false);
+const dismissable = computed(() => props.mode !== 'all');
+
+const ADD = (multiKey: string) => ({
+  title: 'Adding elements',
+  lead: 'Click any element on the page to add it to the model.',
+  keys: [
+    { key: '↑↓', what: 'walk up and down the DOM while hovering, for a precise pick' },
+    { key: `${multiKey}+Click`, what: 'keep adding without arming Add again' },
+    { key: 'Esc', what: 'stop' },
+  ],
+});
+
+const SCAN = {
+  title: 'Scanning a page',
+  lead: 'Click a container and everything interactive inside it is modelled at once — a form, a panel, or the page itself.',
+  keys: [
+    { key: '↑↓', what: 'walk up and down the DOM to widen or narrow what you are about to scan' },
+    { key: 'Esc', what: 'stop' },
+  ],
+};
+
+const sections = computed(() => {
+  if (props.mode === 'add') return [ADD(props.multiKey)];
+  if (props.mode === 'scan') return [SCAN];
+  return [ADD(props.multiKey), SCAN];
+});
+
+const title = computed(() => (props.mode === 'all' ? 'Using Page Modeller' : sections.value[0].title));
+
+/**
+ * Decided on close rather than on tick, so ticking and then unticking before
+ * dismissing means what it looks like it means.
+ */
+function onHide() {
+  if (dontShowAgain.value && props.mode !== 'all') emit('dismiss', [props.mode]);
+  emit('close');
+}
+</script>
+
+<style scoped>
+.help-card {
+  width: 100%;
+  max-width: 440px;
+  background: var(--pm-page-bg);
+  color: var(--pm-text);
+}
+
+.dialog-header {
+  background: var(--pm-toolbar-bg);
+  color: var(--pm-toolbar-fg);
+  border-bottom: 1px solid var(--pm-rule);
+  min-height: 44px;
+}
+
+.section + .section {
+  border-top: 1px solid var(--pm-rule);
+}
+
+.section-title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.lead {
+  margin: 0 0 12px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+/* Two columns so the keys line up and the descriptions can run on. */
+.keys {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 12px;
+  margin: 0;
+  font-size: 12px;
+}
+
+.keys dt {
+  white-space: nowrap;
+}
+
+.keys dd {
+  margin: 0;
+  color: var(--pm-muted);
+  line-height: 1.5;
+}
+
+kbd {
+  font: 11px/1.4 ui-monospace, SFMono-Regular, monospace;
+  border: 1px solid var(--pm-rule);
+  border-radius: 3px;
+  padding: 1px 5px;
+  color: var(--pm-text);
+}
+
+.actions {
+  border-top: 1px solid var(--pm-rule);
+}
+</style>

--- a/v3/ui/PickingHelpDialog.vue
+++ b/v3/ui/PickingHelpDialog.vue
@@ -54,7 +54,7 @@ const ADD = (multiKey: string) => ({
   lead: 'Click any element on the page to add it to the model.',
   keys: [
     { key: '↑↓', what: 'walk the DOM while hovering, for a precise pick' },
-    { key: `${multiKey}+Click`, what: 'keep adding without arming Add again' },
+    { key: `${multiKey}+Click`, what: 'keep adding multiple elements' },
     { key: 'Esc', what: 'stop' },
   ],
 });


### PR DESCRIPTION
Add is one-shot, which is right once and tiresome ten times. Holding **⌘** (or **Ctrl**) while clicking keeps it armed for the next click; releasing it makes the last click behave as it always did.

Decided **per click**, read from the event rather than remembered — hold it through a run, let go on the final element. Either modifier is accepted whatever the platform; only the *name* shown to the user is platform-specific, since calling it Ctrl on a Mac would be wrong. Scan is unaffected: it already takes many elements at once.

## Telling the user

A strip under the toolbar while Add is armed, not a toast — it's advice for the whole time you're picking, not an event:

> Click an element to add it. Hold `⌘` to add several.

## Verification

The E2E proves it behaviourally: two picks with the modifier held, then an unheld one, then a further click that adds nothing. Reverting the background's `keepPicking` branch fails it at the second pick (`Expected: 2, Received: 1`).

There's nothing to assert on for the message side — the panel learns picking ended through a `FROM_TAB` broadcast, and the service worker can't observe its own `runtime.sendMessage`. Worth knowing if you're writing tests here; it cost me a couple of wrong assertions.

254 unit + 35 Playwright green. Hand-test worth doing on both browsers, since the modifier keys differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)