### PR TITLE
No modulepreload hints on the panel pages

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -114,5 +114,27 @@ export default defineConfig({
 
   vite: () => ({
     plugins: [vue({ template: { transformAssetUrls } }), quasar({})],
+    build: {
+      /**
+       * No `<link rel="modulepreload">` on the panel pages.
+       *
+       * Vite emits them with `crossorigin`, which on a `chrome-extension://`
+       * URL fetches in CORS mode while the module import that follows does
+       * not. The preloaded response cannot be reused, so Chromium discards it,
+       * refetches the chunk, and logs two warnings per chunk:
+       *
+       *   A preload for '…/chunks/settings-*.js' is found, but is not used
+       *   because it is a cross-world extension resource mismatch.
+       *
+       * Harmless — the chunk loads the second time — but it fills the
+       * extension's error list on chrome://extensions, where a user or a store
+       * reviewer reads it as something being wrong. Vivaldi surfaces them where
+       * Chrome hides them, which is how they were noticed.
+       *
+       * Nothing is lost by dropping the hints: every chunk is a local file
+       * already on disk, so there is no network latency for a preload to hide.
+       */
+      modulePreload: false,
+    },
   }),
 });


### PR DESCRIPTION
Vivaldi shows a red **Errors** button on the extension card. The errors are five `modulepreload` warnings, and they are not Vivaldi's:

```
A preload for 'chrome-extension://…/chunks/settings-CWBgCR0J.js' is found,
but is not used because it is a cross-world extension resource mismatch.
```

Vite emits `<link rel="modulepreload" crossorigin>` for each chunk. On a `chrome-extension://` URL that preload fetches in CORS mode while the module import that follows does not, so Chromium cannot reuse the response — it discards it, refetches the chunk, and logs the mismatch plus a second "preloaded but not used" warning.

Functionally harmless, which is why nothing ever looked broken. But it fills the extension's error list, and a red badge on the card is what a user or a **store reviewer** sees first. Chrome logs the same warnings and just doesn't surface them, so this has been there all along.

`build.modulePreload: false`. Nothing is lost — every chunk is a local file already on disk, so there is no network latency for the hint to hide.

**Verified:** no `modulepreload` in either build, `check:manifests` unchanged, and `extension.e2e.spec.ts` still loads the built extension and renders every surface.