### PR TITLE
An action popup where there is no side panel

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -704,6 +704,18 @@ Its reason for existing — DevTools being the only surface — is gone in v3. *
 toolbar click opens the panel** (side panel on Chrome, sidebar toggle on Firefox), because a click
 should get you working rather than show you a menu. **[settled]**
 
+**Except where there is no panel to open.** Opera implements no `chrome.sidePanel` at all — it parses
+the `side_panel` manifest key and ignores the feature — so the click had nothing to do and did nothing
+whatever: no panel, no popup, no error. There DevTools is the only surface again, exactly as in v2.5.1,
+and the popup comes back with it: version, *"This browser has no side panel, so please open DevTools"*,
+the platform's shortcut, **Support** and **Options**. Set with `action.setPopup` at runtime on finding
+`sidePanel` undefined, never declared — one Chromium build serves every Chromium browser, and a
+declared `default_popup` would replace the side panel with a leaflet on Chrome. Brave and Vivaldi both
+have the API and are unaffected. **[settled]**
+
+The panel cannot simply open in a tab instead: it finds the page it is modelling with
+`tabs.query({ active: true, currentWindow: true })`, so in a tab of its own it would target itself.
+
 **Right-clicking the toolbar icon carries what the popup did**, via `contextMenus` with
 `contexts: ['action']` — but only what the browser does not already offer. Chrome puts **Options** on
 that menu itself (along with *Open side panel*), so adding our own would show it twice; Firefox offers

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -257,5 +257,22 @@ export default defineBackground(() => {
 
   // Chromium: let the action button open the side panel directly. Doing it this
   // way (rather than sidePanel.open) keeps the click a trusted user gesture.
-  browser.sidePanel?.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
+  if (browser.sidePanel) {
+    browser.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
+  } else {
+    // No side panel API — Opera. It parses the `side_panel` manifest key and
+    // ignores the feature, so there was nothing to set a behaviour on and the
+    // button did nothing whatever: no panel, no popup, no error.
+    //
+    // The panel cannot fall back to a tab of its own, because it finds the
+    // page it is modelling with `tabs.query({ active: true, currentWindow:
+    // true })` and would target itself. DevTools genuinely is the only surface
+    // here, so the click says so — which is what v2.5.1's popup did, back when
+    // DevTools was the only surface anywhere (SPEC §15).
+    //
+    // Set at runtime rather than declared, because one Chromium build serves
+    // every Chromium browser and only this one wants a popup: declaring
+    // `default_popup` would replace the side panel with a leaflet on Chrome.
+    void browser.action.setPopup({ popup: 'nopanel.html' });
+  }
 });

--- a/entrypoints/nopanel/index.html
+++ b/entrypoints/nopanel/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page Modeller</title>
+    <!--
+      The action popup, shown only on a Chromium browser with no side panel
+      API — Opera, today. SPEC §15 dropped v2.5.1's popup because the toolbar
+      click opens the panel instead; where there is no panel to open, its
+      reason for existing comes back, so this is v2.5.1's popup again.
+
+      The panel cannot fall back to an ordinary tab: it finds the page it is
+      modelling with `tabs.query({ active: true, currentWindow: true })`, so in
+      a tab of its own it would target itself. DevTools is the only surface
+      that works here.
+    -->
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #ffffff;
+        --fg: #1d1d1f;
+        --muted: #6b6b70;
+        --key-bg: #2b2b31;
+        --key-fg: #ffffff;
+        --link: #1a73e8;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #1f1f23;
+          --fg: #ececf1;
+          --muted: #a1a1aa;
+          --key-bg: #3a3a42;
+          --link: #7cb2ff;
+        }
+      }
+      body {
+        margin: 0;
+        width: 280px;
+        padding: 18px 20px 14px;
+        background: var(--bg);
+        color: var(--fg);
+        font: 13px/1.55 system-ui, -apple-system, 'Segoe UI', sans-serif;
+      }
+      h1 {
+        margin: 0 0 12px;
+        font-size: 17px;
+        font-weight: 600;
+      }
+      p {
+        margin: 0 0 14px;
+        color: var(--muted);
+      }
+      .keys {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 16px;
+      }
+      kbd {
+        padding: 3px 8px;
+        border-radius: 4px;
+        background: var(--key-bg);
+        color: var(--key-fg);
+        font: inherit;
+        font-size: 12px;
+        font-weight: 500;
+      }
+      .plus {
+        color: var(--muted);
+      }
+      nav {
+        display: flex;
+        justify-content: flex-end;
+        gap: 18px;
+      }
+      a {
+        color: var(--link);
+        font-size: 12px;
+        letter-spacing: 0.06em;
+        text-decoration: none;
+        text-transform: uppercase;
+        cursor: pointer;
+      }
+      a:hover,
+      a:focus-visible {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Page Modeller <span id="version"></span></h1>
+    <p>This browser has no side panel, so please open DevTools to use Page Modeller:</p>
+    <div class="keys" id="keys"></div>
+    <nav>
+      <a id="support" href="#">Support</a>
+      <a id="options" href="#">Options</a>
+    </nav>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/entrypoints/nopanel/main.ts
+++ b/entrypoints/nopanel/main.ts
@@ -1,0 +1,57 @@
+import { browser } from 'wxt/browser';
+
+// The action popup for a browser with no side panel API (SPEC §15).
+//
+// Static markup with three things filled in here, because MV3 forbids an
+// inline script: the version, the DevTools shortcut for this platform, and the
+// two links. v2.5.1 did exactly the same, and this is its popup.
+
+/** Where Support goes — the repository, as in v2.5.1 and the context menu. */
+const SUPPORT_URL = 'https://github.com/danhumphrey/page-modeller';
+
+/**
+ * The DevTools shortcut, per platform. macOS is the odd one; everywhere else
+ * Chromium uses Ctrl+Shift+I.
+ *
+ * `userAgentData.platform` is the supported reading and `navigator.platform`
+ * the deprecated one, so try the first and keep the second as the fallback —
+ * Firefox never sees this page, but a Chromium fork may lag on either.
+ */
+function shortcutKeys(): string[] {
+  const ua = (navigator as { userAgentData?: { platform?: string } }).userAgentData?.platform;
+  const mac = ua ? ua === 'macOS' : /Mac/i.test(navigator.platform);
+  return mac ? ['Command', 'Option', 'I'] : ['Control', 'Shift', 'I'];
+}
+
+const version = document.getElementById('version');
+if (version) version.textContent = browser.runtime.getManifest().version;
+
+const keys = document.getElementById('keys');
+if (keys) {
+  shortcutKeys().forEach((key, i) => {
+    if (i > 0) {
+      const plus = document.createElement('span');
+      plus.className = 'plus';
+      plus.textContent = '+';
+      keys.append(plus);
+    }
+    const kbd = document.createElement('kbd');
+    kbd.textContent = key;
+    keys.append(kbd);
+  });
+}
+
+document.getElementById('support')?.addEventListener('click', (e) => {
+  e.preventDefault();
+  void browser.tabs.create({ url: SUPPORT_URL });
+  window.close();
+});
+
+// Chrome puts Options on the action's own context menu, so the extension does
+// not add one there (SPEC §15) — but that menu is a right-click away and this
+// popup is what a left-click gets, so the link belongs here as it did in 2.5.1.
+document.getElementById('options')?.addEventListener('click', (e) => {
+  e.preventDefault();
+  void browser.runtime.openOptionsPage();
+  window.close();
+});

--- a/scripts/check-manifests.mjs
+++ b/scripts/check-manifests.mjs
@@ -84,6 +84,14 @@ for (const [dir, checks] of Object.entries(EXPECT)) {
   if (!tag) fail(dir, 'devtools.html loads devtools-register.js');
   else if (/type=["']?module/.test(tag)) fail(dir, 'devtools-register.js must NOT be a module (defers panel registration)');
   await readFile(`.output/${dir}/devtools-register.js`, 'utf8').catch(() => fail(dir, 'devtools-register.js emitted'));
+
+  // The popup the background falls back to where there is no side panel API
+  // (SPEC §15). `action.setPopup` with a path that is not there fails exactly
+  // as quietly as the bug it exists to fix: no panel, no popup, no error. The
+  // name is written in two places, so check they still agree.
+  const popup = (await readFile('entrypoints/background.ts', 'utf8')).match(/setPopup\(\{\s*popup:\s*'([^']+)'/)?.[1];
+  if (!popup) fail(dir, 'background sets an action popup when sidePanel is missing');
+  else await readFile(`.output/${dir}/${popup}`, 'utf8').catch(() => fail(dir, `${popup} emitted (referenced by setPopup)`));
 }
 
 if (failed) process.exit(1);


### PR DESCRIPTION
**Opera: the toolbar button does nothing at all.** Confirmed in its service worker console:

```js
chrome.sidePanel                          // undefined
chrome.runtime.getManifest().side_panel   // {default_path: 'sidepanel.html'}
```

It parses the manifest key and ignores the feature. `setPanelBehavior` was never called — the `?.` on that line swallowed it — so there was no panel, no popup and no error. **Brave and Vivaldi both have the API and open the side panel correctly**; this is Opera only.

The panel cannot fall back to a tab of its own: `sidePanelHost` finds the page it is modelling with `tabs.query({ active: true, currentWindow: true })`, so in its own tab it would target itself. DevTools genuinely is the only surface there — which is the position v2.5.1 was in *everywhere*. So this is v2.5.1's popup, back for the one browser that still needs it: version, the platform's DevTools shortcut as keycaps, Support and Options.

`action.setPopup` at runtime on finding `sidePanel` undefined, never declared — one Chromium build serves every Chromium browser, and a declared `default_popup` would replace the side panel with a leaflet on Chrome.

## Verification

`check-manifests.mjs` now asserts the page `setPopup` names is actually emitted, because a wrong path there fails **exactly as quietly as the bug it fixes**. Confirmed it catches one: renaming to `nopanelx.html` fails both builds.

Rendered in both themes (screenshots below), `npm run typecheck` clean, 261 unit tests, extension E2E green.

SPEC §15 updated — it said the popup was dropped outright, which is no longer true.

**Still needs a hand-test on Opera**, which no automation here can reach.