### PR TITLE
v3: run the generated Playwright Python

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,10 +137,15 @@ Two separate questions: does the locator find the element, and is the emitted co
 |---|---|---|
 | Playwright TS | ✅ every expression resolved in real Playwright | ✅ `tsc` against `@playwright/test` |
 | Puppeteer | ✅ real Puppeteer (`puppeteer.fidelity.spec.ts`) | ✅ `tsc` against `puppeteer-core` |
-| Playwright Python | ✅ inherited — proven the mechanical transform of the TS spelling | ✅ `python3 -m ast` |
+| Playwright Python | ✅ **run** in a real browser via the Python bindings | ✅ `python3 -m ast` |
 | Selenium Python | ✅ **run** in a real Chrome via WebDriver | ✅ `python3 -m ast` |
 | Selenium Java | ⚠️ strategy only, but see below | ✅ `javac` against selenium-api + selenium-support |
 | Selenium C# | ⚠️ strategy only, but see below | ✅ `dotnet build` against Selenium.WebDriver |
+
+`tests/playwright-python.run.spec.ts` does the same for Playwright: the generated page object is
+imported into a real Playwright Python run, and every locator must resolve to exactly one element and
+to the right one. It found two syntax errors nothing else could — an element called Continue produced
+`self.continue`, and the TypeScript locators shape produced `const continue`.
 
 `tests/selenium.run.spec.ts` drives the **generated Python** in a real Chrome through WebDriver: every
 locator must find the element it was generated from, each bucket's read method must run, and the frame

--- a/v3/scripts/fetch-test-deps.mjs
+++ b/v3/scripts/fetch-test-deps.mjs
@@ -50,8 +50,13 @@ try {
   if (!existsSync(resolve(VENV, 'bin', 'python'))) {
     execFileSync('python3', ['-m', 'venv', VENV], { stdio: 'inherit' });
   }
-  execFileSync(resolve(VENV, 'bin', 'pip'), ['install', '--quiet', '--upgrade', 'selenium'], { stdio: 'inherit' });
-  console.log('✓ selenium installed in .test-venv');
+  execFileSync(resolve(VENV, 'bin', 'pip'), ['install', '--quiet', '--upgrade', 'selenium', 'playwright'], {
+    stdio: 'inherit',
+  });
+  // Into the same cache the Node Playwright uses, so a browser already there is
+  // not downloaded twice.
+  execFileSync(resolve(VENV, 'bin', 'python'), ['-m', 'playwright', 'install', 'chromium'], { stdio: 'inherit' });
+  console.log('✓ selenium and playwright installed in .test-venv');
 } catch (e) {
   ok = false;
   console.log(`could not set up the Python venv: ${e.message}`);

--- a/v3/src/generators/names.ts
+++ b/v3/src/generators/names.ts
@@ -28,3 +28,52 @@ export function snake(name: string): string {
 export function upperSnake(name: string): string {
   return snake(name).toUpperCase();
 }
+
+/**
+ * Element names come from the page, and pages contain buttons called Continue,
+ * Class and Import. Those are keywords, and a keyword cannot be an identifier.
+ *
+ * A trailing underscore is what PEP 8 prescribes for exactly this, and it reads
+ * the same way in JavaScript. Better than dropping or renaming: the name still
+ * says which element it is.
+ */
+const PYTHON_KEYWORDS = new Set(
+  ('False None True and as assert async await break class continue def del elif else except finally ' +
+    'for from global if import in is lambda nonlocal not or pass raise return try while with yield')
+    .split(' ')
+);
+
+// Reserved words that cannot be a `const` binding. Property names may be
+// keywords in JavaScript, but the locators shape declares variables.
+const JS_KEYWORDS = new Set(
+  ('await break case catch class const continue debugger default delete do else enum export extends ' +
+    'false finally for function if implements import in instanceof interface let new null package ' +
+    'private protected public return static super switch this throw true try typeof var void while ' +
+    'with yield')
+    .split(' ')
+);
+
+export const pythonName = (name: string) => (PYTHON_KEYWORDS.has(name) ? `${name}_` : name);
+export const jsName = (name: string) => (JS_KEYWORDS.has(name) ? `${name}_` : name);
+
+// Java's, for the locators shape, whose fields are bare names. Its methods are
+// prefixed (`getContinueElement`) and safe, and C#'s fields carry the .NET
+// underscore, which happens to make them safe too.
+const JAVA_KEYWORDS = new Set(
+  ('abstract assert boolean break byte case catch char class const continue default do double else ' +
+    'enum extends final finally float for goto if implements import instanceof int interface long ' +
+    'native new package private protected public return short static strictfp super switch ' +
+    'synchronized this throw throws transient try void volatile while true false null')
+    .split(' ')
+);
+
+export const javaName = (name: string) => (JAVA_KEYWORDS.has(name) ? `${name}_` : name);
+
+/**
+ * Every method `java.lang.Object` already has. An element called Class yields
+ * `getClass()`, which cannot be declared — it does not override cleanly, and
+ * javac says so. Found by adding such a name to the compile fixtures.
+ */
+const OBJECT_METHODS = new Set(['getClass', 'hashCode', 'equals', 'toString', 'notify', 'notifyAll', 'wait', 'clone', 'finalize']);
+
+export const javaMethod = (name: string) => (OBJECT_METHODS.has(name) ? `${name}_` : name);

--- a/v3/src/generators/playwright-python.ts
+++ b/v3/src/generators/playwright-python.ts
@@ -7,7 +7,7 @@ import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import { playwrightPyExpr } from '../locators/display';
 import { playwrightPyFramePrefix } from '../locators/frames';
 import { classNameFor } from './class-name';
-import { snake } from './names';
+import { pythonName, snake } from './names';
 
 const expr = (el: ModelElement) =>
   `page.${playwrightPyFramePrefix(el.framePath)}${playwrightPyExpr(activeCandidate(el))}`;
@@ -27,12 +27,12 @@ export function generatePlaywrightPythonPageObject(model: TabModel): string {
 
   return [
     ...head(true),
-    ...model.elements.map((el) => `        self.${snake(el.name)}: Locator = ${expr(el)}`),
+    ...model.elements.map((el) => `        self.${pythonName(snake(el.name))}: Locator = ${expr(el)}`),
     '',
   ].join('\n');
 }
 
 /** Locators only — bare assignments, for your own page-object conventions. */
 export function generatePlaywrightPythonLocators(model: TabModel): string {
-  return model.elements.map((el) => `${snake(el.name)} = ${expr(el)}`).join('\n');
+  return model.elements.map((el) => `${pythonName(snake(el.name))} = ${expr(el)}`).join('\n');
 }

--- a/v3/src/generators/selenium-java.ts
+++ b/v3/src/generators/selenium-java.ts
@@ -5,7 +5,7 @@
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import type { LocatorCandidate } from '../engine/types';
 import { classify, isImage } from './classify';
-import { lowerCamel } from './names';
+import { javaMethod, javaName, lowerCamel } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameFor } from './class-name';
 import { frameContext, frameNote, isOpaque } from '../locators/frames';
@@ -89,6 +89,10 @@ function methods(el: ModelElement): string[] {
   const elExpr = framed ? `driver.findElement(${by(activeCandidate(el))})` : `get${n}Element()`;
   const selectExpr = framed ? `new Select(${elExpr})` : `get${n}Select()`;
 
+  // `getClass` is already on Object, so an element called Class cannot have the
+  // plain getter its bucket would otherwise give it.
+  const getValue = javaMethod(`get${n}`);
+
   const out: string[] = framed
     ? []
     : [`public WebElement get${n}Element() {\n    return driver.findElement(${by(activeCandidate(el))});\n}`];
@@ -102,7 +106,7 @@ function methods(el: ModelElement): string[] {
       out.push(
         // getDomProperty, not getAttribute: the attribute is the INITIAL value
         // and does not change as the user types (Selenium 4.5+).
-        `public String get${n}() {\n    return ${elExpr}.getDomProperty("value");\n}`,
+        `public String ${getValue}() {\n    return ${elExpr}.getDomProperty("value");\n}`,
         // Clearing is the default, because v2.5.1's setter appended and almost
         // nobody wanted that. An overload keeps appending available rather than
         // trading one hard-coded behaviour for the other — Java has no default
@@ -160,7 +164,7 @@ function methods(el: ModelElement): string[] {
         isImage(el)
           ? // getText() on an <img> returns an empty string; alt is the text.
             `public String get${n}AltText() {\n    return ${elExpr}.getDomAttribute("alt");\n}`
-          : `public String get${n}() {\n    return ${elExpr}.getText();\n}`
+          : `public String ${getValue}() {\n    return ${elExpr}.getText();\n}`
       );
       break;
   }
@@ -176,7 +180,7 @@ function methods(el: ModelElement): string[] {
  */
 export function generateSeleniumJavaLocators(model: TabModel): string {
   return model.elements
-    .flatMap((el) => [...frameNote(el.framePath, '//', frameSwitch), `private final By ${lowerCamel(el.name)} = ${by(activeCandidate(el))};`])
+    .flatMap((el) => [...frameNote(el.framePath, '//', frameSwitch), `private final By ${javaName(lowerCamel(el.name))} = ${by(activeCandidate(el))};`])
     .join('\n');
 }
 

--- a/v3/src/generators/ts-page-object.ts
+++ b/v3/src/generators/ts-page-object.ts
@@ -7,7 +7,7 @@
 // is spelled.
 import type { ModelElement, TabModel } from '../model';
 import { classNameFor } from './class-name';
-import { lowerCamel } from './names';
+import { jsName, lowerCamel } from './names';
 
 export interface TsTarget {
   /** The package `Locator` and `Page` are imported from. */
@@ -41,14 +41,14 @@ export function tsPageObject(model: TabModel, target: TsTarget): string {
     `import { type Locator, type Page } from '${target.module}';`,
     '',
     `export class ${className} {`,
-    ...model.elements.map((el) => `  readonly ${lowerCamel(el.name)}: ${target.locatorType ?? 'Locator'};`),
+    ...model.elements.map((el) => `  readonly ${jsName(lowerCamel(el.name))}: ${target.locatorType ?? 'Locator'};`),
     '',
     // Assignment reads the constructor PARAMETER, not `this.page`: a parameter
     // property is not assigned until the constructor body completes.
     '  constructor(private readonly page: Page) {',
     ...model.elements.flatMap((el) => [
       ...(target.note?.(el) ?? []).map((line) => `    ${line}`),
-      `    this.${lowerCamel(el.name)} = page.${target.expr(el)};`,
+      `    this.${jsName(lowerCamel(el.name))} = page.${target.expr(el)};`,
     ]),
     '  }',
     '}',
@@ -59,6 +59,6 @@ export function tsPageObject(model: TabModel, target: TsTarget): string {
 /** Locators only — no class, and the types are inferred. */
 export function tsLocators(model: TabModel, target: TsTarget): string {
   return model.elements
-    .flatMap((el) => [...(target.note?.(el) ?? []), `const ${lowerCamel(el.name)} = page.${target.expr(el)};`])
+    .flatMap((el) => [...(target.note?.(el) ?? []), `const ${jsName(lowerCamel(el.name))} = page.${target.expr(el)};`])
     .join('\n');
 }

--- a/v3/tests/compile/csharp/Generated.cs
+++ b/v3/tests/compile/csharp/Generated.cs
@@ -235,6 +235,61 @@ public void SetPasswordEl(string value, bool clearFirst = true)
 }
 
 /*
+ * Continue
+ * ***************************************************************
+ */
+
+public IWebElement GetContinueElement()
+{
+    return driver.FindElement(By.CssSelector("button.continue"));
+}
+
+public void ClickContinue()
+{
+    GetContinueElement().Click();
+}
+
+/*
+ * Class
+ * ***************************************************************
+ */
+
+public IWebElement GetClassElement()
+{
+    return driver.FindElement(By.CssSelector("input.class"));
+}
+
+public string GetClass()
+{
+    return GetClassElement().GetDomProperty("value");
+}
+
+public void SetClass(string value, bool clearFirst = true)
+{
+    IWebElement el = GetClassElement();
+    if (clearFirst)
+    {
+        el.Clear();
+    }
+    el.SendKeys(value);
+}
+
+/*
+ * Import
+ * ***************************************************************
+ */
+
+public IWebElement GetImportElement()
+{
+    return driver.FindElement(By.CssSelector("a.import"));
+}
+
+public void ClickImport()
+{
+    GetImportElement().Click();
+}
+
+/*
  * FramedActionableEl
  * In frame: #same-frame › #deep-frame
  * ***************************************************************
@@ -617,6 +672,89 @@ public void SetFramedPasswordEl(string value, bool clearFirst = true)
 }
 
 /*
+ * FramedContinue
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public void ClickFramedContinue()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        driver.FindElement(By.CssSelector("button.continue")).Click();
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
+ * FramedClass
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public string GetFramedClass()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        return driver.FindElement(By.CssSelector("input.class")).GetDomProperty("value");
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+public void SetFramedClass(string value, bool clearFirst = true)
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        IWebElement el = driver.FindElement(By.CssSelector("input.class"));
+        if (clearFirst)
+        {
+            el.Clear();
+        }
+        el.SendKeys(value);
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
+ * FramedImport
+ * In frame: #same-frame › #deep-frame
+ * ***************************************************************
+ */
+
+public void ClickFramedImport()
+{
+    driver.SwitchTo().DefaultContent();
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+    driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+    try
+    {
+        driver.FindElement(By.CssSelector("a.import")).Click();
+    }
+    finally
+    {
+        driver.SwitchTo().DefaultContent();
+    }
+}
+
+/*
  * ById
  * ***************************************************************
  */
@@ -758,6 +896,9 @@ private readonly By _multiSelectEl = By.CssSelector("select.toppings");
 private readonly By _staticEl = By.CssSelector("h1");
 private readonly By _imageEl = By.CssSelector("img.logo");
 private readonly By _passwordEl = By.CssSelector("input.pass");
+private readonly By _continue = By.CssSelector("button.continue");
+private readonly By _class = By.CssSelector("input.class");
+private readonly By _import = By.CssSelector("a.import");
 // In frame: #same-frame › #deep-frame
 // driver.SwitchTo().DefaultContent();
 // driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
@@ -803,6 +944,21 @@ private readonly By _framedImageEl = By.CssSelector("img.logo");
 // driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
 // driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
 private readonly By _framedPasswordEl = By.CssSelector("input.pass");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedContinue = By.CssSelector("button.continue");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedClass = By.CssSelector("input.class");
+// In frame: #same-frame › #deep-frame
+// driver.SwitchTo().DefaultContent();
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#same-frame")));
+// driver.SwitchTo().Frame(driver.FindElement(By.CssSelector("#deep-frame")));
+private readonly By _framedImport = By.CssSelector("a.import");
 private readonly By _byId = By.Id("go");
 private readonly By _byName = By.Name("email");
 private readonly By _byClassName = By.ClassName("row");

--- a/v3/tests/playwright-python.run.spec.ts
+++ b/v3/tests/playwright-python.run.spec.ts
@@ -1,0 +1,205 @@
+import { test, expect } from '@playwright/test';
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { generatePlaywrightPythonPageObject } from '../src/generators/playwright-python';
+import { chooseCandidate } from '../src/locators/select';
+import { uniqueName, } from '../src/engine/naming';
+import { emptyModel, type ModelElement } from '../src/model';
+import { pythonName, snake } from '../src/generators/names';
+import type { ElementResult, FrameStep } from '../src/engine/types';
+import { REQUIRE_FULL_SUITE } from './required';
+
+// Does the generated Playwright Python actually work?
+//
+// Its TypeScript sibling is resolved against a real browser on every change,
+// and the Python spelling is asserted to be that one's mechanical transform —
+// but the transform itself was never executed. Selenium taught the lesson:
+// `get_dom_property` is Java's and C#'s spelling and does not exist in Python,
+// and nothing short of running it noticed.
+const PORT = 5255;
+const VENV_PY = resolve('.test-venv/bin/python');
+const ready = existsSync(VENV_PY);
+
+let server: ChildProcess;
+
+test.beforeAll(async () => {
+  server = spawn('node', [resolve('scripts/serve-fixtures.mjs')], {
+    env: { ...process.env, FIXTURES_PORT: String(PORT) },
+    stdio: 'ignore',
+  });
+  for (let i = 0; i < 100; i++) {
+    try {
+      if ((await fetch(`http://localhost:${PORT}/login.html`)).ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error('fixtures server did not start');
+});
+
+test.afterAll(() => server?.kill());
+
+test('the generated Playwright Python resolves every element it describes', async ({ page }) => {
+  test.skip(!ready && !REQUIRE_FULL_SUITE, 'run `npm run fetch:test-deps` for the Python venv');
+  expect(ready, 'PM_REQUIRE_FULL_SUITE is set but .test-venv is missing').toBe(true);
+
+  const fixtures = ['login.html', 'widgets.html', 'ambiguous.html', 'edgecases.html'];
+  const failures: string[] = [];
+  const exercised = new Set<string>();
+
+  for (const fixture of fixtures) {
+    const url = `http://localhost:${PORT}/${fixture}`;
+    await page.goto(url);
+    await page.addScriptTag({ path: resolve('.test-dist/engine.global.js') });
+
+    const results = await page.$$eval('[data-spike]', (els) =>
+      els.map((el) => ({
+        spikeId: el.getAttribute('data-spike') as string,
+        result: (window as unknown as { __spike: { generate: (e: Element) => ElementResult } }).__spike.generate(el),
+      }))
+    );
+
+    const model = emptyModel('playwright-python');
+    const used = new Set<string>();
+    const expected: [string, string][] = [];
+    for (const { spikeId, result } of results) {
+      const name = uniqueName(result.suggestedName, used);
+      expected.push([name, spikeId]);
+      model.elements.push({
+        ...result,
+        id: spikeId,
+        name,
+        selectedIndex: chooseCandidate(result.candidates, 'playwright-python'),
+      } as ModelElement);
+    }
+    for (const el of model.elements) exercised.add(el.candidates[el.selectedIndex].candidate.kind);
+
+    const out = runInPython(generatePlaywrightPythonPageObject(model), expected, url);
+    if (out.trim()) failures.push(`${fixture}\n${out.trim()}`);
+
+    // Again on xpath, which nothing selects on its own — role or better always
+    // wins — so `locator("xpath=…")` would otherwise never run. It is the one
+    // spelling with a prefix that Playwright does not infer.
+    const asXpath = { ...model, elements: [] as ModelElement[] };
+    const xpathExpected: [string, string][] = [];
+    for (const [i, el] of model.elements.entries()) {
+      const at = el.candidates.findIndex((c) => c.candidate.kind === 'xpath');
+      if (at === -1) continue;
+      asXpath.elements.push({ ...el, selectedIndex: at });
+      xpathExpected.push(expected[i]);
+    }
+    for (const el of asXpath.elements) exercised.add('xpath');
+    const xpathOut = runInPython(generatePlaywrightPythonPageObject(asXpath), xpathExpected, url);
+    if (xpathOut.trim()) failures.push(`${fixture} (forced xpath)\n${xpathOut.trim()}`);
+  }
+
+  expect(failures.join('\n\n'), 'generated Playwright Python did not resolve as promised').toBe('');
+
+  // What this actually proved, so "verified" cannot quietly come to mean less.
+  expect([...exercised].sort(), 'locator types exercised against a real browser').toEqual([
+    'css',
+    'label',
+    'placeholder',
+    'role',
+    'testId',
+    'text',
+    'xpath',
+  ]);
+  // Not reached: altText and title. Both are also the element's accessible
+  // name, so role wins ahead of them (SPEC §7) and nothing in the fixtures
+  // falls through — the same reason Selenium never reaches className.
+});
+
+test('the generated Playwright Python chains frameLocator (SPEC §16)', async () => {
+  test.skip(!ready && !REQUIRE_FULL_SUITE, 'run `npm run fetch:test-deps` for the Python venv');
+  expect(ready, 'PM_REQUIRE_FULL_SUITE is set but .test-venv is missing').toBe(true);
+
+  const url = `http://localhost:${PORT}/frames.html`;
+  const model = emptyModel('playwright-python');
+  const cases: [string, string, string[]][] = [
+    ['ChildEmail', 'child-email', ['#same-frame']],
+    ['DeepCvv', 'deep-cvv', ['#same-frame', '#deep-frame']],
+    ['CrossEmail', 'child-email', ['#cross-frame']],
+    ['CrossDeepCvv', 'deep-cvv', ['#cross-frame', '#deep-frame']],
+    ['SrcdocCoupon', 'srcdoc-coupon', ['#srcdoc-frame']],
+  ];
+  for (const [name, spikeId, chain] of cases) {
+    model.elements.push({
+      id: name,
+      name,
+      tag: 'input',
+      role: 'textbox',
+      accessibleName: null,
+      suggestedName: name,
+      candidates: [{ candidate: { kind: 'css', value: `[data-spike="${spikeId}"]` }, predictedCount: 1 }],
+      preferredIndex: 0,
+      selectedIndex: 0,
+      framePath: chain.map((value) => ({ frame: { kind: 'css', value } })) as FrameStep[],
+    } as ModelElement);
+  }
+
+  const out = runInPython(
+    generatePlaywrightPythonPageObject(model),
+    cases.map(([name, spikeId]) => [name, spikeId] as [string, string]),
+    url
+  );
+  expect(out.trim(), 'generated frame chaining did not resolve').toBe('');
+});
+
+/**
+ * Import the generated page object into a real Playwright Python run and check
+ * every locator lands on the element it was generated from.
+ */
+function runInPython(generated: string, expected: [string, string][], url: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pm-pw-python-'));
+  const file = join(dir, 'check.py');
+
+  const source = [
+    'import sys',
+    'from playwright.sync_api import sync_playwright',
+    '',
+    // The generated module, verbatim — its own imports included, so a wrong
+    // one is a failure here too.
+    generated,
+    '',
+    'failures = []',
+    'with sync_playwright() as p:',
+    '    browser = p.chromium.launch()',
+    '    page = browser.new_page()',
+    `    page.goto(${JSON.stringify(url)})`,
+    '    model = ' + className(generated) + '(page)',
+    ...expected.flatMap(([name, spikeId]) => [
+      '    try:',
+      `        found = model.${pythonName(snake(name))}`,
+      '        count = found.count()',
+      '        if count != 1:',
+      `            failures.append("${name}: matched " + str(count) + ", wanted 1")`,
+      '        else:',
+      `            actual = found.get_attribute("data-spike")`,
+      `            if actual != ${JSON.stringify(spikeId)}:`,
+      `                failures.append("${name}: found " + str(actual) + ", wanted ${spikeId}")`,
+      '    except Exception as e:',
+      `        failures.append("${name}: " + type(e).__name__ + " " + str(e).split(chr(10))[0])`,
+    ]),
+    '    browser.close()',
+    '',
+    'print("\\n".join(failures))',
+    'sys.exit(0)',
+  ].join('\n');
+
+  writeFileSync(file, source);
+  try {
+    return execFileSync(VENV_PY, [file], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string };
+    return `harness failed:\n${err.stdout ?? ''}${err.stderr ?? ''}`;
+  }
+}
+
+/** The class the generator named, so the harness instantiates the right one. */
+function className(generated: string): string {
+  return generated.match(/^class (\w+):/m)?.[1] ?? 'GeneratedPage';
+}

--- a/v3/tests/unit/fixtures/model.ts
+++ b/v3/tests/unit/fixtures/model.ts
@@ -144,6 +144,14 @@ export const ALL_BUCKETS: TestElement[] = [
   { name: 'StaticEl', role: 'heading', tag: 'h1', candidate: { kind: 'css', value: 'h1' } },
   { name: 'ImageEl', role: 'img', tag: 'img', candidate: { kind: 'css', value: 'img.logo' } },
   { name: 'PasswordEl', role: null, tag: 'input', inputType: 'password', candidate: { kind: 'css', value: 'input.pass' } },
+  // Pages contain buttons called Continue, Class and Import. Every one of those
+  // is a keyword somewhere, and a keyword cannot be an identifier — `const
+  // continue` and `self.continue` are both syntax errors. Found by running the
+  // generated Python; kept here so the compile and parse checks catch it next
+  // time, which they can and the unit tests alone cannot.
+  { name: 'Continue', role: 'button', tag: 'button', candidate: { kind: 'css', value: 'button.continue' } },
+  { name: 'Class', role: 'textbox', tag: 'input', candidate: { kind: 'css', value: 'input.class' } },
+  { name: 'Import', role: 'link', tag: 'a', candidate: { kind: 'css', value: 'a.import' } },
 ];
 
 /** The same buckets, but two frames deep — so the switching code is compiled. */

--- a/v3/tests/unit/keyword-names.test.ts
+++ b/v3/tests/unit/keyword-names.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { generatePlaywrightPythonPageObject, generatePlaywrightPythonLocators } from '../../src/generators/playwright-python';
+import { generatePlaywrightLocators } from '../../src/generators/playwright-ts';
+import { generateSeleniumJavaLocators, generateSeleniumJava } from '../../src/generators/selenium-java';
+import { modelOf, type TestElement } from './fixtures/model';
+
+// Element names come from the page, and pages have buttons called Continue.
+const kw = (name: string): TestElement => ({
+  name,
+  role: 'button',
+  tag: 'button',
+  candidate: { kind: 'css', value: 'button' },
+});
+
+describe('a name that is a keyword somewhere', () => {
+  it('is suffixed in Python, where it would not parse', () => {
+    const out = generatePlaywrightPythonPageObject(modelOf('playwright-python', kw('Continue'), kw('Class')));
+    expect(out).toContain('self.continue_: Locator =');
+    expect(out).toContain('self.class_: Locator =');
+    expect(generatePlaywrightPythonLocators(modelOf('playwright-python', kw('Import')))).toContain('import_ = page.');
+  });
+
+  it('is suffixed in a JavaScript const, where it would not parse either', () => {
+    // The page-object field form is legal — `this.continue` is fine — but the
+    // locators shape declares variables, and `const continue` is not.
+    expect(generatePlaywrightLocators(modelOf('playwright-ts', kw('Continue')))).toContain('const continue_ =');
+  });
+
+  it('is suffixed in a Java field', () => {
+    expect(generateSeleniumJavaLocators(modelOf('selenium-java', kw('Continue')))).toContain(
+      'private final By continue_ ='
+    );
+  });
+
+  it('does not collide with a method Object already has', () => {
+    // `getClass()` cannot be declared, whatever the element is called.
+    const out = generateSeleniumJava(modelOf('selenium-java', { ...kw('Class'), role: 'heading', tag: 'h1' }));
+    expect(out).toContain('public String getClass_()');
+    expect(out).toContain('public WebElement getClassElement()');
+  });
+
+  it('leaves an ordinary name alone', () => {
+    expect(generatePlaywrightPythonLocators(modelOf('playwright-python', kw('SignIn')))).toContain('sign_in = page.');
+    expect(generateSeleniumJavaLocators(modelOf('selenium-java', kw('SignIn')))).toContain('By signIn =');
+  });
+});


### PR DESCRIPTION
The last unrun target. Its spelling was asserted to be the mechanical transform of the TypeScript one, and the TypeScript one is resolved against a real browser — but **the transform itself had never been executed**.

Now it is: the generated page object is imported into a real Playwright Python run, and every locator must resolve to exactly one element, and the right one.

## Three bugs, all from one element called "Continue"

```python
self.continue: Locator = page.locator(...)   # SyntaxError — Python keyword
```
```js
const continue = page.getByRole(...)          // SyntaxError — JS reserved word
```
```java
public String getClass()                      // cannot override Object.getClass()
```

None was reachable by a compiler, a parser or a unit test — the first two are syntax errors in files nothing compiled, and the third needed an element named `Class` to exist.

Keywords are suffixed with an underscore: PEP 8 prescribes exactly that, and it reads the same in JavaScript and Java. **C# escaped by accident** — the .NET underscore prefix on private fields makes `_continue` legal already.

`Continue`, `Class` and `Import` are now in the compile fixtures, so `javac`, `dotnet`, `tsc` and `ast` catch this next time. They could all along; the names simply weren't there.

## Honesty, as before

The spec asserts which locator types it proved: `css, label, placeholder, role, testId, text, xpath`. **altText and title are not among them** — both are also the element's accessible name, so `role` wins ahead of them and nothing in the fixtures falls through. Same reason Selenium never reaches `className`.

And a forced-xpath pass, because nothing selects xpath on its own and `locator("xpath=…")` is the one spelling with a prefix Playwright does not infer.

## Coverage now

| Target | Locator semantics | Generated code |
|---|---|---|
| Playwright TS | ✅ real browser | ✅ `tsc` |
| Playwright Python | ✅ **run** | ✅ `ast` |
| Puppeteer | ✅ real browser | ✅ `tsc` |
| Selenium Python | ✅ **run** | ✅ `ast` |
| Selenium Java | ⚠️ strategy only | ✅ `javac` |
| Selenium C# | ⚠️ strategy only | ✅ `dotnet build` |

261 unit + 40 Playwright green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)