### PR TITLE
Shadow DOM support (SPEC §19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,12 @@ exploited.
 - **`sender.tab` is not reliable in a Firefox DevTools page.** A content script's `runtime.sendMessage`
   arrives without it, so a `sender.tab.id === myTab` filter silently drops every message. The background
   always sees the sender, so it stamps the tab and re-broadcasts as `FROM_TAB`; panels filter on that.
+- **A content script cannot see the page's `customElements` registry.** An isolated world has its own,
+  and an element the page defined is simply absent from it — `customElements.get('my-widget')` returns
+  undefined for a component that plainly exists. The DOM is shared; the registry is not. Detection has
+  to work from the element itself. This passed every engine test, because those inject into the *main*
+  world via `addScriptTag`; only the extension E2E runs in an isolated one.
+
 - **Never send Vue reactive state through `tabs.sendMessage`.** Anything read out of a `ref` is a Proxy,
   and Firefox serialises messages with structured clone, which throws `DataCloneError` on a Proxy —
   Chrome's path tolerates it, so this fails on Firefox only and presents as an unreachable tab. `send()`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1090,14 +1090,23 @@ the locator itself:
   chain — and the element it arrives at is an ordinary `WebElement`: `send_keys`, `click`,
   `get_property` and `is_displayed` all work through a boundary.
 
-### The eye must agree with the framework **[settled]**
+### The eye pierces, and says so by over-counting **[settled]**
 
-The in-page resolver does not pierce today, so a shadow element reports *0 elements match* even where
-the generated locator is correct. Making it always pierce would be worse: with Selenium selected it
-would report *1 element matches* for a locator Selenium cannot resolve at all.
+The resolver has to pierce, and the reason is the opposite of the expected one. It is not about
+shadow elements — those are resolved within their own root, where the question does not arise. It is
+about **light-DOM** ones: Playwright's engines pierce, so a plain `<button>Submit</button>` on a page
+whose components each contain their own Submit is not unique at all. The engine called it unique and a
+real Playwright run resolved six, which `tests/engine.fidelity.spec.ts` now catches on
+`shadow.html/top-submit`.
 
-So the resolver pierces **when the target framework does**, which is the rule §7 already states —
-*"a green tick on a locator that cannot exist in the target framework is worse than no check at all"*.
+Selenium does not pierce, so where the two differ this reports **more** matches than a Selenium run
+would. That is the safe direction and it is deliberate: an amber *6 elements match* sends the user to
+look, where a green tick on a locator that really matches six would not. The inverse — under-counting
+— is the failure §7 warns about.
+
+A per-framework resolver would be exact, and is not worth what it costs: the framework is fixed before
+picking starts (§3), so it could be threaded through, but the divergence only appears when identical
+content exists both inside and outside a component on the same page.
 
 ### Picking **[settled]**
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1108,6 +1108,24 @@ A per-framework resolver would be exact, and is not worth what it costs: the fra
 picking starts (§3), so it could be threaded through, but the divergence only appears when identical
 content exists both inside and outside a component on the same page.
 
+### Uniqueness is asked the way the frameworks ask it **[settled]**
+
+Both halves of this were wrong in the first implementation, in the same way and
+one layer apart.
+
+**The eye** resolved against the document. Etsy's `<clg-text-input name="password">` mirrors `name`
+onto its host, so `[name=password]` found the host *and* the control inside it and reported *2 elements
+match* for a locator the model had counted as unique. The eye now resolves in the root the locator is
+relative to, so `HIGHLIGHT` carries the shadow path exactly as it carries the frame path.
+
+**The selector builder** then made the same mistake about the host itself. `cssFor` called
+`[name="email"]` unique because it is the only match a plain `querySelectorAll` finds — and Playwright,
+whose css pierces, resolves two. A host selector that is not unique in the framework consuming it
+produces a strict-mode violation from a locator we called good.
+
+So every uniqueness check pierces, because every framework that consumes the answer does. Selenium does
+not, and over-counting is the safe direction (see above).
+
 ### Picking **[settled]**
 
 `event.target` is retargeted to the host for any listener outside the shadow tree, so picking inside a

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -929,6 +929,8 @@ a page cannot read the nonce. Not by "is this frame still armed", which was the 
 cascading scan reaches frames after the background has disarmed everyone, and a frame that refused then
 would be a hole in the middle of the tree.
 
+Shadow roots are the same problem in a different shape, and are specified in §19.
+
 **A scan never crosses a frame boundary on its own.** Scanning a container that happens to hold frames
 gets that document's controls and stops. A frame's contents come only when the scan is rooted at that
 frame — the frame element, or its document — and then everything below it is in scope. **[settled]**
@@ -1038,3 +1040,96 @@ rather than confirmed, flagged so they are visible rather than silent:
 (§12). Not built, and the spec no longer reads as though it were.
 
 **Release blocker:** none outstanding. The AMO `gecko.id` is recorded and guarded (see `RELEASE-PLAN.md`).
+
+## 19. Shadow DOM
+
+New in v3. Numbered here rather than beside §16 only because §17 is referenced from seven places in
+the code; read it as the sibling of Frames, because it is the same problem in a different shape.
+
+**Web components hide their controls.** Etsy's sign-up form is `<clg-text-input>` elements whose real
+`<input>` lives in an open shadow root. `querySelectorAll('*')` does not cross that boundary, so a scan
+of the dialog returned the four buttons around the form and none of the form. It read as the tool
+being broken, which is how it was reported.
+
+An element records its **shadow path**: the hosts between its document and itself, outermost first,
+each located by its own generated selector — exactly as `framePath` records the frames (§16). The two
+compose; an element can be inside a frame inside a shadow root.
+
+**Hosts are located by css only.** A shadow root is entered through its host element, and every API
+that does so takes a CSS selector — `>>>` in Puppeteer, `.shadow_root` in Selenium. `cssFor` already
+prefers a test id, then a name, then a non-generated id (§7), so little is lost.
+
+**The element's own locator is relative to its shadow root.** Ids are scoped to a shadow root, so a
+`>` path anchored inside one is shorter and more stable than a document-wide path would have been.
+
+### What each framework can express **[settled]**
+
+Measured, not read off the documentation — `tests/shadow.probe.spec.ts` asserts every row against a
+real engine, because six generators are built to this table and a wrong assumption in it propagates
+everywhere. Three of the first draft's rows were wrong.
+
+| | Crosses an open shadow root |
+|---|---|
+| Playwright `getByRole` / `getByLabel` / `getByPlaceholder` / `getByText` / `getByAltText` / `getByTitle` / `getByTestId` | **yes**, natively |
+| Playwright css | yes |
+| Playwright xpath | **no** |
+| Puppeteer css | only through the `>>>` deep combinator — but **one `>>>` spans any depth**, so only the outermost host is needed |
+| Selenium, from the host's `shadowRoot` | `name`, `id`, `linkText`, `partialLinkText`, `css`, `className` **all work** |
+| Selenium `xpath` and `tagName`, from a `shadowRoot` | **no** — `invalid locator` |
+| Selenium, from the document | nothing reaches in; the chain is always required |
+
+So **xpath is the only thing v3 generates that cannot cross a boundary**, and it is excluded for a
+shadow element in every framework rather than only in Playwright. Everything else needs no change to
+the locator itself:
+
+- **Playwright** needs nothing at all. Its engines pierce, so a locator generated as though the page
+  were flat already resolves. The path is still recorded, because it is what scopes one of two
+  identical components.
+- **Puppeteer** joins the outermost host to the element's css with `>>>`.
+- **Selenium** walks the chain, one `shadowRoot` at a time, the same shape as its `switchTo().frame()`
+  chain — and the element it arrives at is an ordinary `WebElement`: `send_keys`, `click`,
+  `get_property` and `is_displayed` all work through a boundary.
+
+### The eye must agree with the framework **[settled]**
+
+The in-page resolver does not pierce today, so a shadow element reports *0 elements match* even where
+the generated locator is correct. Making it always pierce would be worse: with Selenium selected it
+would report *1 element matches* for a locator Selenium cannot resolve at all.
+
+So the resolver pierces **when the target framework does**, which is the rule §7 already states —
+*"a green tick on a locator that cannot exist in the target framework is worse than no check at all"*.
+
+### Picking **[settled]**
+
+`event.target` is retargeted to the host for any listener outside the shadow tree, so picking inside a
+web component selected the component, not the control. It happened to work on Etsy because that
+component mirrors `name` and `placeholder` onto its host; a component that does not would have yielded
+a locator for a wrapper. `composedPath()[0]` is the real target.
+
+The ↑/↓ walk (§4) steps out through `getRootNode().host` at a shadow boundary, rather than stopping at
+a `parentElement` of `null`. The breadcrumb marks the crossing, so it is visible that the element is
+inside a component rather than a plain `<div>`.
+
+### Closed roots cannot be read **by us** **[settled]**
+
+`element.shadowRoot` is `null` for a closed root, and the picker is JavaScript in the page, so there is
+nothing to pick and nothing to generate.
+
+Worth recording that this is *our* limit and not the ecosystem's: **WebDriver reads closed roots
+perfectly well** — `shadow_root` returns one and finds inside it — because it uses the element's
+internal slot rather than the JS accessor. Playwright cannot. So a Selenium locator for a closed-root
+element is a thing that could exist; we simply cannot see the element to write one. Nothing to build,
+but it is the answer to "why not just support it".
+
+Hovering one during Add or Scan shows the same red dashed treatment a sandboxed frame gets (§16),
+labelled *cannot be read — closed shadow root*, and a scan that skips one says so rather than silently
+returning less. Silence is indistinguishable from a bug — which is exactly how this whole section came
+to be written.
+
+### Verification
+
+The same three layers frames got: fixtures in `tests/fixtures/`, every expression resolved in real
+Playwright and real Puppeteer by the fidelity specs, and the generated Python **run** in a real browser
+by `selenium.run.spec.ts` and `playwright-python.run.spec.ts`. Nothing here is believed until it has
+resolved against a real engine — Selenium's "css only from a shadow root" restriction included, which
+the run spec is the arbiter of.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1108,6 +1108,34 @@ A per-framework resolver would be exact, and is not worth what it costs: the fra
 picking starts (§3), so it could be threaded through, but the divergence only appears when identical
 content exists both inside and outside a component on the same page.
 
+### The chain is visible, and locked **[settled]**
+
+Exactly as a frame chain is (§16), and for exactly the same reason: a shadow host is **where the
+element is**, not part of how it is found within that component, so editing it would be editing the
+page.
+
+Until this it was neither. The table's Locator column and the Edit dialog both showed the element's
+own locator, and the host chain appeared for the first time in the generated code — so the line a user
+read in the table was not the line they were going to get, and someone overriding a locator could not
+see, let alone manage, the part of it that reached the component.
+
+So the chain is shown wherever the locator is shown: in the table row, and as a read-only **Shadow**
+row in the Edit dialog beside **Frame**. The element's own locator stays fully editable, which is the
+part a user can meaningfully change.
+
+The row reads as the target writes it, so the table is the generated line:
+
+| | |
+|---|---|
+| Playwright | `locator('#join_neu_email_field').locator('[name="email"]')` |
+| Puppeteer | `locator('#join_neu_email_field >>> [name="email"]')` |
+| Selenium | `#join_neu_email_field › css: [name="email"]` — neither chain is expressible in a `By`, so both read as the path they are |
+
+One consequence worth stating: **the table and the generated code are built by the same code**.
+`display.ts` already owned the locator spelling for that reason, and the Puppeteer generator had grown
+its own copy of the `>>>` join — which is how the two came to disagree in the first place. It defers
+again.
+
 ### Uniqueness is asked the way the frameworks ask it **[settled]**
 
 Both halves of this were wrong in the first implementation, in the same way and

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -684,6 +684,15 @@ Four agreed changes: **[settled]**
 Keep v2.5.1's **plain names** by default — `About`, not `AboutLink`. The user can rename before
 exporting.
 
+**A trailing validity marker is dropped.** Etsy's sign-in labels are `Email address*`, where the
+asterisk carries an accessible *"Required"* — so the accname is literally "Email address Required" and
+every required field on the form was named `SomethingRequired`. One trailing `Required` or `Optional`
+comes off, and only when something is left to be called: a field genuinely labelled *Required* keeps
+its name. **[settled]**
+
+The **accessible name is untouched**, because `getByLabel('Email address Required')` has to keep the
+word to match anything. The name is an identifier the user can rename; the locator is not.
+
 **`appendTypeToName`** (§14, off by default) turns the suffix on: `FeelTheMagic` becomes
 `FeelTheMagicLink`. The vocabulary is the one test authors use rather than raw ARIA — `textbox`
 and `searchbox` become `Input`, `combobox` and `listbox` become `Select`, `img` becomes `Image` — since

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -182,6 +182,7 @@ export default defineBackground(() => {
         return;
       }
       case 'FRAME_UNREADABLE':
+      case 'SHADOW_UNREADABLE':
       case 'HIGHLIGHT_RESULT': {
         const tabId = sender.tab?.id;
         if (tabId == null) return;

--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -3,7 +3,7 @@ import { describeBrief, describeElement } from '@/src/engine/describe';
 import { collectClosedHosts, collectInteractive } from '@/src/engine/interactive';
 import { isMessage, type Message, type PickMode } from '@/src/messaging';
 import { frameSelector } from '@/src/locators/frames';
-import type { FrameStep } from '@/src/engine/types';
+import type { FrameStep, ShadowStep } from '@/src/engine/types';
 import { loadSettings, watchSettings } from '@/src/settings';
 
 // Inspector overlay: highlight the element under the cursor (like DevTools) and,
@@ -517,6 +517,22 @@ export default defineContentScript({
      * arrive; nothing has to be collected back up the tree.
      */
     /**
+     * Walk a shadow path to the root it names, or the document when there is
+     * none. Null when a host along the way is missing — the page has changed
+     * since the element was captured, and reporting zero matches is the honest
+     * answer rather than resolving against the wrong tree.
+     */
+    function shadowRootFor(path: ShadowStep[] | undefined): Document | ShadowRoot | null {
+      let root: Document | ShadowRoot = document;
+      for (const step of path ?? []) {
+        const host: Element | null = root.querySelector((step.host as { value: string }).value);
+        if (!host?.shadowRoot) return null;
+        root = host.shadowRoot;
+      }
+      return root;
+    }
+
+    /**
      * Say what a scan could not read. A closed root holds real controls and no
      * script can reach them, so the alternative is a scan that returns fewer
      * rows than the page has and gives no reason — which is exactly how this
@@ -751,7 +767,12 @@ export default defineContentScript({
         // answering frame would forget.
         clearMarks();
         if (!samePath(myPath, m.framePath)) return;
-        const targets = resolveCandidate(document, m.candidate);
+        // Resolve where the generated locator resolves: inside the element's
+        // own shadow root, not the document (SPEC §19). A host that mirrors an
+        // attribute onto itself otherwise matches alongside the control inside
+        // it, and the eye contradicts the count the model was built with.
+        const root = shadowRootFor(m.shadowPath);
+        const targets = root ? resolveCandidate(root, m.candidate) : [];
         const { hidden } = highlightAll(targets);
         // Answered as a message, not a reply — sendResponse is not portable.
         browser.runtime.sendMessage({ type: 'HIGHLIGHT_RESULT', count: targets.length, hidden }).catch(() => {});

--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -1,6 +1,6 @@
 import { frameStepFor, generate, resolveCandidate, setTestIdAttribute } from '@/src/engine/candidates';
 import { describeBrief, describeElement } from '@/src/engine/describe';
-import { collectInteractive } from '@/src/engine/interactive';
+import { collectClosedHosts, collectInteractive } from '@/src/engine/interactive';
 import { isMessage, type Message, type PickMode } from '@/src/messaging';
 import { frameSelector } from '@/src/locators/frames';
 import type { FrameStep } from '@/src/engine/types';
@@ -177,12 +177,14 @@ export default defineContentScript({
       ensureOverlay();
       const r = el.getBoundingClientRect();
       Object.assign(box!.style, { left: `${r.left}px`, top: `${r.top}px`, width: `${r.width}px`, height: `${r.height}px` });
-      const unreadable = isFrame(el) && !isReadableFrame(el);
-      setTone(unreadable);
+      const frameUnreadable = isFrame(el) && !isReadableFrame(el);
+      // A closed root renders content no script can reach — the same situation
+      // as a sandboxed frame, drawn the same way (SPEC §19).
+      const closedRoot = !frameUnreadable && isClosedShadowHost(el);
+      setTone(frameUnreadable || closedRoot);
       renderBreadcrumb(el);
-      if (unreadable) {
-        const warn = crumb('cannot be read \u2014 sandboxed', true);
-        label!.appendChild(warn);
+      if (frameUnreadable || closedRoot) {
+        label!.appendChild(crumb(closedRoot ? 'cannot be read \u2014 closed shadow root' : 'cannot be read \u2014 sandboxed', true));
       }
       label!.style.left = `${r.left}px`;
       label!.style.top = `${Math.max(0, r.top - 18)}px`;
@@ -343,6 +345,14 @@ export default defineContentScript({
     const onOver = (e: MouseEvent) => onMove(e);
 
     const isFrame = (el: Element) => el.localName === 'iframe' || el.localName === 'frame';
+
+    /**
+     * Whether THIS element is a closed shadow host. Asked of the element's own
+     * parent so the collector's rule is not duplicated: one definition of what
+     * counts, used both for the overlay and for what a scan reports.
+     */
+    const isClosedShadowHost = (el: Element) =>
+      el.parentElement != null && collectClosedHosts(el.parentElement).includes(el);
 
     /**
      * Marks the one message this script accepts from another frame. Isolated
@@ -506,12 +516,24 @@ export default defineContentScript({
      * Each frame reports its own haul, so the model simply gains rows as they
      * arrive; nothing has to be collected back up the tree.
      */
+    /**
+     * Say what a scan could not read. A closed root holds real controls and no
+     * script can reach them, so the alternative is a scan that returns fewer
+     * rows than the page has and gives no reason — which is exactly how this
+     * whole area came to be looked at.
+     */
+    function reportClosedRoots(root: Element) {
+      const count = collectClosedHosts(root).length;
+      if (count > 0) browser.runtime.sendMessage({ type: 'SHADOW_UNREADABLE', count }).catch(() => {});
+    }
+
     function scanDocument() {
       const root = document.body ?? document.documentElement;
       const results = collectInteractive(root, includeHidden).map((el) => generate(el, myPath));
       const nested = Array.from(document.querySelectorAll('iframe, frame'));
       stop({ notify: false });
       if (results.length > 0) browser.runtime.sendMessage({ type: 'ELEMENTS_PICKED', results }).catch(() => {});
+      reportClosedRoots(root);
       for (const frame of nested) delegateScan(frame);
     }
 
@@ -553,6 +575,7 @@ export default defineContentScript({
 
       // Scan takes the container's interactive descendants, never the container
       // itself: you are modelling what is inside the section you chose.
+      if (mode === 'scan') reportClosedRoots(target);
       const message =
         mode === 'scan'
           ? { type: 'ELEMENTS_PICKED', results: collectInteractive(target, includeHidden).map((el) => generate(el, myPath)) }

--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -112,23 +112,33 @@ export default defineContentScript({
      * Built as elements rather than innerHTML: the text comes from the page.
      */
     function renderBreadcrumb(el: Element) {
-      const chain: Element[] = [];
-      for (let cur: Element | null = el.parentElement; cur && cur !== document.documentElement; cur = cur.parentElement) {
-        chain.unshift(cur);
+      // Ancestors, and whether each step crossed a shadow boundary — the walk
+      // uses `parentOf`, so it steps out of a component instead of stopping at
+      // it (SPEC §19). The crossing is drawn, because "this element is inside a
+      // web component" changes what the locator will look like and there is
+      // nothing else on screen that says so.
+      const chain: { el: Element; crossed: boolean }[] = [];
+      for (let cur: Element | null = el; cur && cur !== document.documentElement; ) {
+        const up = parentOf(cur);
+        if (!up || up === document.documentElement) break;
+        chain.unshift({ el: up, crossed: cur.parentElement === null });
+        cur = up;
       }
       const shown = chain.slice(-CRUMB_DEPTH);
 
       label!.replaceChildren();
       if (chain.length > shown.length) label!.appendChild(crumb('…', false));
       for (const ancestor of shown) {
-        label!.appendChild(crumb(describeBrief(ancestor), false));
+        label!.appendChild(crumb(describeBrief(ancestor.el), false));
       }
-      label!.appendChild(crumb(describeElement(el), true));
+      label!.appendChild(crumb(describeElement(el), true, chain.at(-1)?.crossed ?? false));
     }
 
-    function crumb(text: string, isTarget: boolean): HTMLSpanElement {
+    function crumb(text: string, isTarget: boolean, inShadow = false): HTMLSpanElement {
       const span = document.createElement('span');
-      span.textContent = text;
+      // `⛉` marks a shadow boundary: everything after it lives inside a web
+      // component, which is why its locator will be scoped by the host.
+      span.textContent = inShadow ? `⛉ ${text}` : text;
       Object.assign(span.style, {
         opacity: isTarget ? '1' : '0.55',
         fontWeight: isTarget ? '600' : '400',
@@ -292,9 +302,27 @@ export default defineContentScript({
       return { hidden: placed.filter((p) => p.hidden).length };
     }
 
+    /**
+     * The element actually under the pointer (SPEC §19).
+     *
+     * `e.target` is RETARGETED to the host for any listener outside the shadow
+     * tree, so hovering a web component's input reports the component. On Etsy
+     * that still produced a working locator, because that component mirrors
+     * `name` and `placeholder` onto its host — a component that does not would
+     * have handed back a locator for a wrapper.
+     *
+     * `composedPath()[0]` is the innermost target, and stops at a closed root
+     * of its own accord: a closed tree is absent from the composed path, so
+     * this yields the host, which is the most specific thing there is.
+     */
+    const targetOf = (e: Event): Element | null => {
+      const first = e.composedPath()[0];
+      return first instanceof Element ? first : ((e.target as Element | null) ?? null);
+    };
+
     const onMove = (e: MouseEvent) => {
       if (!active) return;
-      const el = e.target as Element | null;
+      const el = targetOf(e);
       if (!el || el === hovered) return;
       // Moving the mouse abandons any arrow-key walk and starts again from
       // whatever is under the cursor.
@@ -548,11 +576,25 @@ export default defineContentScript({
     };
 
     /** The child of `of` that contains `hovered`, for walking back down. */
+    /**
+     * The element above this one, crossing a shadow boundary where there is
+     * one (SPEC §19).
+     *
+     * `parentElement` is null at the top of a shadow tree — the parent is the
+     * root, which is not an Element — so the ↑ walk stopped dead inside a
+     * component instead of stepping out to it.
+     */
+    function parentOf(el: Element): Element | null {
+      if (el.parentElement) return el.parentElement;
+      const root = el.getRootNode();
+      return root instanceof ShadowRoot ? root.host : null;
+    }
+
     function childTowardsHovered(of: Element): Element | null {
       if (!hovered || of === hovered) return null;
       let cur: Element | null = hovered;
-      while (cur && cur.parentElement && cur.parentElement !== of) cur = cur.parentElement;
-      return cur?.parentElement === of ? cur : null;
+      while (cur && parentOf(cur) && parentOf(cur) !== of) cur = parentOf(cur);
+      return cur && parentOf(cur) === of ? cur : null;
     }
 
     /**
@@ -565,9 +607,11 @@ export default defineContentScript({
       if (!active || !current) return;
       const next =
         direction === 'up'
-          ? // Stop at <body>: <html> is never a useful target.
-            current.parentElement && current.parentElement !== document.documentElement
-            ? current.parentElement
+          ? // Stop at <body>: <html> is never a useful target. `parentOf`
+            // crosses a shadow boundary, so ↑ from a component's input steps
+            // out to the component rather than stopping.
+            parentOf(current) && parentOf(current) !== document.documentElement
+            ? parentOf(current)
             : null
           : childTowardsHovered(current);
       if (!next) return;

--- a/src/engine/candidates.ts
+++ b/src/engine/candidates.ts
@@ -260,12 +260,43 @@ export function ariaHidden(el: Element): boolean {
  * WebDriver answers `invalid locator` — which is why §19 excludes xpath for a
  * shadow element rather than trying to emit one.
  */
+/**
+ * querySelectorAll, descending into open shadow roots.
+ *
+ * Playwright's engines pierce, and the eye reports what a Playwright test will
+ * get — so a resolver that stopped at the boundary under-counted. A plain
+ * `<button>Submit</button>` on a page of web components each containing their
+ * own Submit read as unique here and resolved to six in a real run.
+ *
+ * Piercing downward is right for every scope: a locator scoped to a shadow
+ * root still sees roots nested below it, both for us and for Playwright.
+ *
+ * Selenium does not pierce, so where the two differ this reports MORE matches
+ * than a Selenium run would. That direction is the safe one: an amber
+ * "6 elements match" sends the user to look, where a green tick on a locator
+ * that matches six would not (SPEC §7, §19).
+ */
+function pierce(root: Document | ShadowRoot | Element, sel: string): Element[] {
+  const out = Array.from(root.querySelectorAll(sel));
+  for (const el of Array.from(root.querySelectorAll('*'))) {
+    if (el.shadowRoot) out.push(...pierce(el.shadowRoot, sel));
+  }
+  return out;
+}
+
+/**
+ * Elements that render no text of their own. Playwright's text engine ignores
+ * them; ours counted `<title>` as a match for the page heading, because a
+ * document's title so often repeats it.
+ */
+const NON_RENDERED = new Set(['TITLE', 'SCRIPT', 'STYLE', 'NOSCRIPT', 'TEMPLATE', 'HEAD', 'META', 'LINK']);
+
 export function resolveCandidate(root: Document | ShadowRoot, c: LocatorCandidate): Element[] {
   const doc = root;
-  const all = () => Array.from(doc.querySelectorAll('*'));
+  const all = () => pierce(doc, '*').filter((e) => !NON_RENDERED.has(e.tagName));
   switch (c.kind) {
     case 'testId':
-      return Array.from(doc.querySelectorAll(`[${testIdAttribute}="${CSS.escape(c.value)}"]`));
+      return pierce(doc, `[${testIdAttribute}="${CSS.escape(c.value)}"]`);
     case 'role':
       return all()
         .filter((e) => safeRole(e) === c.role && (c.name === undefined || matchesText(safeName(e), c.name, c.exact)))
@@ -273,7 +304,7 @@ export function resolveCandidate(root: Document | ShadowRoot, c: LocatorCandidat
     case 'label':
       return all().filter((e) => LABEL_TARGETS.has(e.tagName) && matchesText(safeName(e), c.text, c.exact));
     case 'placeholder':
-      return Array.from(doc.querySelectorAll('[placeholder]')).filter((e) =>
+      return pierce(doc, '[placeholder]').filter((e) =>
         matchesText(e.getAttribute('placeholder') ?? '', c.text, c.exact)
       );
     case 'text': {
@@ -284,15 +315,15 @@ export function resolveCandidate(root: Document | ShadowRoot, c: LocatorCandidat
       return hits.filter((e) => !hits.some((other) => other !== e && e.contains(other)));
     }
     case 'altText':
-      return Array.from(doc.querySelectorAll('img[alt], input[alt], area[alt]')).filter((e) =>
+      return pierce(doc, 'img[alt], input[alt], area[alt]').filter((e) =>
         matchesText(e.getAttribute('alt') ?? '', c.text, c.exact)
       );
     case 'title':
-      return Array.from(doc.querySelectorAll('[title]')).filter((e) => matchesText(e.getAttribute('title') ?? '', c.text, c.exact));
+      return pierce(doc, '[title]').filter((e) => matchesText(e.getAttribute('title') ?? '', c.text, c.exact));
     case 'css':
       // A hand-typed selector can be invalid; that is a miss, not a crash.
       try {
-        return Array.from(doc.querySelectorAll(c.value));
+        return pierce(doc, c.value);
       } catch {
         return [];
       }
@@ -309,20 +340,20 @@ export function resolveCandidate(root: Document | ShadowRoot, c: LocatorCandidat
 
     // Selenium's By strategies, so the eye can test a hand-typed one.
     case 'id':
-      return c.value ? Array.from(doc.querySelectorAll(`#${CSS.escape(c.value)}`)) : [];
+      return c.value ? pierce(doc, `#${CSS.escape(c.value)}`) : [];
     case 'name':
-      return c.value ? Array.from(doc.querySelectorAll(`[name="${CSS.escape(c.value)}"]`)) : [];
+      return c.value ? pierce(doc, `[name="${CSS.escape(c.value)}"]`) : [];
     case 'className':
       // By.className takes ONE class name, not a selector. Expressed as a
       // selector because a ShadowRoot has no getElementsByClassName.
-      return c.value ? Array.from(doc.querySelectorAll(`.${CSS.escape(c.value)}`)) : [];
+      return c.value ? pierce(doc, `.${CSS.escape(c.value)}`) : [];
     case 'tagName':
-      return c.value ? Array.from(doc.querySelectorAll(CSS.escape(c.value))) : [];
+      return c.value ? pierce(doc, CSS.escape(c.value)) : [];
     case 'linkText':
       // Selenium matches links on their rendered text, trimmed.
-      return Array.from(doc.querySelectorAll('a')).filter((a) => norm(a.textContent) === norm(c.text));
+      return pierce(doc, 'a').filter((a) => norm(a.textContent) === norm(c.text));
     case 'partialLinkText':
-      return Array.from(doc.querySelectorAll('a')).filter((a) => norm(a.textContent).includes(norm(c.text)));
+      return pierce(doc, 'a').filter((a) => norm(a.textContent).includes(norm(c.text)));
   }
 }
 

--- a/src/engine/candidates.ts
+++ b/src/engine/candidates.ts
@@ -1,5 +1,5 @@
 import { computeAccessibleName, getRole } from 'dom-accessibility-api';
-import type { LocatorCandidate, ElementResult, FrameStep, RankedCandidate } from './types';
+import type { LocatorCandidate, ElementResult, FrameStep, RankedCandidate, ShadowStep } from './types';
 import { baseName, looksGenerated } from './naming';
 
 const norm = (s: string | null | undefined): string => (s ?? '').replace(/\s+/g, ' ').trim();
@@ -49,6 +49,29 @@ export function safeRole(el: Element): string | null {
   }
 }
 
+/**
+ * The Document or ShadowRoot an element is scoped to (SPEC §19).
+ *
+ * Everything that asks "is this selector unique?" has to ask it of the right
+ * tree. `ownerDocument` cannot see inside a shadow root at all, so every
+ * candidate for a shadow element was rejected as matching zero elements, and
+ * the `>` path then walked up to a `parentElement` of null and stopped
+ * mid-component.
+ *
+ * Scoping to the root is also what the generated locator does: a shadow
+ * element's locator is relative to its root, reached through the host chain.
+ * Ids are scoped to a shadow root, so a path anchored inside one is shorter
+ * and steadier than a document-wide path could be.
+ */
+export function isShadowRoot(node: Node): node is ShadowRoot {
+  return node.nodeType === 11 && 'host' in node;
+}
+
+export function rootOf(el: Element): Document | ShadowRoot {
+  const root = el.getRootNode();
+  return isShadowRoot(root) ? root : el.ownerDocument;
+}
+
 // ---- selector builders (deterministic fallbacks) ----
 
 /**
@@ -85,7 +108,7 @@ function attrSelector(el: Element, attr: string): string | null {
   // escaping. CSS.escape is for identifiers and would render `/forgot` as
   // `\/forgot` — still valid, but nobody writes that.
   const sel = `${prefix}[${attr}="${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"]`;
-  return el.ownerDocument.querySelectorAll(sel).length === 1 ? sel : null;
+  return rootOf(el).querySelectorAll(sel).length === 1 ? sel : null;
 }
 
 /** `#id`, unless the id is framework-generated — same rule as the id candidate. */
@@ -93,7 +116,7 @@ function idSelector(el: Element): string | null {
   const id = el.getAttribute('id');
   if (!id || looksGenerated(id)) return null;
   const sel = `#${CSS.escape(id)}`;
-  return el.ownerDocument.querySelectorAll(sel).length === 1 ? sel : null;
+  return rootOf(el).querySelectorAll(sel).length === 1 ? sel : null;
 }
 
 /**
@@ -120,7 +143,11 @@ function cssFor(el: Element): string {
 
   const parts: string[] = [];
   let cur: Element | null = el;
-  while (cur && cur.nodeType === 1 && cur !== cur.ownerDocument.documentElement) {
+  // Inside a shadow root the topmost element's `parentElement` is already
+  // null — its parent is the root, which is not an Element — so the walk stops
+  // at the boundary on its own, and the path is relative to the root.
+  const stopAt = isShadowRoot(rootOf(el)) ? null : el.ownerDocument.documentElement;
+  while (cur && cur.nodeType === 1 && cur !== stopAt) {
     // Anchoring the path on a generated id would defeat the point.
     const anchor = idSelector(cur);
     if (anchor) {
@@ -218,8 +245,23 @@ export function ariaHidden(el: Element): boolean {
   return false;
 }
 
-/** Every element the candidate matches, in document order. */
-export function resolveCandidate(doc: Document, c: LocatorCandidate): Element[] {
+/**
+ * Every element the candidate matches, in tree order.
+ *
+ * `root` is a Document or a ShadowRoot (SPEC §19). A shadow element's locator
+ * is relative to its root, so the eye has to resolve it there — resolving in
+ * the document would report zero for a locator that works, and piercing from
+ * the document would report a count no framework will reproduce.
+ *
+ * A ShadowRoot is a DocumentFragment, so it has querySelectorAll but NOT
+ * getElementsByClassName, getElementsByTagName or evaluate. The first two have
+ * exact selector equivalents. The third does not, and does not need one: XPath
+ * cannot address a shadow tree in any engine — Playwright resolves zero,
+ * WebDriver answers `invalid locator` — which is why §19 excludes xpath for a
+ * shadow element rather than trying to emit one.
+ */
+export function resolveCandidate(root: Document | ShadowRoot, c: LocatorCandidate): Element[] {
+  const doc = root;
   const all = () => Array.from(doc.querySelectorAll('*'));
   switch (c.kind) {
     case 'testId':
@@ -255,6 +297,8 @@ export function resolveCandidate(doc: Document, c: LocatorCandidate): Element[] 
         return [];
       }
     case 'xpath': {
+      // No engine can XPath into a shadow tree, so neither do we.
+      if (isShadowRoot(doc)) return [];
       try {
         const r = doc.evaluate(c.value, doc, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
         return Array.from({ length: r.snapshotLength }, (_, i) => r.snapshotItem(i) as Element);
@@ -269,10 +313,11 @@ export function resolveCandidate(doc: Document, c: LocatorCandidate): Element[] 
     case 'name':
       return c.value ? Array.from(doc.querySelectorAll(`[name="${CSS.escape(c.value)}"]`)) : [];
     case 'className':
-      // By.className takes ONE class name, not a selector.
-      return c.value ? Array.from(doc.getElementsByClassName(c.value)) : [];
+      // By.className takes ONE class name, not a selector. Expressed as a
+      // selector because a ShadowRoot has no getElementsByClassName.
+      return c.value ? Array.from(doc.querySelectorAll(`.${CSS.escape(c.value)}`)) : [];
     case 'tagName':
-      return c.value ? Array.from(doc.getElementsByTagName(c.value)) : [];
+      return c.value ? Array.from(doc.querySelectorAll(CSS.escape(c.value))) : [];
     case 'linkText':
       // Selenium matches links on their rendered text, trimmed.
       return Array.from(doc.querySelectorAll('a')).filter((a) => norm(a.textContent) === norm(c.text));
@@ -354,6 +399,49 @@ export function frameStepFor(frame: Element): FrameStep {
   return { frame: best?.candidate ?? { kind: 'css', value: frame.localName } };
 }
 
+/**
+ * The chain of shadow hosts between this element's document and the element,
+ * outermost first (SPEC §19).
+ *
+ * Walked from the element outwards: each `getRootNode()` that is a ShadowRoot
+ * contributes its host, and the walk continues from that host — which may
+ * itself sit in another shadow root.
+ *
+ * Every host is located in ITS OWN tree, which `rankFor` already does via
+ * `rootOf`, so a component nested inside another component gets a selector
+ * that is unique where it is used rather than where it is read.
+ */
+export function shadowPathOf(el: Element): ShadowStep[] {
+  const path: ShadowStep[] = [];
+  let node: Node = el;
+
+  // Bounded, as framePathOf is: a malformed tree must not spin here.
+  for (let depth = 0; depth < 32; depth++) {
+    const root = node.getRootNode();
+    if (!isShadowRoot(root)) break;
+    const host = root.host;
+    path.unshift({ host: hostCandidate(host) });
+    node = host;
+  }
+  return path;
+}
+
+/**
+ * A host's selector. css only — `>>>` and `shadowRoot` both take one — and
+ * never xpath, which cannot address a shadow tree and so could not be used to
+ * reach a host nested inside one.
+ */
+function hostCandidate(host: Element): LocatorCandidate {
+  const ranked = rankFor(host, safeRole(host), safeName(host)).filter((c) => c.candidate.kind === 'css');
+  const best = ranked[chooseFirstUnique(ranked)] ?? ranked[0];
+  return best?.candidate ?? { kind: 'css', value: host.localName };
+}
+
+/** A selector string for a shadow step. */
+export function shadowSelector(step: ShadowStep): string {
+  return (step.host as { value: string }).value;
+}
+
 /** A selector string for a frame step, for the APIs that take one. */
 export function frameSelector(step: FrameStep): string {
   return step.frame.kind === 'xpath' ? `xpath=${step.frame.value}` : (step.frame as { value: string }).value;
@@ -365,7 +453,11 @@ export function frameSelector(step: FrameStep): string {
  * which needs exactly this for an `<iframe>` in its parent document.
  */
 function rankFor(el: Element, role: string | null, name: string): RankedCandidate[] {
-  const doc = el.ownerDocument;
+  // The element's own tree, which for shadow content is its root rather than
+  // the document (SPEC §19). Also what drops the xpath candidate for a shadow
+  // element without a special case: no engine can XPath into a shadow tree, so
+  // `resolveCandidate` finds nothing and the filter below removes it.
+  const doc = rootOf(el);
   const tag = el.tagName.toLowerCase();
   const out: LocatorCandidate[] = [];
 
@@ -466,5 +558,9 @@ export function generate(el: Element, framePath?: FrameStep[]): ElementResult {
     // caller, because only the top frame can see the whole chain — see
     // `frameStepFor` and the FRAME_PATH broadcast in the content script.
     framePath: framePath ?? framePathOf(el.ownerDocument.defaultView),
+    // And the chain of components around it, for the same reason (SPEC §19).
+    // Read here rather than supplied: unlike a frame chain, every host is
+    // visible from the element itself, so nothing has to be pushed down.
+    shadowPath: shadowPathOf(el),
   };
 }

--- a/src/engine/candidates.ts
+++ b/src/engine/candidates.ts
@@ -97,6 +97,46 @@ export function setTestIdAttribute(attr: string): void {
   testIdAttribute = attr.trim() || 'data-testid';
 }
 
+/**
+ * querySelectorAll, descending into open shadow roots.
+ *
+ * Playwright's engines pierce, and the eye reports what a Playwright test will
+ * get — so a resolver that stopped at the boundary under-counted. A plain
+ * `<button>Submit</button>` on a page of web components each containing their
+ * own Submit read as unique here and resolved to six in a real run.
+ *
+ * Piercing downward is right for every scope: a locator scoped to a shadow
+ * root still sees roots nested below it, both for us and for Playwright.
+ *
+ * Selenium does not pierce, so where the two differ this reports MORE matches
+ * than a Selenium run would. That direction is the safe one: an amber
+ * "6 elements match" sends the user to look, where a green tick on a locator
+ * that matches six would not (SPEC §7, §19).
+ */
+function pierce(root: Document | ShadowRoot | Element, sel: string): Element[] {
+  const out = Array.from(root.querySelectorAll(sel));
+  for (const el of Array.from(root.querySelectorAll('*'))) {
+    if (el.shadowRoot) out.push(...pierce(el.shadowRoot, sel));
+  }
+  return out;
+}
+
+/**
+ * Whether a selector singles this element out — asked the way the frameworks
+ * ask it, which means piercing (SPEC §19).
+ *
+ * A non-piercing check calls `[name="email"]` unique on Etsy's sign-in form,
+ * because `<clg-text-input name="email">` is the only match in the document.
+ * Playwright's css pierces and finds two: the host and the `<input name="email">`
+ * that the component mirrors the attribute onto. Emitting it produced a locator
+ * that resolved to two elements in the framework it was generated for.
+ *
+ * This is the same mistake the resolver made, one layer down.
+ */
+function unique(el: Element, sel: string): boolean {
+  return pierce(rootOf(el), sel).length === 1;
+}
+
 function attrSelector(el: Element, attr: string): string | null {
   const value = el.getAttribute(attr);
   if (!value) return null;
@@ -108,7 +148,7 @@ function attrSelector(el: Element, attr: string): string | null {
   // escaping. CSS.escape is for identifiers and would render `/forgot` as
   // `\/forgot` — still valid, but nobody writes that.
   const sel = `${prefix}[${attr}="${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"]`;
-  return rootOf(el).querySelectorAll(sel).length === 1 ? sel : null;
+  return unique(el, sel) ? sel : null;
 }
 
 /** `#id`, unless the id is framework-generated — same rule as the id candidate. */
@@ -116,7 +156,7 @@ function idSelector(el: Element): string | null {
   const id = el.getAttribute('id');
   if (!id || looksGenerated(id)) return null;
   const sel = `#${CSS.escape(id)}`;
-  return rootOf(el).querySelectorAll(sel).length === 1 ? sel : null;
+  return unique(el, sel) ? sel : null;
 }
 
 /**
@@ -260,30 +300,6 @@ export function ariaHidden(el: Element): boolean {
  * WebDriver answers `invalid locator` — which is why §19 excludes xpath for a
  * shadow element rather than trying to emit one.
  */
-/**
- * querySelectorAll, descending into open shadow roots.
- *
- * Playwright's engines pierce, and the eye reports what a Playwright test will
- * get — so a resolver that stopped at the boundary under-counted. A plain
- * `<button>Submit</button>` on a page of web components each containing their
- * own Submit read as unique here and resolved to six in a real run.
- *
- * Piercing downward is right for every scope: a locator scoped to a shadow
- * root still sees roots nested below it, both for us and for Playwright.
- *
- * Selenium does not pierce, so where the two differ this reports MORE matches
- * than a Selenium run would. That direction is the safe one: an amber
- * "6 elements match" sends the user to look, where a green tick on a locator
- * that matches six would not (SPEC §7, §19).
- */
-function pierce(root: Document | ShadowRoot | Element, sel: string): Element[] {
-  const out = Array.from(root.querySelectorAll(sel));
-  for (const el of Array.from(root.querySelectorAll('*'))) {
-    if (el.shadowRoot) out.push(...pierce(el.shadowRoot, sel));
-  }
-  return out;
-}
-
 /**
  * Elements that render no text of their own. Playwright's text engine ignores
  * them; ours counted `<title>` as a match for the page heading, because a

--- a/src/engine/inject-global.ts
+++ b/src/engine/inject-global.ts
@@ -1,4 +1,4 @@
-import { generate, shadowPathOf, shadowSelector } from './candidates';
+import { generate, resolveCandidate, shadowPathOf, shadowSelector } from './candidates';
 import { collectInteractive, collectClosedHosts } from './interactive';
 
 // Test-only entry: exposes the engine on window.__spike so the fidelity harness
@@ -12,10 +12,11 @@ import { collectInteractive, collectClosedHosts } from './interactive';
   window as unknown as {
     __spike: {
       generate: typeof generate;
+      resolveCandidate: typeof resolveCandidate;
       shadowPathOf: typeof shadowPathOf;
       shadowSelector: typeof shadowSelector;
       collectInteractive: typeof collectInteractive;
       collectClosedHosts: typeof collectClosedHosts;
     };
   }
-).__spike = { generate, shadowPathOf, shadowSelector, collectInteractive, collectClosedHosts };
+).__spike = { generate, resolveCandidate, shadowPathOf, shadowSelector, collectInteractive, collectClosedHosts };

--- a/src/engine/inject-global.ts
+++ b/src/engine/inject-global.ts
@@ -1,5 +1,21 @@
-import { generate } from './candidates';
+import { generate, shadowPathOf, shadowSelector } from './candidates';
+import { collectInteractive, collectClosedHosts } from './interactive';
 
 // Test-only entry: exposes the engine on window.__spike so the fidelity harness
 // can inject it into a page and call it. Not part of the shipped extension.
-(window as unknown as { __spike: { generate: typeof generate } }).__spike = { generate };
+//
+// The scan-side functions are here too because shadow DOM (SPEC §19) is the
+// first behaviour where what a SCAN collects differs from what `generate`
+// produces for one element, and it can only be checked in a real browser —
+// jsdom is not where a web component's rendering is decided.
+(
+  window as unknown as {
+    __spike: {
+      generate: typeof generate;
+      shadowPathOf: typeof shadowPathOf;
+      shadowSelector: typeof shadowSelector;
+      collectInteractive: typeof collectInteractive;
+      collectClosedHosts: typeof collectClosedHosts;
+    };
+  }
+).__spike = { generate, shadowPathOf, shadowSelector, collectInteractive, collectClosedHosts };

--- a/src/engine/interactive.ts
+++ b/src/engine/interactive.ts
@@ -109,13 +109,19 @@ export function collectInteractive(root: Element | ShadowRoot, includeHidden: bo
  * there was nothing to collect from it either way.
  */
 function isClosedHost(el: Element): boolean {
+  // A hyphen is what makes a tag name a custom element.
+  //
+  // NOT `customElements.get()`, which is the obvious check and does not work
+  // where this runs: a content script lives in an isolated world with its own
+  // registry, so an element the PAGE defined is absent from it and every
+  // closed root read as an ordinary unknown tag. The engine's own spec did not
+  // catch that, because it injects into the main world — the extension E2E
+  // did.
   if (!el.localName.includes('-')) return false;
   if (el.childElementCount > 0 || el.textContent?.trim()) return false;
-  try {
-    if (!el.ownerDocument.defaultView?.customElements.get(el.localName)) return false;
-  } catch {
-    return false;
-  }
+  // Rendering a box with no light DOM to explain it: the content is coming
+  // from somewhere unreachable. An undefined custom element is an inline box
+  // with no content and no size, so it does not qualify.
   const box = el.getBoundingClientRect();
   return box.width > 0 && box.height > 0;
 }

--- a/src/engine/interactive.ts
+++ b/src/engine/interactive.ts
@@ -76,12 +76,70 @@ export function isInteractive(el: Element): boolean {
  * find. On, they are kept: a validation message or an unopened modal is real
  * page-object material, and Add cannot reach what is not rendered.
  */
-export function collectInteractive(root: Element, includeHidden: boolean): Element[] {
+export function collectInteractive(root: Element | ShadowRoot, includeHidden: boolean): Element[] {
   const found: Element[] = [];
   for (const el of Array.from(root.querySelectorAll('*'))) {
-    if (!isInteractive(el)) continue;
-    if (!includeHidden && ariaHidden(el)) continue;
-    found.push(el);
+    if (isInteractive(el) && (includeHidden || !ariaHidden(el))) found.push(el);
+    // A web component's controls live in its shadow root, which
+    // querySelectorAll does not enter (SPEC §19). Etsy's sign-up form is
+    // <clg-text-input> elements whose real <input> is inside one, so a scan of
+    // the dialog returned the buttons around the form and none of the form.
+    //
+    // Open roots only: `shadowRoot` is null for a closed one and there is no
+    // way in from script. `collectClosedHosts` reports those separately, so a
+    // scan says what it could not read rather than quietly returning less.
+    if (el.shadowRoot) found.push(...collectInteractive(el.shadowRoot, includeHidden));
   }
   return found;
+}
+
+/**
+ * A custom element rendering content that no tree walk can reach.
+ *
+ * A closed root cannot be detected directly — `shadowRoot` is null exactly as
+ * it is for an element with no root at all — so this asks whether the element
+ * DRAWS something it has no light DOM to explain. A defined custom element
+ * with no children, no text and a real box on screen is rendering from a
+ * closed root; there is nowhere else for it to come from.
+ *
+ * Deliberately conservative. A false positive warns about an element that is
+ * fine, and a warning that fires on every inert custom element stops being
+ * read — so a behaviour-only component, which is common, must not trip it.
+ * A closed root that is itself hidden goes unreported, which costs nothing:
+ * there was nothing to collect from it either way.
+ */
+function isClosedHost(el: Element): boolean {
+  if (!el.localName.includes('-')) return false;
+  if (el.childElementCount > 0 || el.textContent?.trim()) return false;
+  try {
+    if (!el.ownerDocument.defaultView?.customElements.get(el.localName)) return false;
+  } catch {
+    return false;
+  }
+  const box = el.getBoundingClientRect();
+  return box.width > 0 && box.height > 0;
+}
+
+/**
+ * Hosts inside `root` whose shadow root is closed, so a scan can say what it
+ * could not read (SPEC §19). Silence is indistinguishable from a bug, which is
+ * how the whole shadow DOM gap was first reported.
+ *
+ * A closed root is detectable even though it is not readable: the element is a
+ * custom element that renders content no tree walk can reach. `shadowRoot`
+ * being null is not enough on its own — most elements have no shadow root at
+ * all — so this asks the element whether it has one the only way available,
+ * which is to look for a registered custom element whose rendering cannot be
+ * accounted for by its light DOM.
+ */
+export function collectClosedHosts(root: Element | ShadowRoot): Element[] {
+  const out: Element[] = [];
+  for (const el of Array.from(root.querySelectorAll('*'))) {
+    if (el.shadowRoot) {
+      out.push(...collectClosedHosts(el.shadowRoot));
+    } else if (isClosedHost(el)) {
+      out.push(el);
+    }
+  }
+  return out;
 }

--- a/src/engine/naming.ts
+++ b/src/engine/naming.ts
@@ -115,6 +115,32 @@ function toPascalCase(raw: string): string {
   return words.map((w) => w[0].toUpperCase() + w.slice(1)).join('');
 }
 
+/**
+ * Validity markers a form puts in its label, which the accessible name picks up
+ * and nobody wants in an identifier (SPEC §13).
+ *
+ * Etsy's sign-in labels are `Email address*`, where the asterisk carries an
+ * accessible "Required" — so the accname is literally "Email address Required"
+ * and the field was named `EmailAddressRequired`. The same markup gives every
+ * required field on a form the same suffix, which is noise on all of them.
+ *
+ * Stripped from the NAME only. The accessible name is unchanged, because
+ * `getByLabel('Email address Required')` has to keep the word to match — the
+ * name is an identifier the user can rename, the locator is not.
+ */
+const VALIDITY_SUFFIX = /(Required|Optional)$/;
+
+/**
+ * Drop one trailing marker, and only when something is left to be called.
+ *
+ * One, not all: a field genuinely called "Required" keeps its name, and
+ * "PasswordRequiredRequired" is a doubled marker rather than a word.
+ */
+function dropValiditySuffix(name: string): string {
+  const stripped = name.replace(VALIDITY_SUFFIX, '');
+  return stripped === '' ? name : stripped;
+}
+
 /** Truncate at a word boundary rather than mid-word (SPEC §13). */
 function truncate(name: string): string {
   if (name.length <= MAX_NAME_LENGTH) return name;
@@ -132,7 +158,7 @@ function clean(raw: string): string {
   // Defensive: accname already normalises whitespace, so this only bites on a
   // raw attribute (placeholder, name, id) that contains a newline.
   const firstLine = raw.split(/\r\n|\r|\n/)[0];
-  let name = toPascalCase(firstLine);
+  let name = dropValiditySuffix(toPascalCase(firstLine));
   if (!name) return '';
   // Identifiers cannot start with a digit.
   if (/^\d/.test(name)) {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -47,6 +47,26 @@ export interface ElementResult {
   preferredIndex: number;
   /** Outermost first; empty for an element in the main frame (SPEC §16). */
   framePath: FrameStep[];
+  /** Outermost first; empty for an element in the light DOM (SPEC §19). */
+  shadowPath: ShadowStep[];
+}
+
+/**
+ * One shadow host between an element's document and the element, located the
+ * same way a frame is — the tree holding the host is just a tree.
+ *
+ * Restricted to css for the same reason a frame step is: every API that enters
+ * a shadow root takes a selector. Puppeteer's `>>>` and Selenium's
+ * `shadowRoot` both do, and `cssFor` already prefers a test id, then a name,
+ * then a non-generated id (§7).
+ *
+ * Unlike a frame there is no `opaque` case: a host is an ordinary element in
+ * its own tree and is always readable from there. The unreachable case is a
+ * CLOSED root, and that is invisible from the outside rather than partially
+ * visible, so there is no half-path to record (§19).
+ */
+export interface ShadowStep {
+  host: LocatorCandidate;
 }
 
 /**

--- a/src/generators/playwright-python.ts
+++ b/src/generators/playwright-python.ts
@@ -6,11 +6,12 @@
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import { playwrightPyExpr } from '../locators/display';
 import { playwrightPyFramePrefix } from '../locators/frames';
+import { playwrightPyShadowPrefix } from '../locators/shadow';
 import { classNameOf } from './class-name';
 import { pythonName, snake } from './names';
 
 const expr = (el: ModelElement) =>
-  `page.${playwrightPyFramePrefix(el.framePath)}${playwrightPyExpr(activeCandidate(el))}`;
+  `page.${playwrightPyFramePrefix(el.framePath)}${playwrightPyShadowPrefix(el.shadowPath)}${playwrightPyExpr(activeCandidate(el))}`;
 
 export function generatePlaywrightPythonPageObject(model: TabModel): string {
   const className = classNameOf(model);

--- a/src/generators/playwright-ts.ts
+++ b/src/generators/playwright-ts.ts
@@ -5,13 +5,18 @@
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import { playwrightExpr } from '../locators/display';
 import { playwrightFramePrefix } from '../locators/frames';
+import { playwrightShadowPrefix } from '../locators/shadow';
 import { tsPageObject, tsLocators, type TsTarget } from './ts-page-object';
 
 const PLAYWRIGHT: TsTarget = {
   module: '@playwright/test',
   // frameLocator chains, so a framed element needs no explanation and no
-  // switching — the locator is complete on its own (SPEC §16).
-  expr: (el: ModelElement) => playwrightFramePrefix(el.framePath) + playwrightExpr(activeCandidate(el)),
+  // switching — the locator is complete on its own (SPEC §16). A shadow path
+  // chains the same way, with `locator(host)` per boundary: Playwright's own
+  // engines pierce, so this is what separates two identical components rather
+  // than what makes the element reachable at all (SPEC §19).
+  expr: (el: ModelElement) =>
+    playwrightFramePrefix(el.framePath) + playwrightShadowPrefix(el.shadowPath) + playwrightExpr(activeCandidate(el)),
 };
 
 export const generatePlaywrightPageObject = (model: TabModel) => tsPageObject(model, PLAYWRIGHT);

--- a/src/generators/puppeteer.ts
+++ b/src/generators/puppeteer.ts
@@ -11,6 +11,7 @@
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import { puppeteerExpr } from '../locators/display';
 import { frameNote, frameSelector } from '../locators/frames';
+import { puppeteerShadowSelector, shadowContext } from '../locators/shadow';
 import type { FrameStep } from '../engine/types';
 import { singleQuoted as q } from '../quote';
 import { tsPageObject, tsLocators, type TsTarget } from './ts-page-object';
@@ -34,16 +35,39 @@ const frameSwitch = (path: FrameStep[]) => {
 
 const PUPPETEER: TsTarget = {
   module: 'puppeteer',
-  expr: (el: ModelElement) => puppeteerExpr(activeCandidate(el)),
+  // A shadow element is reached with `>>>`, Puppeteer's deep descendant
+  // combinator — its plain css does not pierce (SPEC §19). The selector goes
+  // through puppeteerExpr first so the table and the code cannot disagree
+  // about what the locator is, then the hosts are joined in front of it.
+  expr: (el: ModelElement) => puppeteerShadowExpr(el),
   // `page.locator` is page-scoped and Puppeteer has no frameLocator, so a
   // framed element needs `page.frames()` first. Said out loud, because the
   // locator is otherwise indistinguishable from a main-frame one (SPEC §16).
-  note: (el: ModelElement) => frameNote(el.framePath, '//', frameSwitch),
+  note: (el: ModelElement) => [...frameNote(el.framePath, '//', frameSwitch), ...shadowContext(el.shadowPath, '//')],
   // `Locator<T>` is generic over the node it yields — `page.locator('button')`
   // is a `Locator<HTMLButtonElement>`. Element is the common supertype, and
   // widening to it is what lets one field hold any of them.
   locatorType: 'Locator<Element>',
 };
+
+/**
+ * `page.locator('host >>> input[name="x"]')`.
+ *
+ * Rebuilt from the selector rather than wrapped around the expression, because
+ * the hosts belong INSIDE the quoted selector — prefixing the expression would
+ * produce `page.locator('host').locator('input')`, which is Playwright's shape
+ * and does not pierce in Puppeteer.
+ */
+function puppeteerShadowExpr(el: ModelElement): string {
+  const base = puppeteerExpr(activeCandidate(el));
+  if (!el.shadowPath?.length) return base;
+  const m = base.match(/^locator\('([\s\S]*)'\)$/);
+  // Anything not a plain single-quoted css selector is left alone: the shadow
+  // path would have nowhere to go, and a wrong guess is worse than none.
+  if (!m) return base;
+  const inner = m[1].replace(/\\'/g, "'");
+  return `locator(${q(puppeteerShadowSelector(el.shadowPath, inner))})`;
+}
 
 export const generatePuppeteerPageObject = (model: TabModel) => tsPageObject(model, PUPPETEER);
 export const generatePuppeteerLocators = (model: TabModel) => tsLocators(model, PUPPETEER);

--- a/src/generators/puppeteer.ts
+++ b/src/generators/puppeteer.ts
@@ -11,7 +11,7 @@
 import { activeCandidate, type ModelElement, type TabModel } from '../model';
 import { puppeteerExpr } from '../locators/display';
 import { frameNote, frameSelector } from '../locators/frames';
-import { puppeteerShadowSelector, shadowContext } from '../locators/shadow';
+import { shadowContext } from '../locators/shadow';
 import type { FrameStep } from '../engine/types';
 import { singleQuoted as q } from '../quote';
 import { tsPageObject, tsLocators, type TsTarget } from './ts-page-object';
@@ -39,7 +39,7 @@ const PUPPETEER: TsTarget = {
   // combinator — its plain css does not pierce (SPEC §19). The selector goes
   // through puppeteerExpr first so the table and the code cannot disagree
   // about what the locator is, then the hosts are joined in front of it.
-  expr: (el: ModelElement) => puppeteerShadowExpr(el),
+  expr: (el: ModelElement) => puppeteerExpr(activeCandidate(el), el.shadowPath),
   // `page.locator` is page-scoped and Puppeteer has no frameLocator, so a
   // framed element needs `page.frames()` first. Said out loud, because the
   // locator is otherwise indistinguishable from a main-frame one (SPEC §16).
@@ -49,25 +49,6 @@ const PUPPETEER: TsTarget = {
   // widening to it is what lets one field hold any of them.
   locatorType: 'Locator<Element>',
 };
-
-/**
- * `page.locator('host >>> input[name="x"]')`.
- *
- * Rebuilt from the selector rather than wrapped around the expression, because
- * the hosts belong INSIDE the quoted selector — prefixing the expression would
- * produce `page.locator('host').locator('input')`, which is Playwright's shape
- * and does not pierce in Puppeteer.
- */
-function puppeteerShadowExpr(el: ModelElement): string {
-  const base = puppeteerExpr(activeCandidate(el));
-  if (!el.shadowPath?.length) return base;
-  const m = base.match(/^locator\('([\s\S]*)'\)$/);
-  // Anything not a plain single-quoted css selector is left alone: the shadow
-  // path would have nowhere to go, and a wrong guess is worse than none.
-  if (!m) return base;
-  const inner = m[1].replace(/\\'/g, "'");
-  return `locator(${q(puppeteerShadowSelector(el.shadowPath, inner))})`;
-}
 
 export const generatePuppeteerPageObject = (model: TabModel) => tsPageObject(model, PUPPETEER);
 export const generatePuppeteerLocators = (model: TabModel) => tsLocators(model, PUPPETEER);

--- a/src/generators/selenium-csharp.ts
+++ b/src/generators/selenium-csharp.ts
@@ -11,6 +11,7 @@ import { underscoreCamel } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameOf } from './class-name';
 import { frameContext, frameNote, isOpaque } from '../locators/frames';
+import { seleniumShadowRoot, shadowContext, shadowNote } from '../locators/shadow';
 import type { FrameStep } from '../engine/types';
 
 const q = doubleQuoted;
@@ -37,11 +38,29 @@ const frameSwitch = (path: FrameStep[]) => [
   ...path.map((s) => `driver.SwitchTo().Frame(driver.FindElement(${by(s.frame)}));`),
 ];
 
+/**
+ * What a find runs against: the driver, or a chain of hosts ending in a
+ * `GetShadowRoot()` (SPEC §19), which returns an `ISearchContext` and so
+ * carries `FindElement` unchanged.
+ *
+ * Nothing is mutated, unlike a frame switch, so there is no try/finally here.
+ */
+function shadowRoot(el: ModelElement): string {
+  return seleniumShadowRoot(el.shadowPath, 'driver', (r, css) => `${r}.FindElement(By.CssSelector(${q(css)})).GetShadowRoot()`);
+}
+
+/** The element expression, host chain included. */
+function findIn(el: ModelElement): string {
+  return `${shadowRoot(el)}.FindElement(${by(activeCandidate(el))})`;
+}
+
 function banner(el: ModelElement): string {
   // The frame chain goes in the banner, where a reader is already looking to
   // see what this block is about (SPEC §16).
   // Context only: every method below switches for itself.
-  const frames = frameContext(el.framePath, '//').map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
+  const frames = [...frameContext(el.framePath, '//'), ...shadowContext(el.shadowPath, '//')].map((line) =>
+    ` * ${line.replace(/^\/\/ /, '')}`
+  );
   return [`/*`, ` * ${el.name}`, ...frames, ` * ***************************************************************`, ` */`].join('\n');
 }
 
@@ -72,12 +91,12 @@ function methods(el: ModelElement): string[] {
 
   // No element getter for a framed element: an IWebElement goes stale the
   // moment the driver switches away (SPEC §16).
-  const elExpr = framed ? `driver.FindElement(${by(activeCandidate(el))})` : `Get${n}Element()`;
+  const elExpr = framed ? findIn(el) : `Get${n}Element()`;
   const selectExpr = framed ? `new SelectElement(${elExpr})` : `Get${n}Select()`;
 
   const out: string[] = framed
     ? []
-    : [`public IWebElement Get${n}Element()\n{\n    return driver.FindElement(${by(activeCandidate(el))});\n}`];
+    : [`public IWebElement Get${n}Element()\n{\n    return ${findIn(el)};\n}`];
 
   switch (classify(el)) {
     case 'actionable':
@@ -173,7 +192,12 @@ function methods(el: ModelElement): string[] {
 /** `By` fields to paste into your own page object. */
 export function generateSeleniumCSharpLocators(model: TabModel): string {
   return model.elements
-    .flatMap((el) => [...frameNote(el.framePath, '//', frameSwitch), `private readonly By ${underscoreCamel(el.name)} = ${by(activeCandidate(el))};`])
+    .flatMap((el) => [
+      ...frameNote(el.framePath, '//', frameSwitch),
+      // A `By` cannot carry the host chain, so the traversal is spelled out.
+      ...shadowNote(el.shadowPath, '//', () => [`${shadowRoot(el)}.FindElement(${underscoreCamel(el.name)})`]),
+      `private readonly By ${underscoreCamel(el.name)} = ${by(activeCandidate(el))};`,
+    ])
     .join('\n');
 }
 

--- a/src/generators/selenium-java.ts
+++ b/src/generators/selenium-java.ts
@@ -9,6 +9,7 @@ import { javaMethod, javaName, lowerCamel } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameOf } from './class-name';
 import { frameContext, frameNote, isOpaque } from '../locators/frames';
+import { hasShadow, seleniumShadowRoot, shadowContext, shadowNote } from '../locators/shadow';
 import type { FrameStep } from '../engine/types';
 
 const q = doubleQuoted;
@@ -45,11 +46,32 @@ const frameSwitch = (path: FrameStep[]) => [
   ...path.map((s) => `driver.switchTo().frame(driver.findElement(${by(s.frame)}));`),
 ];
 
+/**
+ * What a find runs against: the driver, or a chain of hosts ending in a
+ * `getShadowRoot()` (SPEC §19). `SearchContext` is what that returns, and it
+ * carries `findElement`, so the call below is unchanged.
+ *
+ * Unlike a frame switch this mutates nothing, so there is no try/finally: a
+ * shadow root is reached by chaining off an element rather than by moving the
+ * driver. An element inside both a frame and a component needs both, and gets
+ * both — the frame switch wraps the method, this builds the receiver.
+ */
+function shadowRoot(el: ModelElement): string {
+  return seleniumShadowRoot(el.shadowPath, 'driver', (r, css) => `${r}.findElement(By.cssSelector(${q(css)})).getShadowRoot()`);
+}
+
+/** The element expression, host chain included. */
+function findIn(el: ModelElement): string {
+  return `${shadowRoot(el)}.findElement(${by(activeCandidate(el))})`;
+}
+
 function banner(el: ModelElement): string {
   // The frame chain goes in the banner, where a reader is already looking to
   // see what this block is about (SPEC §16).
   // Context only: every method below switches for itself.
-  const frames = frameContext(el.framePath, '//').map((line) => ` * ${line.replace(/^\/\/ /, '')}`);
+  const frames = [...frameContext(el.framePath, '//'), ...shadowContext(el.shadowPath, '//')].map((line) =>
+    ` * ${line.replace(/^\/\/ /, '')}`
+  );
   return [`/*`, ` * ${el.name}`, ...frames, ` * ***************************************************************`, ` */`].join('\n');
 }
 
@@ -86,7 +108,7 @@ function methods(el: ModelElement): string[] {
   // No element getter for a framed element: a WebElement goes stale the moment
   // the driver switches away, so handing one back is handing back a guaranteed
   // failure (SPEC §16). Same for the Select wrapper, which holds one.
-  const elExpr = framed ? `driver.findElement(${by(activeCandidate(el))})` : `get${n}Element()`;
+  const elExpr = framed ? findIn(el) : `get${n}Element()`;
   const selectExpr = framed ? `new Select(${elExpr})` : `get${n}Select()`;
 
   // `getClass` is already on Object, so an element called Class cannot have the
@@ -95,7 +117,7 @@ function methods(el: ModelElement): string[] {
 
   const out: string[] = framed
     ? []
-    : [`public WebElement get${n}Element() {\n    return driver.findElement(${by(activeCandidate(el))});\n}`];
+    : [`public WebElement get${n}Element() {\n    return ${findIn(el)};\n}`];
 
   switch (classify(el)) {
     case 'actionable':
@@ -206,7 +228,12 @@ function methods(el: ModelElement): string[] {
  */
 export function generateSeleniumJavaLocators(model: TabModel): string {
   return model.elements
-    .flatMap((el) => [...frameNote(el.framePath, '//', frameSwitch), `private final By ${javaName(lowerCamel(el.name))} = ${by(activeCandidate(el))};`])
+    .flatMap((el) => [
+      ...frameNote(el.framePath, '//', frameSwitch),
+      // A `By` cannot carry the host chain, so the traversal is spelled out.
+      ...shadowNote(el.shadowPath, '//', () => [`${shadowRoot(el)}.findElement(${javaName(lowerCamel(el.name))})`]),
+      `private final By ${javaName(lowerCamel(el.name))} = ${by(activeCandidate(el))};`,
+    ])
     .join('\n');
 }
 

--- a/src/generators/selenium-python.ts
+++ b/src/generators/selenium-python.ts
@@ -11,6 +11,7 @@ import { snake, upperSnake } from './names';
 import { doubleQuoted } from '../quote';
 import { classNameOf } from './class-name';
 import { frameContext, frameNote, isOpaque } from '../locators/frames';
+import { hasShadow, seleniumShadowRoot, shadowContext, shadowNote } from '../locators/shadow';
 import type { FrameStep } from '../engine/types';
 
 /** Double-quoted, Black's default. */
@@ -44,6 +45,31 @@ function find(c: LocatorCandidate, recv: string): string {
   return parts ? `${recv}driver.find_element(${findArgs(c)})` : byTuple(c);
 }
 
+/**
+ * What a find runs against: the driver, or a chain of hosts ending in a
+ * `.shadow_root` (SPEC §19).
+ *
+ * Nothing here mutates driver state the way a frame switch does — a shadow
+ * root is reached by chaining off an element — so there is no `finally` and no
+ * default content to return to. A shadow element inside a frame needs both,
+ * and gets both: the frame switch wraps the method, this builds the receiver.
+ */
+function shadowRoot(el: ModelElement, recv: string): string {
+  return seleniumShadowRoot(
+    el.shadowPath,
+    `${recv}driver`,
+    (r, css) => `${r}.find_element(By.CSS_SELECTOR, ${q(css)}).shadow_root`
+  );
+}
+
+/** The element expression, host chain included. */
+function findIn(el: ModelElement, recv: string): string {
+  const c = activeCandidate(el);
+  if (!hasShadow(el.shadowPath)) return find(c, recv);
+  const parts = byParts(c);
+  return parts ? `${shadowRoot(el, recv)}.find_element(${findArgs(c)})` : byTuple(c);
+}
+
 /** The switch a reader can paste, one line per level, outermost first. */
 const frameSwitch = (path: FrameStep[], recv = '') => [
   `${recv}driver.switch_to.default_content()`,
@@ -53,7 +79,7 @@ const frameSwitch = (path: FrameStep[], recv = '') => [
 function banner(el: ModelElement): string {
   const rule = '#'.repeat(63);
   // Context only: every definition below switches for itself.
-  return [rule, `# ${el.name}`, ...frameContext(el.framePath, '#'), rule].join('\n');
+  return [rule, `# ${el.name}`, ...frameContext(el.framePath, '#'), ...shadowContext(el.shadowPath, '#'), rule].join('\n');
 }
 
 /**
@@ -83,9 +109,7 @@ function methods(el: ModelElement, recv: string): string[] {
 
   // No element getter for a framed element: the WebElement goes stale the
   // moment the driver switches away (SPEC §16).
-  const elExpr = framed
-    ? `${recv}driver.find_element(${findArgs(activeCandidate(el))})`
-    : `${recv}get_${n}_element()`;
+  const elExpr = framed ? findIn(el, recv) : `${recv}get_${n}_element()`;
   const selectExpr = framed ? `Select(${elExpr})` : `${recv}get_${n}_select()`;
   // `def f()` at module level, `def f(self)` in a class — and `self` goes
   // first, ahead of any real arguments.
@@ -97,7 +121,7 @@ function methods(el: ModelElement, recv: string): string[] {
   };
   const out: string[] = framed
     ? []
-    : [`${def(`get_${n}_element()`)}:\n    return ${find(activeCandidate(el), recv)}`];
+    : [`${def(`get_${n}_element()`)}:\n    return ${findIn(el, recv)}`];
 
   switch (classify(el)) {
     case 'actionable':
@@ -197,7 +221,15 @@ function methods(el: ModelElement, recv: string): string[] {
  */
 export function generateSeleniumPythonLocators(model: TabModel): string {
   return model.elements
-    .flatMap((el) => [...frameNote(el.framePath, '#', frameSwitch), `${upperSnake(el.name)} = ${byTuple(activeCandidate(el))}`])
+    .flatMap((el) => [
+      ...frameNote(el.framePath, '#', frameSwitch),
+      // A tuple cannot carry the host chain, so the traversal is spelled out:
+      // `driver.find_element(*COUPON)` finds nothing on its own (SPEC §19).
+      ...shadowNote(el.shadowPath, '#', () => [
+        `${shadowRoot(el, '')}.find_element(*${upperSnake(el.name)})`,
+      ]),
+      `${upperSnake(el.name)} = ${byTuple(activeCandidate(el))}`,
+    ])
     .join('\n');
 }
 

--- a/src/locators/display.ts
+++ b/src/locators/display.ts
@@ -7,6 +7,8 @@ import type { LocatorCandidate } from '../engine/types';
 import { singleQuoted, doubleQuoted } from '../quote';
 import type { FrameStep } from '../engine/types';
 import { frameSelector, playwrightFramePrefix, playwrightPyFramePrefix } from './frames';
+import type { ShadowStep } from '../engine/types';
+import { playwrightPyShadowPrefix, playwrightShadowPrefix, puppeteerShadowSelector, shadowSelector } from './shadow';
 
 const q = singleQuoted;
 const qq = doubleQuoted;
@@ -103,8 +105,11 @@ export function puppeteerSelector(c: LocatorCandidate): string {
 }
 
 /** The Puppeteer call this candidate becomes. */
-export function puppeteerExpr(c: LocatorCandidate): string {
-  return `locator(${q(puppeteerSelector(c))})`;
+export function puppeteerExpr(c: LocatorCandidate, shadowPath?: ShadowStep[]): string {
+  // The hosts belong INSIDE the quoted selector, joined with `>>>` (SPEC §19).
+  // Prefixing the expression would give Playwright's `locator(a).locator(b)`
+  // shape, which does not pierce in Puppeteer.
+  return `locator(${q(puppeteerShadowSelector(shadowPath, puppeteerSelector(c)))})`;
 }
 
 /** `type: value`, for frameworks whose locators are a flat pair. */
@@ -141,11 +146,34 @@ export function typeValue(c: LocatorCandidate): string {
  * looking identical when only their frame differs — which is exactly what
  * happened before this existed.
  */
-export function displayElementLocator(c: LocatorCandidate, frameworkId: string, framePath?: FrameStep[]): string {
-  if (!framePath || framePath.length === 0) return displayLocator(c, frameworkId);
-  if (frameworkId === 'playwright-python') return playwrightPyFramePrefix(framePath) + playwrightPyExpr(c);
-  if (frameworkId.startsWith('playwright')) return playwrightFramePrefix(framePath) + playwrightExpr(c);
-  const chain = framePath.map(frameSelector).join(' › ');
+export function displayElementLocator(
+  c: LocatorCandidate,
+  frameworkId: string,
+  framePath?: FrameStep[],
+  shadowPath?: ShadowStep[]
+): string {
+  const frames = framePath ?? [];
+  const hosts = shadowPath ?? [];
+  if (frames.length === 0 && hosts.length === 0) return displayLocator(c, frameworkId);
+
+  // Playwright carries both chains inside the locator, so the row reads as the
+  // line that will be generated.
+  if (frameworkId === 'playwright-python') {
+    return playwrightPyFramePrefix(frames) + playwrightPyShadowPrefix(hosts) + playwrightPyExpr(c);
+  }
+  if (frameworkId.startsWith('playwright')) {
+    return playwrightFramePrefix(frames) + playwrightShadowPrefix(hosts) + playwrightExpr(c);
+  }
+  // Puppeteer puts the hosts inside its selector, so only the frames are a
+  // prefix — and a frame is not expressible there at all, hence ` › `.
+  if (frameworkId === 'puppeteer') {
+    const expr = puppeteerExpr(c, hosts);
+    return frames.length ? `${frames.map(frameSelector).join(' › ')} › ${expr}` : expr;
+  }
+  // Selenium expresses neither chain in the locator itself: both are steps the
+  // generated code takes before the `By` is used, so both read as the path
+  // they are.
+  const chain = [...frames.map(frameSelector), ...hosts.map(shadowSelector)].join(' › ');
   return `${chain} › ${displayLocator(c, frameworkId)}`;
 }
 

--- a/src/locators/shadow.ts
+++ b/src/locators/shadow.ts
@@ -1,0 +1,103 @@
+// How a shadow path reads in each target (SPEC §19).
+//
+// The sibling of frames.ts, and the same split: Playwright and Puppeteer carry
+// the chain inside the locator, so their output stays self-contained. Selenium
+// cannot — a `By` is tree-agnostic — so it walks the hosts one `shadowRoot` at
+// a time, and the expression that finds the element changes rather than a
+// comment being added.
+//
+// Unlike a frame switch, nothing here mutates driver state: a shadow root is
+// reached by chaining off an element, so there is no default content to return
+// to and no `finally` to write.
+import type { ShadowStep } from '../engine/types';
+import { singleQuoted, doubleQuoted } from '../quote';
+
+/**
+ * The selector for one host. Always css: every API that enters a shadow root
+ * takes one, and xpath cannot address a shadow tree in any engine — measured
+ * in `tests/shadow.probe.spec.ts`, where WebDriver answers `invalid locator`
+ * and Playwright resolves zero.
+ */
+export function shadowSelector(step: ShadowStep): string {
+  return (step.host as { value: string }).value;
+}
+
+/**
+ * Optional throughout, as frame paths are: `storage.session` survives an
+ * extension reload, so elements captured before shadow support existed still
+ * arrive without one.
+ */
+type Path = ShadowStep[] | undefined;
+
+export const hasShadow = (path: Path) => (path ?? []).length > 0;
+
+/**
+ * `locator('outer-panel').locator('inner-field').`, or '' in the light DOM.
+ *
+ * Playwright's own engines pierce, so a locator generated as though the page
+ * were flat already resolves — but the chain is still emitted, because it is
+ * what separates two identical components, and because a locator that says
+ * where the element lives survives a page growing a second one.
+ */
+export function playwrightShadowPrefix(path: Path): string {
+  return (path ?? []).map((s) => `locator(${singleQuoted(shadowSelector(s))}).`).join('');
+}
+
+/** The Python spelling of the same chain. */
+export function playwrightPyShadowPrefix(path: Path): string {
+  return (path ?? []).map((s) => `locator(${doubleQuoted(shadowSelector(s))}).`).join('');
+}
+
+/**
+ * Puppeteer joins the hosts to the element's own selector with `>>>`, its deep
+ * descendant combinator. One `>>>` spans any depth, so this is more explicit
+ * than it strictly needs to be — and stays correct when a page grows a second
+ * component that the outermost host alone would no longer separate.
+ */
+export function puppeteerShadowSelector(path: Path, selector: string): string {
+  return [...(path ?? []).map(shadowSelector), selector].join(' >>> ');
+}
+
+/**
+ * The receiver a Selenium `find` runs against: the driver, or a chain of hosts
+ * ending in a `shadowRoot`.
+ *
+ * `step` is supplied per language because only the spelling differs —
+ * `.shadow_root`, `.getShadowRoot()`, `.GetShadowRoot()` — and each already
+ * has its own `By` builder and its own find call.
+ */
+export function seleniumShadowRoot(path: Path, base: string, step: (recv: string, hostCss: string) => string): string {
+  return (path ?? []).reduce((recv, s) => step(recv, shadowSelector(s)), base);
+}
+
+/**
+ * What to say in a banner above a shadow-bound definition.
+ *
+ * Worth saying even where the locator carries the chain itself: "this element
+ * is inside a web component" is why its locator looks the way it does, and a
+ * reader pasting it somewhere else needs to know the host has to exist.
+ */
+export function shadowContext(path: Path, comment: string): string[] {
+  if (!hasShadow(path)) return [];
+  return [`${comment} In shadow DOM: ${(path ?? []).map(shadowSelector).join(' \u203a ')}`];
+}
+
+/**
+ * The note a shadow-bound locator needs in a shape that cannot carry the
+ * chain — Selenium's locators-only, where the output is a bare `By` and the
+ * call site supplies the receiver.
+ *
+ * Without it the constant is indistinguishable from a light-DOM one and
+ * `driver.find_element(*COUPON)` silently finds nothing: the driver cannot see
+ * into a shadow root at all, which `tests/shadow.probe.spec.ts` measures.
+ *
+ * Carries the traversal itself rather than an instruction to write one, so the
+ * reader can paste it — the same choice `frameNote` makes.
+ */
+export function shadowNote(path: Path, comment: string, howTo: (path: ShadowStep[]) => string[]): string[] {
+  if (!hasShadow(path)) return [];
+  return [
+    `In shadow DOM: ${(path ?? []).map(shadowSelector).join(' \u203a ')}`,
+    ...howTo(path ?? []),
+  ].map((line) => `${comment} ${line}`);
+}

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -27,6 +27,11 @@ export type PanelToContent =
   // A frame was asked to scan itself and never answered — there is no content
   // script inside it. Silence is indistinguishable from a bug, so it is said.
   | { type: 'FRAME_UNREADABLE'; sandboxed: boolean }
+  // A scan met web components whose shadow roots are closed, so their contents
+  // could not be collected (SPEC §19). Reported for the same reason an
+  // unreadable frame is: a scan that quietly returns less looks like a scan
+  // that found less, which is how the whole shadow DOM gap was first reported.
+  | { type: 'SHADOW_UNREADABLE'; count: number }
   | { type: 'OVERLAY_SHOWN'; token: string }
   | { type: 'OVERLAY_OWNER'; token: string }
   // Walk the pick target up or down the DOM (SPEC §4). Sent by the panel

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,4 +1,4 @@
-import type { ElementResult, FrameStep, LocatorCandidate } from './engine/types';
+import type { ElementResult, FrameStep, LocatorCandidate, ShadowStep } from './engine/types';
 import type { TabModel } from './model';
 
 // Messages panel → content (sent via browser.tabs.sendMessage to the active tab).
@@ -44,7 +44,12 @@ export type PanelToContent =
   // reply — see the note on ContentToPanel below.
   // framePath says WHICH document to resolve in: every frame hears this, and
   // the one whose own path matches is the one that answers (SPEC §16).
-  | { type: 'HIGHLIGHT'; candidate: LocatorCandidate; framePath?: FrameStep[] }
+  // shadowPath says which ROOT to resolve in, for the same reason framePath
+  // says which document. Without it the eye resolves against the page: Etsy's
+  // <clg-text-input> mirrors `name` onto its host, so `[name=password]` found
+  // the host AND the input inside it and reported 2 for a locator the model
+  // had counted as unique (SPEC §19).
+  | { type: 'HIGHLIGHT'; candidate: LocatorCandidate; framePath?: FrameStep[]; shadowPath?: ShadowStep[] }
   // Clear the highlight early — the user dismissed the match count.
   | { type: 'CLEAR_HIGHLIGHT' };
 

--- a/tests/capture.e2e.spec.ts
+++ b/tests/capture.e2e.spec.ts
@@ -1316,3 +1316,69 @@ test('a hidden match is marked on its nearest visible ancestor', async () => {
     )
     .toBe(1);
 });
+
+test('a scan says what it could not read: a closed shadow root (SPEC §19)', async () => {
+  let [sw] = context.serviceWorkers();
+  if (!sw) sw = await context.waitForEvent('serviceworker', { timeout: 10_000 });
+  const extId = new URL(sw.url()).host;
+
+  for (const open of context.pages()) {
+    if (open.url().startsWith('chrome-extension://')) await open.close();
+  }
+
+  const { page, tabId } = await openFixture(sw as never, 'closed-shadow', 'shadow.html');
+
+  const panel = await context.newPage();
+  await panel.goto(`chrome-extension://${extId}/devtools-panel.html`);
+  await panel.evaluate(() => {
+    (window as unknown as { __msgs: unknown[] }).__msgs = [];
+    chrome.runtime.onMessage.addListener((m) => {
+      (window as unknown as { __msgs: unknown[] }).__msgs.push(m);
+    });
+  });
+
+  await panel.evaluate(
+    (id) =>
+      chrome.runtime.sendMessage({
+        type: 'RELAY_TO_TAB',
+        tabId: id,
+        message: { type: 'START_PICKING', mode: 'scan', includeHidden: false },
+      }),
+    tabId
+  );
+
+  // Scan the whole page: <body> is the one container that holds every kind of
+  // component in the fixture.
+  const label = page.locator('[data-page-modeller="label"]');
+  await page.getByRole('heading', { name: 'Shadow DOM' }).hover();
+  for (let i = 0; i < 8 && !/(^|› )body$/.test((await label.textContent()) ?? ''); i++) {
+    await page.keyboard.press('ArrowUp');
+  }
+  // No `›` before it: at <body> the ancestor chain is empty, because the
+  // breadcrumb stops short of <html>.
+  await expect(label).toHaveText(/(^|› )body$/);
+  await page.keyboard.press('Enter');
+
+  const messages = async () =>
+    (await panel.evaluate(
+      () => (window as unknown as { __msgs: { type: string; message?: { type: string; count?: number } }[] }).__msgs
+    )).filter((m) => m.type === 'FROM_TAB');
+
+  // The controls inside the OPEN roots arrive — the bug this all started from.
+  await expect
+    .poll(async () =>
+      (await panel.evaluate(
+        () => (window as unknown as { __msgs: { type: string; model?: { elements: unknown[] } }[] }).__msgs
+      ))
+        .filter((m) => m.type === 'MODEL')
+        .at(-1)?.model?.elements.length
+    )
+    .toBeGreaterThan(8);
+
+  // And the one it could NOT read is named rather than silently dropped.
+  await expect
+    .poll(async () => (await messages()).filter((m) => m.message?.type === 'SHADOW_UNREADABLE').length)
+    .toBeGreaterThan(0);
+  const report = (await messages()).find((m) => m.message?.type === 'SHADOW_UNREADABLE')!;
+  expect(report.message?.count, 'exactly the one closed component, not every custom element').toBe(1);
+});

--- a/tests/engine.fidelity.spec.ts
+++ b/tests/engine.fidelity.spec.ts
@@ -6,6 +6,7 @@ import { playwrightExpr } from '../src/locators/display';
 import { playwrightShadowPrefix } from '../src/locators/shadow';
 import { frameworkById } from '../src/frameworks';
 import type { ElementResult } from '../src/engine/types';
+import './spike';
 
 const PLAYWRIGHT_KINDS = new Set(frameworkById('playwright-ts').locatorTypes);
 
@@ -110,7 +111,7 @@ test('locator engine matches real Playwright resolution', async ({ page }) => {
         failures.push(`${fixture}/${spikeId}: no unique candidate`);
         continue;
       }
-      const preferred = result.candidates[result.preferredIndex].candidate;
+      const preferred = result.candidates[result.preferredIndex]!.candidate;
       const loc = buildLocator(scope, preferred);
       const count = await loc.count();
       const sid = count === 1 ? await loc.getAttribute('data-spike') : null;
@@ -122,9 +123,3 @@ test('locator engine matches real Playwright resolution', async ({ page }) => {
 
   expect(failures, 'engine/Playwright divergences').toEqual([]);
 });
-
-declare global {
-  interface Window {
-    __spike: { generate(el: Element): ElementResult };
-  }
-}

--- a/tests/engine.fidelity.spec.ts
+++ b/tests/engine.fidelity.spec.ts
@@ -1,8 +1,9 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page, type Locator } from '@playwright/test';
 import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
 import { buildLocator } from './pw-builder';
 import { playwrightExpr } from '../src/locators/display';
+import { playwrightShadowPrefix } from '../src/locators/shadow';
 import { frameworkById } from '../src/frameworks';
 import type { ElementResult } from '../src/engine/types';
 
@@ -10,7 +11,7 @@ const PLAYWRIGHT_KINDS = new Set(frameworkById('playwright-ts').locatorTypes);
 
 // The crown-jewel correctness gate: every locator the engine deems unique must
 // resolve uniquely to the correct element in a REAL Playwright run.
-const FIXTURES = ['login.html', 'widgets.html', 'ambiguous.html', 'edgecases.html'];
+const FIXTURES = ['login.html', 'widgets.html', 'ambiguous.html', 'edgecases.html', 'shadow.html'];
 
 test('locator engine matches real Playwright resolution', async ({ page }) => {
   const failures: string[] = [];
@@ -28,13 +29,27 @@ test('locator engine matches real Playwright resolution', async ({ page }) => {
         result: window.__spike.generate(el) as ElementResult,
       }));
 
+      // A shadow element's candidates are generated and counted within its
+      // root, so they must be RESOLVED there too (SPEC §19). Scoping by the
+      // host chain is exactly what the generator emits, so this checks the
+      // shape a user actually gets rather than an idealised one.
+      //
+      // `page.$$('[data-spike]')` reaches these at all because Playwright's css
+      // pierces — which is also why an unscoped count would be the number of
+      // identical components on the page rather than 1.
+      const shadowPath = result.shadowPath ?? [];
+      const scope = shadowPath.reduce<Page | Locator>(
+        (acc, step) => acc.locator((step.host as { value: string }).value),
+        page
+      );
+
       // Every candidate's predicted count must equal Playwright's real count.
       // The engine's in-page resolver is our own approximation of Playwright
       // semantics — text matching, `exact`, whitespace normalisation — and the
       // eye (SPEC §8) reports from it. If the two drift, the count the user is
       // shown is not the count their test will get.
       for (const { candidate, predictedCount } of result.candidates) {
-        const loc = buildLocator(page, candidate);
+        const loc = buildLocator(scope, candidate);
         const actual = await loc.count();
         if (actual !== predictedCount) {
           failures.push(
@@ -62,7 +77,9 @@ test('locator engine matches real Playwright resolution', async ({ page }) => {
         // `xpath=` prefix, because Playwright infers XPath only from a leading
         // `//` or `..` and the engine's fallback path starts with one slash.
         if (PLAYWRIGHT_KINDS.has(candidate.kind)) {
-          const expr = playwrightExpr(candidate);
+          // The prefix the generator adds, so the string under test is the
+          // one that lands in the page object.
+          const expr = playwrightShadowPrefix(shadowPath) + playwrightExpr(candidate);
           const generated = await new Function('page', `return page.${expr};`)(page)
             .count()
             .catch((e: Error) => `threw: ${String(e).split('\n')[0]}`);
@@ -77,8 +94,16 @@ test('locator engine matches real Playwright resolution', async ({ page }) => {
       // dropped. So a missing one means the generator is broken for this shape
       // — which is how SVG XPaths, silently resolving to nothing, were caught.
       const kinds = result.candidates.map((c) => c.candidate.kind);
-      for (const required of ['css', 'xpath'] as const) {
-        if (!kinds.includes(required)) failures.push(`${fixture}/${spikeId}: no working ${required} candidate`);
+      // xpath cannot address a shadow tree in ANY engine (SPEC §19), so its
+      // absence there is the correct answer rather than a missing fallback.
+      // Asserted the other way round as well: it must be gone, or the model
+      // would offer Selenium a locator that answers `invalid locator`.
+      const required = shadowPath.length > 0 ? (['css'] as const) : (['css', 'xpath'] as const);
+      for (const kind of required) {
+        if (!kinds.includes(kind)) failures.push(`${fixture}/${spikeId}: no working ${kind} candidate`);
+      }
+      if (shadowPath.length > 0 && kinds.includes('xpath')) {
+        failures.push(`${fixture}/${spikeId}: xpath offered for a shadow element`);
       }
 
       if (result.preferredIndex < 0) {
@@ -86,7 +111,7 @@ test('locator engine matches real Playwright resolution', async ({ page }) => {
         continue;
       }
       const preferred = result.candidates[result.preferredIndex].candidate;
-      const loc = buildLocator(page, preferred);
+      const loc = buildLocator(scope, preferred);
       const count = await loc.count();
       const sid = count === 1 ? await loc.getAttribute('data-spike') : null;
       if (count !== 1 || sid !== spikeId) {

--- a/tests/fixtures/shadow.html
+++ b/tests/fixtures/shadow.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Shadow DOM</title></head>
+<body>
+  <nav aria-label="Fixtures" style="font: 12px/1.6 ui-monospace, monospace; padding: 6px 8px; border-bottom: 1px solid #ddd; margin-bottom: 12px">
+    fixtures: <a href="login.html">login</a> · <a href="widgets.html">widgets</a> · <a href="edgecases.html">edgecases</a> ·
+    <a href="ambiguous.html">ambiguous</a> · <a href="frames.html">frames</a> · <a href="frameset.html">frameset</a> ·
+    <strong>shadow</strong>
+  </nav>
+  <main style="font: 14px/1.5 system-ui, sans-serif; padding: 0 8px; max-width: 46rem">
+    <h1 data-spike="top-heading">Shadow DOM</h1>
+
+    <!-- The control: the same accessible name as the Submit inside every
+         component below, so a locator that ignores the shadow path is
+         ambiguous and one that respects it is not. -->
+    <button data-spike="top-submit">Submit</button>
+
+    <h2>Open root, attributes mirrored onto the host</h2>
+    <!-- The Etsy shape, and the reason the bug was survivable there: the host
+         carries `name` and `placeholder`, so picking the HOST rather than the
+         inner input still produced a working locator. A component that does
+         not mirror them is the next case. -->
+    <mirrored-field name="email" placeholder="Enter your email" label="Email address"></mirrored-field>
+
+    <h2>Open root, nothing mirrored</h2>
+    <!-- The honest case. Nothing on the host identifies the control, so a
+         locator can only come from inside the shadow root. -->
+    <plain-field></plain-field>
+
+    <h2>Nested open roots</h2>
+    <!-- Two boundaries between the document and the input, so the path has two
+         steps and a one-step implementation passes the case above and fails
+         this one. -->
+    <outer-panel></outer-panel>
+
+    <h2>Two components that look alike</h2>
+    <!-- Same tag, same internals. They must be distinguishable, which means
+         the host selector has to pick one — the frames fixture has the same
+         trap for the same reason. -->
+    <plain-field class="twin" id="twin-one"></plain-field>
+    <plain-field class="twin" id="twin-two"></plain-field>
+
+    <h2>Closed root</h2>
+    <!-- `element.shadowRoot` is null and there is no way in. Must be reported,
+         never silently skipped (SPEC §19). -->
+    <closed-field></closed-field>
+
+    <h2>An iframe inside a shadow root</h2>
+    <!-- framePath and shadowPath have to compose, in both directions. -->
+    <frame-host></frame-host>
+
+    <h2>Slotted light DOM</h2>
+    <!-- The button is an ordinary child of the host in the light DOM; only its
+         *rendering* moves into the shadow root. So it needs NO shadow path,
+         and an implementation that walks the flat tree will wrongly give it
+         one. -->
+    <slotting-panel><button data-spike="slotted-button">Slotted action</button></slotting-panel>
+  </main>
+
+  <script>
+    // Components are defined here rather than inline so the markup above stays
+    // readable. Each attaches its root in the mode its name says.
+
+    customElements.define('mirrored-field', class extends HTMLElement {
+      connectedCallback() {
+        const root = this.attachShadow({ mode: 'open' });
+        root.innerHTML = `
+          <label style="display:block">
+            <span>${this.getAttribute('label') ?? ''}</span>
+            <input data-spike="mirrored-input" name="${this.getAttribute('name') ?? ''}"
+                   placeholder="${this.getAttribute('placeholder') ?? ''}">
+          </label>
+          <button data-spike="mirrored-submit">Submit</button>`;
+      }
+    });
+
+    customElements.define('plain-field', class extends HTMLElement {
+      connectedCallback() {
+        const root = this.attachShadow({ mode: 'open' });
+        // Carries one of every identifier a Selenium strategy can use, so the
+        // probe can establish which of them survive a shadow boundary.
+        root.innerHTML = `
+          <label style="display:block">
+            <span>Coupon code</span>
+            <input data-spike="plain-input" id="coupon-field" class="coupon-input"
+                   name="coupon" placeholder="Enter a coupon">
+          </label>
+          <a href="#terms" data-spike="plain-link">Coupon terms</a>
+          <button data-spike="plain-submit">Submit</button>`;
+      }
+    });
+
+    customElements.define('outer-panel', class extends HTMLElement {
+      connectedCallback() {
+        const root = this.attachShadow({ mode: 'open' });
+        root.innerHTML = `<inner-field id="inner"></inner-field>`;
+      }
+    });
+
+    customElements.define('inner-field', class extends HTMLElement {
+      connectedCallback() {
+        const root = this.attachShadow({ mode: 'open' });
+        root.innerHTML = `
+          <label style="display:block">
+            <span>Postcode</span>
+            <input data-spike="nested-input" name="postcode" placeholder="Enter a postcode">
+          </label>
+          <button data-spike="nested-submit">Submit</button>`;
+      }
+    });
+
+    customElements.define('closed-field', class extends HTMLElement {
+      connectedCallback() {
+        // No reference kept: this really is unreachable from outside.
+        const root = this.attachShadow({ mode: 'closed' });
+        root.innerHTML = `<input name="secret" placeholder="Unreachable"><button>Submit</button>`;
+      }
+    });
+
+    customElements.define('frame-host', class extends HTMLElement {
+      connectedCallback() {
+        const root = this.attachShadow({ mode: 'open' });
+        root.innerHTML = `
+          <iframe id="in-shadow" title="In shadow" width="440" height="80"
+            srcdoc="&lt;body style=&quot;font:14px system-ui&quot;&gt;&lt;input name=&quot;giftcard&quot; placeholder=&quot;Enter a gift card&quot; data-spike=&quot;shadow-frame-input&quot;&gt;&lt;button&gt;Submit&lt;/button&gt;&lt;/body&gt;"></iframe>`;
+      }
+    });
+
+    customElements.define('slotting-panel', class extends HTMLElement {
+      connectedCallback() {
+        const root = this.attachShadow({ mode: 'open' });
+        root.innerHTML = `<div style="border:1px solid #ccc;padding:8px"><slot></slot></div>`;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/tests/fixtures/shadow.html
+++ b/tests/fixtures/shadow.html
@@ -45,6 +45,12 @@
          never silently skipped (SPEC §19). -->
     <closed-field></closed-field>
 
+    <h2>A custom element with no shadow root</h2>
+    <!-- Defined, and renders nothing of its own. It must NOT be reported as a
+         closed root, or a scan would warn about every inert custom element on
+         a page and the warning would stop meaning anything. -->
+    <behaviour-only></behaviour-only>
+
     <h2>An iframe inside a shadow root</h2>
     <!-- framePath and shadowPath have to compose, in both directions. -->
     <frame-host></frame-host>
@@ -116,6 +122,9 @@
         root.innerHTML = `<input name="secret" placeholder="Unreachable"><button>Submit</button>`;
       }
     });
+
+    // Behaviour only: no shadow root, nothing rendered.
+    customElements.define('behaviour-only', class extends HTMLElement {});
 
     customElements.define('frame-host', class extends HTMLElement {
       connectedCallback() {

--- a/tests/playwright-python.run.spec.ts
+++ b/tests/playwright-python.run.spec.ts
@@ -46,9 +46,16 @@ test('the generated Playwright Python resolves every element it describes', asyn
   test.skip(!ready && !REQUIRE_FULL_SUITE, 'run `npm run fetch:test-deps` for the Python venv');
   expect(ready, 'PM_REQUIRE_FULL_SUITE is set but .test-venv is missing').toBe(true);
 
-  const fixtures = ['login.html', 'widgets.html', 'ambiguous.html', 'edgecases.html'];
+  // shadow.html included because Playwright's own engines pierce, so the chain
+  // this generator emits is not what makes the element reachable — it is what
+  // scopes one of two identical components, and nothing but a real run proves
+  // it scopes to the right one (SPEC §19).
+  const fixtures = ['login.html', 'widgets.html', 'ambiguous.html', 'edgecases.html', 'shadow.html'];
   const failures: string[] = [];
   const exercised = new Set<string>();
+  // Counted so a model that quietly stopped containing shadow elements cannot
+  // pass this by containing fewer things (SPEC §19).
+  let shadowElements = 0;
 
   for (const fixture of fixtures) {
     const url = `http://localhost:${PORT}/${fixture}`;
@@ -76,6 +83,7 @@ test('the generated Playwright Python resolves every element it describes', asyn
       } as ModelElement);
     }
     for (const el of model.elements) exercised.add(el.candidates[el.selectedIndex].candidate.kind);
+    shadowElements += model.elements.filter((el) => (el.shadowPath?.length ?? 0) > 0).length;
 
     const out = runInPython(generatePlaywrightPythonPageObject(model), expected, url);
     if (out.trim()) failures.push(`${fixture}\n${out.trim()}`);
@@ -97,6 +105,7 @@ test('the generated Playwright Python resolves every element it describes', asyn
   }
 
   expect(failures.join('\n\n'), 'generated Playwright Python did not resolve as promised').toBe('');
+  expect(shadowElements, 'elements reached through a shadow root').toBeGreaterThan(4);
 
   // What this actually proved, so "verified" cannot quietly come to mean less.
   expect([...exercised].sort(), 'locator types exercised against a real browser').toEqual([

--- a/tests/puppeteer-browser.ts
+++ b/tests/puppeteer-browser.ts
@@ -1,0 +1,25 @@
+import puppeteer, { type Browser } from 'puppeteer-core';
+import { chromium } from '@playwright/test';
+
+/**
+ * A Puppeteer browser, launched the one way that works everywhere.
+ *
+ * Two things are easy to omit and fail only on CI:
+ *
+ *   * Chrome's sandbox needs kernel privileges a CI container does not grant.
+ *     Playwright passes the flags for us; puppeteer-core does not, and the
+ *     failure is a SIGABRT with `No usable sandbox!` rather than anything that
+ *     names the cause.
+ *   * The executable is Playwright's bundled Chromium, so no second browser
+ *     download is needed.
+ *
+ * Shared because writing the launch by hand a second time is exactly how the
+ * shadow probe came to pass locally and fail on CI.
+ */
+export function launchPuppeteer(): Promise<Browser> {
+  return puppeteer.launch({
+    executablePath: chromium.executablePath(),
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+}

--- a/tests/puppeteer.fidelity.spec.ts
+++ b/tests/puppeteer.fidelity.spec.ts
@@ -1,5 +1,6 @@
-import { test, expect, chromium } from '@playwright/test';
-import puppeteer, { type Browser } from 'puppeteer-core';
+import { test, expect } from '@playwright/test';
+import { type Browser } from 'puppeteer-core';
+import { launchPuppeteer } from './puppeteer-browser';
 import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
 import { puppeteerSelector } from '../src/locators/display';
@@ -22,13 +23,7 @@ const PUPPETEER_KINDS = new Set(frameworkById('puppeteer').locatorTypes);
 test('Puppeteer resolves every selector we generate for it', async () => {
   let browser: Browser | undefined;
   try {
-    browser = await puppeteer.launch({
-      executablePath: chromium.executablePath(),
-      headless: true,
-      // Chrome's sandbox needs kernel privileges a CI container does not grant.
-      // Playwright passes this for us; puppeteer-core does not.
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    });
+    browser = await launchPuppeteer();
   } catch (e) {
     const why = `puppeteer-core could not launch chromium: ${String(e).split('\n')[0]}`;
     // Silently skipping is how this check stops running without anyone

--- a/tests/puppeteer.fidelity.spec.ts
+++ b/tests/puppeteer.fidelity.spec.ts
@@ -3,6 +3,7 @@ import puppeteer, { type Browser } from 'puppeteer-core';
 import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
 import { puppeteerSelector } from '../src/locators/display';
+import { puppeteerShadowSelector } from '../src/locators/shadow';
 import { frameworkById } from '../src/frameworks';
 import type { ElementResult } from '../src/engine/types';
 import { REQUIRE_FULL_SUITE } from './required';
@@ -15,7 +16,7 @@ import { REQUIRE_FULL_SUITE } from './required';
 // this resolves every generated selector for real.
 //
 // puppeteer-core, driving Playwright's chromium — no second browser download.
-const FIXTURES = ['login.html', 'widgets.html', 'ambiguous.html', 'edgecases.html'];
+const FIXTURES = ['login.html', 'widgets.html', 'ambiguous.html', 'edgecases.html', 'shadow.html'];
 const PUPPETEER_KINDS = new Set(frameworkById('puppeteer').locatorTypes);
 
 test('Puppeteer resolves every selector we generate for it', async () => {
@@ -38,6 +39,9 @@ test('Puppeteer resolves every selector we generate for it', async () => {
   }
 
   const failures: string[] = [];
+  // Selectors that actually crossed a boundary. Without this the suite passes
+  // just as happily on a model containing no shadow elements at all.
+  let deepSelectors = 0;
   try {
     const page = await browser.newPage();
 
@@ -45,19 +49,36 @@ test('Puppeteer resolves every selector we generate for it', async () => {
       await page.goto(pathToFileURL(resolve('tests/fixtures', fixture)).href);
       await page.addScriptTag({ path: resolve('.test-dist/engine.global.js') });
 
-      const handles = await page.$$('[data-spike]');
-      expect(handles.length, `${fixture} has tagged elements`).toBeGreaterThan(0);
+      // Walked explicitly rather than with `page.$$('[data-spike]')`, which
+      // does not pierce — every tagged element in shadow.html would have been
+      // invisible and the fixture would have proved nothing (SPEC §19).
+      //
+      // Not with `>>>` either, even though it would reach them: that is the
+      // combinator under test here, so using it to find the elements it is
+      // being tested on would assume the answer.
+      const tagged = await page.evaluate(() => {
+        const out: { spikeId: string; result: ElementResult }[] = [];
+        const walk = (root: Document | ShadowRoot) => {
+          for (const el of Array.from(root.querySelectorAll('*'))) {
+            const id = el.getAttribute('data-spike');
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            if (id) out.push({ spikeId: id, result: (window as any).__spike.generate(el) as ElementResult });
+            if (el.shadowRoot) walk(el.shadowRoot);
+          }
+        };
+        walk(document);
+        return out;
+      });
+      expect(tagged.length, `${fixture} has tagged elements`).toBeGreaterThan(0);
 
-      for (const handle of handles) {
-        const { spikeId, result } = await handle.evaluate((el) => ({
-          spikeId: el.getAttribute('data-spike'),
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          result: (window as any).__spike.generate(el) as ElementResult,
-        }));
+      for (const { spikeId, result } of tagged) {
 
         for (const { candidate, predictedCount } of result.candidates) {
           if (!PUPPETEER_KINDS.has(candidate.kind)) continue;
-          const selector = puppeteerSelector(candidate);
+          // The selector the generator actually emits: hosts joined with the
+          // deep combinator in front of the element's own (SPEC §19).
+          const selector = puppeteerShadowSelector(result.shadowPath, puppeteerSelector(candidate));
+          if (selector.includes('>>>')) deepSelectors++;
 
           let matched: string[] | string;
           try {
@@ -88,4 +109,5 @@ test('Puppeteer resolves every selector we generate for it', async () => {
   }
 
   expect(failures, `${failures.length} Puppeteer selector failures`).toEqual([]);
+  expect(deepSelectors, 'selectors that crossed a shadow boundary').toBeGreaterThan(10);
 });

--- a/tests/pw-builder.ts
+++ b/tests/pw-builder.ts
@@ -1,8 +1,15 @@
 import type { Page, Locator } from '@playwright/test';
 import type { LocatorCandidate } from '../src/engine/types';
 
-/** Resolve an IR candidate with Playwright's own engine — the ground-truth bridge. */
-export function buildLocator(page: Page, c: LocatorCandidate): Locator {
+/**
+ * Resolve an IR candidate with Playwright's own engine — the ground-truth bridge.
+ *
+ * `page` is a Page or a Locator, because a shadow element's locator is scoped
+ * by its host chain (SPEC §19) and the scoping is done by resolving the host
+ * first and building the candidate against that. A Locator offers the same
+ * getBy* surface, so nothing below changes.
+ */
+export function buildLocator(page: Page | Locator, c: LocatorCandidate): Locator {
   switch (c.kind) {
     case 'testId':
       return page.getByTestId(c.value);

--- a/tests/pw-builder.ts
+++ b/tests/pw-builder.ts
@@ -1,6 +1,21 @@
 import type { Page, Locator } from '@playwright/test';
 import type { LocatorCandidate } from '../src/engine/types';
 
+/** A double-quoted string inside a Playwright selector. */
+const pwQuoted = (value: string) => `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+/** Literal text as a regex, for `:text-matches`. */
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * The same, but tolerant of the whitespace Selenium normalises away.
+ *
+ * `:text-is` normalises; `:text-matches` does not, so a literal regex built
+ * from the normalised candidate text missed `<a>  Read   more  </a>` — which
+ * is exactly the case `edgecases.html/ws-link` exists to catch.
+ */
+const looseWhitespace = (value: string) => escapeRegExp(value).replace(/ +/g, '\\s+');
+
 /**
  * Resolve an IR candidate with Playwright's own engine — the ground-truth bridge.
  *
@@ -44,11 +59,22 @@ export function buildLocator(page: Page | Locator, c: LocatorCandidate): Locator
       return page.locator(`.${cssEscape(c.value)}`);
     case 'tagName':
       return page.locator(c.value);
+    // Selenium matches a link's rendered text, whitespace-normalised and
+    // case-sensitively.
+    //
+    // Not XPath, which is how this was written: XPath cannot address a shadow
+    // tree in any engine (SPEC §19), so a link inside a web component resolved
+    // to nothing here while Selenium's LINK_TEXT finds it perfectly well — the
+    // bridge was failing, not the candidate. Measured in shadow.probe.spec.ts.
+    //
+    // `:text-is` is exact and CASE-SENSITIVE, and `:text-matches` without
+    // flags is a case-sensitive regex. `:has-text` would have been the obvious
+    // choice for the partial form and is case-INSENSITIVE, which would have
+    // made the ground truth disagree with Selenium on case.
     case 'linkText':
-      // Selenium matches a link's rendered text, whitespace-normalised.
-      return page.locator(`xpath=//a[normalize-space(.)=${xpathLiteral(c.text)}]`);
+      return page.locator(`a:text-is(${pwQuoted(c.text)})`);
     case 'partialLinkText':
-      return page.locator(`xpath=//a[contains(normalize-space(.), ${xpathLiteral(c.text)})]`);
+      return page.locator(`a:text-matches(${pwQuoted(looseWhitespace(c.text))})`);
   }
 }
 

--- a/tests/selenium.run.spec.ts
+++ b/tests/selenium.run.spec.ts
@@ -51,9 +51,18 @@ test('the generated Selenium finds every element it describes', async ({ page })
   test.skip(!ready && !REQUIRE_FULL_SUITE, 'run `npm run fetch:test-deps` for the Python venv');
   expect(ready, 'PM_REQUIRE_FULL_SUITE is set but .test-venv is missing').toBe(true);
 
-  const fixtures = ['login.html', 'widgets.html', 'ambiguous.html', 'edgecases.html'];
+  // shadow.html included because the host chain is the part of the generator
+  // that no compiler and no parser can check: `getShadowRoot()` exists whether
+  // or not the chain it is built from lands in the right tree (SPEC §19).
+  const fixtures = ['login.html', 'widgets.html', 'ambiguous.html', 'edgecases.html', 'shadow.html'];
   const failures: string[] = [];
   const exercised = new Set<string>();
+  // How many of the elements run here were reached through a shadow root. The
+  // suite would pass just as happily if none were — which is the whole risk
+  // with a fixture whose interesting content is invisible to an ordinary tree
+  // walk (SPEC §19).
+  let shadowElements = 0;
+  let deepestChain = 0;
 
   for (const fixture of fixtures) {
     const url = `http://localhost:${PORT}/${fixture}`;
@@ -84,6 +93,11 @@ test('the generated Selenium finds every element it describes', async ({ page })
     }
 
     for (const el of model.elements) exercised.add(activeCandidate(el).kind);
+    for (const el of model.elements) {
+      const depth = el.shadowPath?.length ?? 0;
+      if (depth > 0) shadowElements++;
+      deepestChain = Math.max(deepestChain, depth);
+    }
 
     const out = runInSelenium(generateSeleniumPython(model), [...expected], url, 'getter', model.elements);
     if (out.trim()) failures.push(`${fixture}\n${out.trim()}`);
@@ -120,6 +134,12 @@ test('the generated Selenium finds every element it describes', async ({ page })
   ]);
   // className, tagName and partialLinkText rank below css in Selenium's order
   // (SPEC §11) and nothing reaches them, so breaking those would not fail this.
+
+  // And that the shadow chain was genuinely walked, not skipped. An engine
+  // change that stopped collecting shadow content would leave every assertion
+  // above passing on a smaller model.
+  expect(shadowElements, 'elements reached through a shadow root').toBeGreaterThan(4);
+  expect(deepestChain, 'deepest host chain walked').toBeGreaterThanOrEqual(2);
 });
 
 test('the generated Selenium moves a slider to the value asked for', async ({ page }) => {

--- a/tests/shadow.engine.spec.ts
+++ b/tests/shadow.engine.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
 import { buildLocator } from './pw-builder';
-import type { ElementResult, ShadowStep } from '../src/engine/types';
+import './spike';
 
 // The engine against real web components (SPEC §19).
 //
@@ -16,19 +16,6 @@ import type { ElementResult, ShadowStep } from '../src/engine/types';
 const FIXTURE = pathToFileURL(resolve('tests/fixtures/shadow.html')).href;
 const ENGINE = resolve('.test-dist/engine.global.js');
 
-type Spike = {
-  generate: (el: Element) => ElementResult;
-  resolveCandidate: (root: Document | ShadowRoot, c: unknown) => Element[];
-  shadowPathOf: (el: Element) => ShadowStep[];
-  shadowSelector: (step: ShadowStep) => string;
-  collectInteractive: (root: Element, includeHidden: boolean) => Element[];
-  collectClosedHosts: (root: Element) => Element[];
-};
-declare global {
-  interface Window {
-    __spike: Spike;
-  }
-}
 
 test.beforeEach(async ({ page }) => {
   await page.goto(FIXTURE);
@@ -109,8 +96,8 @@ test('every shadow host selector resolves to exactly one element', async ({ page
       .shadowRoot!.querySelector('inner-field')!
       .shadowRoot!.querySelector('[data-spike="nested-input"]')!;
     const path = spike.shadowPathOf(input).map(spike.shadowSelector);
-    const outer = document.querySelectorAll(path[0]).length;
-    const inner = document.querySelector(path[0])!.shadowRoot!.querySelectorAll(path[1]).length;
+    const outer = document.querySelectorAll(path[0]!).length;
+    const inner = document.querySelector(path[0]!)!.shadowRoot!.querySelectorAll(path[1]!).length;
     return { path, outer, inner };
   });
 
@@ -146,8 +133,9 @@ test('candidates for a shadow element are scoped to its root, and exclude xpath'
   // components share this placeholder, but only one is in THIS root.
   expect(kinds).toContain('placeholder');
   expect(kinds).toContain('name');
-  const placeholder = result.candidates.find((c) => c.candidate.kind === 'placeholder')!;
-  expect(placeholder.predictedCount, 'counted within the shadow root, not the document').toBe(1);
+  const placeholder = result.candidates.find((c) => c.candidate.kind === 'placeholder');
+  expect(placeholder, 'a placeholder candidate').toBeDefined();
+  expect(placeholder!.predictedCount, 'counted within the shadow root, not the document').toBe(1);
 });
 
 test('a shadow element scoped by its host resolves uniquely in real Playwright', async ({ page }) => {
@@ -158,7 +146,7 @@ test('a shadow element scoped by its host resolves uniquely in real Playwright',
     const result = spike.generate(input);
     return {
       host: spike.shadowPathOf(input).map(spike.shadowSelector).join(' '),
-      candidate: result.candidates[result.preferredIndex].candidate,
+      candidate: result.candidates[result.preferredIndex]!.candidate,
     };
   });
 
@@ -213,6 +201,6 @@ test('a host that mirrors an attribute does not double the count', async ({ page
   // selector, because `cssFor` prefers `[name]` over the tag and which one it
   // picks is its business, not this test's.
   expect(counts.path).toHaveLength(1);
-  await expect(page.locator(counts.path[0])).toHaveCount(1);
-  await expect(page.locator(counts.path[0])).toHaveJSProperty('localName', 'mirrored-field');
+  await expect(page.locator(counts.path[0]!)).toHaveCount(1);
+  await expect(page.locator(counts.path[0]!)).toHaveJSProperty('localName', 'mirrored-field');
 });

--- a/tests/shadow.engine.spec.ts
+++ b/tests/shadow.engine.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect } from '@playwright/test';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+import { buildLocator } from './pw-builder';
+import type { ElementResult, ShadowStep } from '../src/engine/types';
+
+// The engine against real web components (SPEC §19).
+//
+// A real browser rather than jsdom, because what a component renders is decided
+// by the browser: `attachShadow`, slot distribution, and whether a closed root
+// is detectable at all are exactly the things a DOM emulation is least likely
+// to agree with.
+//
+// `shadow.probe.spec.ts` says what the frameworks do. This says the engine
+// agrees with them.
+const FIXTURE = pathToFileURL(resolve('tests/fixtures/shadow.html')).href;
+const ENGINE = resolve('.test-dist/engine.global.js');
+
+type Spike = {
+  generate: (el: Element) => ElementResult;
+  shadowPathOf: (el: Element) => ShadowStep[];
+  shadowSelector: (step: ShadowStep) => string;
+  collectInteractive: (root: Element, includeHidden: boolean) => Element[];
+  collectClosedHosts: (root: Element) => Element[];
+};
+declare global {
+  interface Window {
+    __spike: Spike;
+  }
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(FIXTURE);
+  await page.addScriptTag({ path: ENGINE });
+});
+
+test('a scan collects controls inside open shadow roots', async ({ page }) => {
+  const names = await page.evaluate(() =>
+    window.__spike
+      .collectInteractive(document.body, false)
+      .map((el) => el.getAttribute('data-spike') ?? `${el.localName}:${el.getAttribute('name') ?? ''}`)
+  );
+
+  // The bug this whole section exists for: before, this returned only the
+  // light-DOM button and nothing from any component.
+  expect(names).toContain('mirrored-input');
+  expect(names).toContain('plain-input');
+  expect(names).toContain('plain-link');
+  // Two boundaries deep.
+  expect(names).toContain('nested-input');
+  // And still everything in the light DOM.
+  expect(names).toContain('top-submit');
+  expect(names).toContain('slotted-button');
+
+  // Slotted content must appear exactly once: it is an ordinary child of the
+  // host, and a walk that also descended through the <slot> would double it.
+  expect(names.filter((n) => n === 'slotted-button')).toHaveLength(1);
+
+  // Nothing from the closed root, because nothing there is reachable.
+  expect(names).not.toContain('secret');
+});
+
+test('shadowPathOf records the hosts, outermost first', async ({ page }) => {
+  const paths = await page.evaluate(() => {
+    const spike = window.__spike;
+    const at = (sel: string) => {
+      const el = document.querySelector(sel);
+      return el ? spike.shadowPathOf(el).map(spike.shadowSelector) : null;
+    };
+    // Light DOM: no path at all.
+    const light = spike.shadowPathOf(document.querySelector('[data-spike="top-submit"]')!);
+    // One boundary, two boundaries, and slotted light DOM.
+    const shallow = spike.shadowPathOf(
+      document.querySelector('plain-field:not(.twin)')!.shadowRoot!.querySelector('[data-spike="plain-input"]')!
+    );
+    const deep = spike.shadowPathOf(
+      document
+        .querySelector('outer-panel')!
+        .shadowRoot!.querySelector('inner-field')!
+        .shadowRoot!.querySelector('[data-spike="nested-input"]')!
+    );
+    const slotted = spike.shadowPathOf(document.querySelector('[data-spike="slotted-button"]')!);
+    return {
+      light: light.map(spike.shadowSelector),
+      shallow: shallow.map(spike.shadowSelector),
+      deep: deep.map(spike.shadowSelector),
+      slotted: slotted.map(spike.shadowSelector),
+      at,
+    };
+  });
+
+  expect(paths.light).toEqual([]);
+  expect(paths.shallow).toHaveLength(1);
+  expect(paths.deep).toHaveLength(2);
+
+  // Slotted light DOM is NOT in a shadow root — only its rendering moves there.
+  // A walk over the flat tree would wrongly give it a path.
+  expect(paths.slotted).toEqual([]);
+});
+
+test('every shadow host selector resolves to exactly one element', async ({ page }) => {
+  // A host is located in its own tree, so the outer one is checked against the
+  // document and the inner against the outer's root.
+  const check = await page.evaluate(() => {
+    const spike = window.__spike;
+    const input = document
+      .querySelector('outer-panel')!
+      .shadowRoot!.querySelector('inner-field')!
+      .shadowRoot!.querySelector('[data-spike="nested-input"]')!;
+    const path = spike.shadowPathOf(input).map(spike.shadowSelector);
+    const outer = document.querySelectorAll(path[0]).length;
+    const inner = document.querySelector(path[0])!.shadowRoot!.querySelectorAll(path[1]).length;
+    return { path, outer, inner };
+  });
+
+  expect(check.outer, `outer host ${check.path[0]}`).toBe(1);
+  expect(check.inner, `inner host ${check.path[1]}`).toBe(1);
+});
+
+test('two identical components are told apart by their host', async ({ page }) => {
+  // The case that decides whether the path is needed at all for Playwright:
+  // the inputs are indistinguishable, the hosts are not.
+  const hosts = await page.evaluate(() => {
+    const spike = window.__spike;
+    return ['#twin-one', '#twin-two'].map((sel) => {
+      const input = document.querySelector(sel)!.shadowRoot!.querySelector('input')!;
+      return spike.shadowPathOf(input).map(spike.shadowSelector).join(' >>> ');
+    });
+  });
+
+  expect(hosts[0]).not.toBe(hosts[1]);
+  for (const host of hosts) await expect(page.locator(host)).toHaveCount(1);
+});
+
+test('candidates for a shadow element are scoped to its root, and exclude xpath', async ({ page }) => {
+  const result = await page.evaluate(() => {
+    const input = document.querySelector('plain-field:not(.twin)')!.shadowRoot!.querySelector('input')!;
+    return window.__spike.generate(input);
+  });
+
+  const kinds = result.candidates.map((c) => c.candidate.kind);
+  // No engine can XPath into a shadow tree, so the candidate must not survive.
+  expect(kinds, 'xpath must not be offered for a shadow element').not.toContain('xpath');
+  // And the ordinary ones must still be there, counted within the root: three
+  // components share this placeholder, but only one is in THIS root.
+  expect(kinds).toContain('placeholder');
+  expect(kinds).toContain('name');
+  const placeholder = result.candidates.find((c) => c.candidate.kind === 'placeholder')!;
+  expect(placeholder.predictedCount, 'counted within the shadow root, not the document').toBe(1);
+});
+
+test('a shadow element scoped by its host resolves uniquely in real Playwright', async ({ page }) => {
+  // The whole point: what the engine predicts is what Playwright finds.
+  const { host, candidate } = await page.evaluate(() => {
+    const spike = window.__spike;
+    const input = document.querySelector('#twin-two')!.shadowRoot!.querySelector('input')!;
+    const result = spike.generate(input);
+    return {
+      host: spike.shadowPathOf(input).map(spike.shadowSelector).join(' '),
+      candidate: result.candidates[result.preferredIndex].candidate,
+    };
+  });
+
+  const scoped = buildLocator(page.locator(host), candidate);
+  await expect(scoped).toHaveCount(1);
+  // And it is the right one.
+  await expect(scoped).toHaveAttribute('data-spike', 'plain-input');
+});
+
+test('a closed root is reported, and nothing else is', async ({ page }) => {
+  const closed = await page.evaluate(() =>
+    window.__spike.collectClosedHosts(document.body).map((el) => el.localName)
+  );
+
+  // Exactly the closed one. Every open component must be absent, or a scan
+  // would warn about every web component on the page and the warning would
+  // mean nothing.
+  expect(closed).toEqual(['closed-field']);
+});

--- a/tests/shadow.engine.spec.ts
+++ b/tests/shadow.engine.spec.ts
@@ -18,6 +18,7 @@ const ENGINE = resolve('.test-dist/engine.global.js');
 
 type Spike = {
   generate: (el: Element) => ElementResult;
+  resolveCandidate: (root: Document | ShadowRoot, c: unknown) => Element[];
   shadowPathOf: (el: Element) => ShadowStep[];
   shadowSelector: (step: ShadowStep) => string;
   collectInteractive: (root: Element, includeHidden: boolean) => Element[];
@@ -176,4 +177,42 @@ test('a closed root is reported, and nothing else is', async ({ page }) => {
   // would warn about every web component on the page and the warning would
   // mean nothing.
   expect(closed).toEqual(['closed-field']);
+});
+
+test('a host that mirrors an attribute does not double the count', async ({ page }) => {
+  // Etsy's shape, and the bug it caused: <clg-text-input name="password">
+  // carries `name` on the host AND on the <input> inside its shadow root, so
+  // `[name=password]` matches two elements from the document. The model
+  // counted the input within its own root and said 1; the eye resolved against
+  // the page and said 2, contradicting it on a locator that was fine.
+  const counts = await page.evaluate(() => {
+    const spike = window.__spike;
+    const host = document.querySelector('mirrored-field')!;
+    const input = host.shadowRoot!.querySelector('input')!;
+    const result = spike.generate(input);
+    const nameCandidate = result.candidates.find((c) => c.candidate.kind === 'name');
+    const c = nameCandidate!.candidate;
+    return {
+      // What the model records: counted inside the element's own root.
+      predicted: nameCandidate?.predictedCount ?? -1,
+      // What the eye reported before it was scoped — the resolver pierces, so
+      // from the document it finds the host AND the control inside it.
+      unscoped: spike.resolveCandidate(document, c).length,
+      // And what it reports now, resolved where the locator is relative to.
+      scoped: spike.resolveCandidate(host.shadowRoot!, c).length,
+      path: spike.shadowPathOf(input).map(spike.shadowSelector),
+    };
+  });
+
+  // The reported bug: two matches for a locator the model called unique.
+  expect(counts.unscoped, 'resolving from the document finds the host too').toBe(2);
+  // Both halves of the fix agree now.
+  expect(counts.predicted, 'counted within the shadow root').toBe(1);
+  expect(counts.scoped, 'the eye resolves in the same root').toBe(1);
+  // One host, and it resolves to the component — not asserted as a literal
+  // selector, because `cssFor` prefers `[name]` over the tag and which one it
+  // picks is its business, not this test's.
+  expect(counts.path).toHaveLength(1);
+  await expect(page.locator(counts.path[0])).toHaveCount(1);
+  await expect(page.locator(counts.path[0])).toHaveJSProperty('localName', 'mirrored-field');
 });

--- a/tests/shadow.probe.spec.ts
+++ b/tests/shadow.probe.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
-import puppeteer from 'puppeteer-core';
-import { chromium } from '@playwright/test';
+import { launchPuppeteer } from './puppeteer-browser';
 import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -81,7 +80,7 @@ test.describe('Playwright: what pierces an open shadow root', () => {
 test('Puppeteer: plain css does not pierce, >>> does', async () => {
   // Driven through Playwright's bundled Chromium so this needs no separate
   // browser download, the same arrangement puppeteer.fidelity.spec.ts uses.
-  const browser = await puppeteer.launch({ executablePath: chromium.executablePath(), headless: true });
+  const browser = await launchPuppeteer();
   try {
     const page = await browser.newPage();
     await page.goto(FIXTURE);

--- a/tests/shadow.probe.spec.ts
+++ b/tests/shadow.probe.spec.ts
@@ -1,0 +1,213 @@
+import { test, expect } from '@playwright/test';
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+import puppeteer from 'puppeteer-core';
+import { chromium } from '@playwright/test';
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { REQUIRE_FULL_SUITE } from './required';
+
+// What actually crosses an open shadow root.
+//
+// SPEC §19 states a table of which strategies pierce. This is where that table
+// comes from: every row is asserted against a real engine rather than read off
+// the documentation, because the implementation is built to whatever this says
+// and a wrong assumption here propagates into six generators.
+//
+// It runs first and on every change, so a browser that changes its mind breaks
+// this rather than breaking a user's locators quietly.
+
+const FIXTURE = pathToFileURL(resolve('tests/fixtures/shadow.html')).href;
+
+test.describe('Playwright: what pierces an open shadow root', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(FIXTURE);
+  });
+
+  // The input inside <plain-field> — nothing about it is in the light DOM, so
+  // any locator that finds it has pierced.
+  test('the built-in getBy* engines pierce', async ({ page }) => {
+    // Two twins plus the standalone, so counts say whether it pierced AND
+    // whether it found every one.
+    await expect(page.getByPlaceholder('Enter a coupon')).toHaveCount(3);
+    await expect(page.getByLabel('Coupon code')).toHaveCount(3);
+    await expect(page.getByText('Coupon code')).toHaveCount(3);
+    await expect(page.getByRole('textbox', { name: 'Coupon code' })).toHaveCount(3);
+  });
+
+  test('css pierces', async ({ page }) => {
+    await expect(page.locator('input[name="coupon"]')).toHaveCount(3);
+  });
+
+  test('xpath does NOT pierce', async ({ page }) => {
+    // The reason §19 excludes xpath for a shadow element.
+    await expect(page.locator('xpath=//input[@name="coupon"]')).toHaveCount(0);
+  });
+
+  test('a closed root is invisible to everything', async ({ page }) => {
+    await expect(page.getByPlaceholder('Unreachable')).toHaveCount(0);
+    await expect(page.locator('input[name="secret"]')).toHaveCount(0);
+  });
+
+  test('nested roots pierce to any depth', async ({ page }) => {
+    await expect(page.getByPlaceholder('Enter a postcode')).toHaveCount(1);
+  });
+
+  test('a host selector scopes to one component', async ({ page }) => {
+    // How twins are told apart: the host picks one, the rest is relative.
+    await expect(page.locator('#twin-one').getByPlaceholder('Enter a coupon')).toHaveCount(1);
+    await expect(page.locator('#twin-two').getByPlaceholder('Enter a coupon')).toHaveCount(1);
+  });
+
+  test('slotted light DOM needs no shadow path', async ({ page }) => {
+    // It is an ordinary child of the host; only its rendering moves.
+    await expect(page.locator('slotting-panel > button')).toHaveCount(1);
+    await expect(page.getByRole('button', { name: 'Slotted action' })).toHaveCount(1);
+  });
+
+  test('frames and shadow roots compose', async ({ page }) => {
+    // No shadow-crossing syntax needed, because Playwright's css already
+    // pierces: the frame inside the shadow root is addressed exactly as one in
+    // the light DOM would be. `frame-host >>> iframe#in-shadow` also resolves,
+    // which is why this is asserted rather than assumed — it would have read
+    // as evidence that a deep combinator was required here.
+    await expect(page.locator('#in-shadow')).toHaveCount(1);
+    await expect(page.frameLocator('#in-shadow').getByPlaceholder('Enter a gift card')).toHaveCount(1);
+  });
+});
+
+test('Puppeteer: plain css does not pierce, >>> does', async () => {
+  // Driven through Playwright's bundled Chromium so this needs no separate
+  // browser download, the same arrangement puppeteer.fidelity.spec.ts uses.
+  const browser = await puppeteer.launch({ executablePath: chromium.executablePath(), headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.goto(FIXTURE);
+
+    expect(await page.$$('input[name="coupon"]')).toHaveLength(0);
+    expect(await page.$$('plain-field >>> input[name="coupon"]')).toHaveLength(3);
+
+    // Depth: two boundaries.
+    expect(await page.$$('outer-panel >>> inner-field >>> input[name="postcode"]')).toHaveLength(1);
+    // And whether one `>>>` spans both, which decides if the path needs every
+    // host or only the outermost.
+    expect(await page.$$('outer-panel >>> input[name="postcode"]')).toHaveLength(1);
+
+    expect(await page.$$('input[name="secret"]')).toHaveLength(0);
+    expect(await page.$$('closed-field >>> input[name="secret"]')).toHaveLength(0);
+  } finally {
+    await browser.close();
+  }
+});
+
+// ── Selenium ────────────────────────────────────────────────────────────────
+// The row that mattered most, because it was the one most wrong. "css only
+// from a shadow root" was a reading of the WebDriver spec; six of the eight
+// strategies actually work, and two of the three things this asserts about
+// closed roots contradict what the section first said.
+//
+// Python because it is the only Selenium runtime that installs without a
+// toolchain, and because WHICH strategies survive a boundary is a property of
+// the driver, not the language binding.
+const PORT = 5267;
+const VENV_PY = resolve('.test-venv/bin/python');
+const seleniumReady = existsSync(VENV_PY);
+let server: ChildProcess | undefined;
+
+test.describe('Selenium: what survives a shadow boundary', () => {
+  test.beforeAll(async () => {
+    if (!seleniumReady && !REQUIRE_FULL_SUITE) return;
+    server = spawn('node', [resolve('scripts/serve-fixtures.mjs')], {
+      env: { ...process.env, FIXTURES_PORT: String(PORT) },
+      stdio: 'ignore',
+    });
+    for (let i = 0; i < 100; i++) {
+      try {
+        if ((await fetch(`http://localhost:${PORT}/shadow.html`)).ok) return;
+      } catch {
+        /* not up yet */
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    throw new Error('fixtures server did not start');
+  });
+
+  test.afterAll(() => server?.kill());
+
+  test('the strategies, and what a closed root really costs', () => {
+    test.skip(!seleniumReady && !REQUIRE_FULL_SUITE, 'run `npm run fetch:test-deps` for the Python venv');
+    expect(seleniumReady, 'PM_REQUIRE_FULL_SUITE is set but .test-venv is missing').toBe(true);
+
+    const dir = mkdtempSync(join(tmpdir(), 'pm-shadow-'));
+    const file = join(dir, 'probe.py');
+    writeFileSync(
+      file,
+      [
+        'import json',
+        'from selenium import webdriver',
+        'from selenium.webdriver.common.by import By',
+        'from selenium.webdriver.chrome.options import Options',
+        'opts = Options(); opts.add_argument("--headless=new")',
+        'd = webdriver.Chrome(options=opts)',
+        'out = {}',
+        'def probe(k, fn):',
+        '    try: out[k] = fn()',
+        '    except Exception as e: out[k] = type(e).__name__',
+        'try:',
+        `    d.get("http://localhost:${PORT}/shadow.html")`,
+        '    sr = d.find_element(By.CSS_SELECTOR, "plain-field:not(.twin)").shadow_root',
+        '    probe("name", lambda: len(sr.find_elements(By.NAME, "coupon")))',
+        '    probe("id", lambda: len(sr.find_elements(By.ID, "coupon-field")))',
+        '    probe("linkText", lambda: len(sr.find_elements(By.LINK_TEXT, "Coupon terms")))',
+        '    probe("css", lambda: len(sr.find_elements(By.CSS_SELECTOR, \'input[name="coupon"]\')))',
+        '    probe("xpath", lambda: len(sr.find_elements(By.XPATH, "//input")))',
+        '    probe("tagName", lambda: len(sr.find_elements(By.TAG_NAME, "input")))',
+        '    probe("fromDocument", lambda: len(d.find_elements(By.NAME, "coupon")))',
+        '    el = sr.find_element(By.CSS_SELECTOR, \'input[name="coupon"]\')',
+        '    probe("usable", lambda: (el.send_keys("abc"), el.get_property("value"))[1])',
+        '    outer = d.find_element(By.CSS_SELECTOR, "outer-panel")',
+        '    probe("nested", lambda: outer.shadow_root.find_element(By.CSS_SELECTOR, "inner-field")',
+        '                                  .shadow_root.find_element(By.NAME, "postcode").tag_name)',
+        '    fh = d.find_element(By.CSS_SELECTOR, "frame-host")',
+        '    def framed():',
+        '        d.switch_to.frame(fh.shadow_root.find_element(By.CSS_SELECTOR, "iframe"))',
+        '        n = len(d.find_elements(By.NAME, "giftcard"))',
+        '        d.switch_to.default_content()',
+        '        return n',
+        '    probe("frameInShadow", framed)',
+        '    closed = d.find_element(By.CSS_SELECTOR, "closed-field")',
+        '    probe("closedViaWebDriver", lambda: closed.shadow_root.find_element(By.NAME, "secret").tag_name)',
+        '    probe("closedViaJs", lambda: d.execute_script(',
+        '        "return document.querySelector(\'closed-field\').shadowRoot"))',
+        'finally:',
+        '    d.quit()',
+        'print(json.dumps(out))',
+      ].join('\n')
+    );
+
+    const out = JSON.parse(execFileSync(VENV_PY, [file], { encoding: 'utf8' }).trim());
+
+    // Six of eight strategies cross a boundary. Only these two do not.
+    expect(out.xpath, 'xpath from a shadow root').toBe('InvalidArgumentException');
+    expect(out.tagName, 'tagName from a shadow root').toBe('InvalidArgumentException');
+    expect(out.name).toBe(1);
+    expect(out.id).toBe(1);
+    expect(out.linkText).toBe(1);
+    expect(out.css).toBe(1);
+
+    // Nothing reaches in from the document, so the chain is never optional.
+    expect(out.fromDocument, 'a document-rooted find must not reach shadow content').toBe(0);
+
+    // What it arrives at is an ordinary WebElement.
+    expect(out.usable).toBe('abc');
+    expect(out.nested).toBe('input');
+    expect(out.frameInShadow, 'switch_to a frame found inside a shadow root').toBe(1);
+
+    // The asymmetry §19 records: WebDriver reads a closed root, the page cannot.
+    // So the limit is the picker being JavaScript, not the framework.
+    expect(out.closedViaWebDriver, 'WebDriver can read a closed root').toBe('input');
+    expect(out.closedViaJs, 'the page cannot').toBe(null);
+  });
+});

--- a/tests/spike.ts
+++ b/tests/spike.ts
@@ -1,0 +1,24 @@
+import type { ElementResult, ShadowStep } from '../src/engine/types';
+
+/**
+ * The engine, as injected into a page under test by `bundle-engine`.
+ *
+ * Declared once, here, because two specs used to declare `window.__spike`
+ * independently and the narrower declaration won — so the shadow spec's calls
+ * were type errors against a shape that did not include them, on a global that
+ * plainly had them at runtime.
+ */
+export interface Spike {
+  generate(el: Element): ElementResult;
+  resolveCandidate(root: Document | ShadowRoot, c: unknown): Element[];
+  shadowPathOf(el: Element): ShadowStep[];
+  shadowSelector(step: ShadowStep): string;
+  collectInteractive(root: Element, includeHidden: boolean): Element[];
+  collectClosedHosts(root: Element): Element[];
+}
+
+declare global {
+  interface Window {
+    __spike: Spike;
+  }
+}

--- a/tests/unit/EditElementDialog.test.ts
+++ b/tests/unit/EditElementDialog.test.ts
@@ -181,3 +181,64 @@ describe('EditElementDialog', () => {
     expect(vm(w).candidate).toEqual({ kind: 'css', value: 'button.draft' });
   });
 });
+
+describe('the shadow host chain (SPEC §19)', () => {
+  const inShadow = (hosts: string[]): ModelElement =>
+    ({
+      ...element,
+      shadowPath: hosts.map((value) => ({ host: { kind: 'css' as const, value } })),
+    }) as ModelElement;
+
+  /**
+   * Mount and wait for the dialog to appear.
+   *
+   * QDialog renders through a portal, which lands in the document rather than
+   * in the wrapper and not until a tick has passed — which is why every test
+   * above reads the vm instead. These are about markup, so they have to wait
+   * for it, and unmount afterwards or the next query finds the last one's
+   * dialog still in the body.
+   */
+  async function open(el?: ModelElement) {
+    const w = el ? render({ element: el }) : render();
+    await w.vm.$nextTick();
+    await new Promise((r) => setTimeout(r, 0));
+    return {
+      row: () => document.querySelector('[data-testid="edit-shadow"]'),
+      inputs: () => document.querySelectorAll('.q-dialog input'),
+      done: () => w.unmount(),
+    };
+  }
+
+  it('is shown, because it is part of the generated locator', async () => {
+    // Until this, the only way to discover that an element was inside a web
+    // component was to open the code dialog: the table and this dialog both
+    // showed the element's own locator and nothing else.
+    const d = await open(inShadow(['clg-text-input[name="email"]']));
+    expect(d.row()).not.toBeNull();
+    expect(d.row()!.textContent).toContain('clg-text-input[name="email"]');
+    d.done();
+  });
+
+  it('shows every host, outermost first', async () => {
+    const d = await open(inShadow(['outer-panel', 'inner-field']));
+    const text = d.row()!.textContent ?? '';
+    expect(text.indexOf('outer-panel')).toBeLessThan(text.indexOf('inner-field'));
+    d.done();
+  });
+
+  it('is read-only, like the frame chain', async () => {
+    // A host is where the element IS, not how it is found within the
+    // component, so editing it would be editing the page. The element's own
+    // locator stays editable, which is the part a user can meaningfully change.
+    const d = await open(inShadow(['clg-text-input']));
+    expect(d.row()!.querySelectorAll('input')).toHaveLength(0);
+    expect(d.inputs().length, 'the element locator is still editable').toBeGreaterThan(0);
+    d.done();
+  });
+
+  it('is absent for an element in the light DOM', async () => {
+    const d = await open();
+    expect(d.row()).toBeNull();
+    d.done();
+  });
+});

--- a/tests/unit/naming.test.ts
+++ b/tests/unit/naming.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { JSDOM } from 'jsdom';
 import { baseName, uniqueName } from '../../src/engine/naming';
+import { safeName } from '../../src/engine/candidates';
 
 let used: Set<string>;
 beforeEach(() => {
@@ -130,5 +131,43 @@ describe('uniqueName', () => {
   it('reserves the name it returns', () => {
     uniqueName('About', used);
     expect(used.has('About')).toBe(true);
+  });
+});
+
+describe('a validity marker in the label (SPEC §13)', () => {
+  it('is dropped from the derived name', () => {
+    // Etsy's labels are `Email address*`, where the asterisk carries an
+    // accessible "Required" — so every required field on the form came out as
+    // SomethingRequired.
+    expect(baseName(el('<label>Email address<span aria-label="Required">*</span><input data-t></label>'))).toBe(
+      'EmailAddress'
+    );
+  });
+
+  it('does not change the accessible name the locator uses', () => {
+    // The whole reason this is safe: the name is an identifier a user can
+    // rename, the locator is not. getByLabel has to keep the word to match.
+    const input = el('<label>Email address<span aria-label="Required">*</span><input data-t></label>');
+    // Concatenated without a space here because the markup has none between
+    // them — which is the point: the marker is in the accessible name however
+    // it is spaced, and only the derived name drops it.
+    expect(safeName(input)).toBe('Email addressRequired');
+  });
+
+  it('keeps a name that is only the marker', () => {
+    // Nothing left to call it otherwise, and `Element` would say less.
+    expect(baseName(el('<label>Required<input data-t></label>'))).toBe('Required');
+  });
+
+  it('drops one marker, not a run of them', () => {
+    expect(baseName(el('<label>Password Required Required<input data-t></label>'))).toBe('PasswordRequired');
+  });
+
+  it('leaves the word alone anywhere but the end', () => {
+    expect(baseName(el('<label>Required fields notice<input data-t></label>'))).toBe('RequiredFieldsNotice');
+  });
+
+  it('handles Optional the same way', () => {
+    expect(baseName(el('<label>Company name (optional)<input data-t></label>'))).toBe('CompanyName');
   });
 });

--- a/ui/App.vue
+++ b/ui/App.vue
@@ -285,6 +285,18 @@ function onRuntimeMessage(msg: unknown) {
         color: 'negative',
       });
     }
+    else if (m.type === 'SHADOW_UNREADABLE') {
+      // Plural handled by hand: `count` is the number of components skipped,
+      // and "1 web components" would undercut the message it is carrying.
+      notice('shadow-unreadable', {
+        message:
+          m.count === 1
+            ? 'One web component has a closed shadow root and could not be read.'
+            : `${m.count} web components have closed shadow roots and could not be read.`,
+        icon: 'block',
+        color: 'warning',
+      });
+    }
     else if (m.type === 'PICKING_STOPPED') isAdding.value = isScanning.value = false;
     else if (m.type === 'HIGHLIGHT_RESULT') showMatchCount(m.count, m.hidden);
   }

--- a/ui/App.vue
+++ b/ui/App.vue
@@ -89,7 +89,7 @@ import { activeCandidate, emptyModel, type ModelElement, type TabModel } from '@
 import { isMessage, PANEL_PORT, type BackgroundToPanel, type PanelToBackground, type PanelToContent, type PickMode } from '@/src/messaging';
 import { hostKey } from '@/host/types';
 import { applyTheme } from './theme';
-import type { FrameStep, LocatorCandidate } from '@/src/engine/types';
+import type { FrameStep, LocatorCandidate, ShadowStep } from '@/src/engine/types';
 import { defaultSettings, loadSettings, saveSettings, watchSettings } from '@/src/settings';
 
 // The panel is a VIEW. The background owns the model, one per tab (SPEC §5), so
@@ -417,12 +417,12 @@ function clearHighlight() {
 function highlight(id: string) {
   const el = model.value.elements.find((e) => e.id === id);
   if (!el) return;
-  highlightCandidate(activeCandidate(el), el.framePath);
+  highlightCandidate(activeCandidate(el), el.framePath, el.shadowPath);
 }
 
 /** The dialog tests a candidate against the element's own frame. */
 function highlightEdited(candidate: LocatorCandidate) {
-  highlightCandidate(candidate, editing.value?.framePath);
+  highlightCandidate(candidate, editing.value?.framePath, editing.value?.shadowPath);
 }
 
 /**
@@ -431,10 +431,10 @@ function highlightEdited(candidate: LocatorCandidate) {
  * document the element lives in, and testing it anywhere else answers a
  * different question (SPEC §16).
  */
-function highlightCandidate(candidate: LocatorCandidate, framePath?: FrameStep[]) {
+function highlightCandidate(candidate: LocatorCandidate, framePath?: FrameStep[], shadowPath?: ShadowStep[]) {
   if (tabId.value == null) return;
   // Fire and forget; the count arrives as HIGHLIGHT_RESULT.
-  send(tabId.value, { type: 'HIGHLIGHT', candidate, framePath });
+  send(tabId.value, { type: 'HIGHLIGHT', candidate, framePath, shadowPath });
 }
 
 function openEditor(id: string) {

--- a/ui/App.vue
+++ b/ui/App.vue
@@ -118,7 +118,7 @@ const rows = computed<ModelRow[]>(() =>
   model.value.elements.map((el) => ({
     id: el.id,
     name: el.name,
-    locator: displayElementLocator(activeCandidate(el), model.value.frameworkId, el.framePath),
+    locator: displayElementLocator(activeCandidate(el), model.value.frameworkId, el.framePath, el.shadowPath),
   }))
 );
 

--- a/ui/App.vue
+++ b/ui/App.vue
@@ -514,7 +514,7 @@ function notYet(what: string) {
   flex-wrap: wrap;
   padding: 6px 12px;
   font-size: 12px;
-  color: var(--pm-muted);
+  color: var(--pm-text-muted);
   border-bottom: 1px solid var(--pm-rule);
 }
 

--- a/ui/EditElementDialog.vue
+++ b/ui/EditElementDialog.vue
@@ -21,14 +21,14 @@
              it is found within that frame. Editing it would be editing the
              page. Shown because two elements can otherwise look identical
              (SPEC §16). -->
-        <div v-if="framePath.length" class="frame-row" data-testid="edit-frame">
-          <span class="frame-label">Frame</span>
-          <span class="frame-chain">
+        <div v-if="framePath.length" class="meta-field" data-testid="edit-frame">
+          <div class="meta-label">Frame</div>
+          <div class="meta-value">
             <template v-for="(step, i) in framePath" :key="i">
-              <span v-if="i > 0" class="frame-sep">›</span>
+              <span v-if="i > 0" class="meta-sep">›</span>
               <code>{{ step }}</code>
             </template>
-          </span>
+          </div>
         </div>
         <div v-if="frameOpaque" class="frame-warn" data-testid="edit-frame-opaque">
           A frame above this one is cross-origin, so the chain starts inside it.
@@ -39,14 +39,14 @@
              component, so editing it would be editing the page. Shown because
              it IS part of the generated locator, and until this the only way
              to discover that was to open the code dialog (SPEC §19). -->
-        <div v-if="shadowPath.length" class="frame-row" data-testid="edit-shadow">
-          <span class="frame-label">Shadow</span>
-          <span class="frame-chain">
+        <div v-if="shadowPath.length" class="meta-field" data-testid="edit-shadow">
+          <div class="meta-label">Shadow</div>
+          <div class="meta-value">
             <template v-for="(step, i) in shadowPath" :key="i">
-              <span v-if="i > 0" class="frame-sep">›</span>
+              <span v-if="i > 0" class="meta-sep">›</span>
               <code>{{ step }}</code>
             </template>
-          </span>
+          </div>
         </div>
 
         <div class="locator-row">
@@ -193,24 +193,41 @@ function save() {
 </script>
 
 <style scoped>
-.frame-row {
+/* A read-only field, styled to match the Quasar inputs beside it.
+   The numbers are Quasar's own: `.q-field__label` is 16px scaled by 0.75 when
+   floated, which is the 12px the Name and Type labels render at, and
+   `.q-field` sets the 14px the values render at. Copied rather than
+   approximated, so a read-only row reads as a field rather than as a caption
+   somebody added. */
+.meta-field {
   display: flex;
-  gap: 8px;
-  align-items: baseline;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.meta-label {
   font-size: 12px;
+  line-height: 1.25;
+  font-weight: 400;
+  letter-spacing: 0.00937em;
+  color: var(--pm-text-muted);
 }
 
-.frame-label {
-  color: var(--pm-muted);
+.meta-value {
+  font-size: 14px;
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
-.frame-chain code {
-  font: 12px/1.5 ui-monospace, SFMono-Regular, monospace;
+.meta-value code {
+  font: 13px/1.5 ui-monospace, SFMono-Regular, monospace;
 }
 
-.frame-sep {
-  margin: 0 4px;
-  color: var(--pm-muted);
+.meta-sep {
+  margin: 0 6px;
+  color: var(--pm-text-muted);
 }
 
 .frame-warn {

--- a/ui/EditElementDialog.vue
+++ b/ui/EditElementDialog.vue
@@ -34,6 +34,21 @@
           A frame above this one is cross-origin, so the chain starts inside it.
         </div>
 
+        <!-- Read-only for the same reason the frame chain is: a shadow host is
+             where the element IS, not part of how it is found inside that
+             component, so editing it would be editing the page. Shown because
+             it IS part of the generated locator, and until this the only way
+             to discover that was to open the code dialog (SPEC §19). -->
+        <div v-if="shadowPath.length" class="frame-row" data-testid="edit-shadow">
+          <span class="frame-label">Shadow</span>
+          <span class="frame-chain">
+            <template v-for="(step, i) in shadowPath" :key="i">
+              <span v-if="i > 0" class="frame-sep">›</span>
+              <code>{{ step }}</code>
+            </template>
+          </span>
+        </div>
+
         <div class="locator-row">
           <q-select
             v-model="kind"
@@ -96,6 +111,7 @@ import { activeCandidate, type ModelElement } from '@/src/model';
 import { buildCandidate, fieldsFor, isComplete, valuesOf, type LocatorKind } from '@/src/locators/fields';
 import type { LocatorCandidate } from '@/src/engine/types';
 import { frameSelector, isOpaque } from '@/src/locators/frames';
+import { shadowSelector } from '@/src/locators/shadow';
 
 const props = defineProps<{
   showTooltips: boolean;
@@ -125,6 +141,10 @@ const framePath = computed(() =>
   (props.element.framePath ?? []).filter((s) => !s.opaque).map((s) => frameSelector(s))
 );
 const frameOpaque = computed(() => isOpaque(props.element.framePath));
+
+// The hosts between the element's document and the element. Always css, so
+// unlike a frame step there is no prose case to handle.
+const shadowPath = computed(() => (props.element.shadowPath ?? []).map((step) => shadowSelector(step)));
 
 const typeOptions = computed(() => frameworkById(props.frameworkId).locatorTypes.map((t) => ({ label: t, value: t })));
 

--- a/ui/PickingHelpDialog.vue
+++ b/ui/PickingHelpDialog.vue
@@ -134,7 +134,7 @@ function onHide() {
 
 .keys dd {
   margin: 0;
-  color: var(--pm-muted);
+  color: var(--pm-text-muted);
   line-height: 1.5;
 }
 


### PR DESCRIPTION
Etsy's sign-up form is web components whose inputs live in open shadow roots. `querySelectorAll('*')` does not cross that boundary, so a scan of the dialog returned the four buttons around the form and none of the form itself. It read as the tool being broken, which is how it was reported.

Specified as the sibling of Frames (§16): an element records the hosts between its document and itself, outermost first, and each generator expresses that chain in its own idiom.

```ts
playwright   page.locator('#join_neu_email_field').locator('[name="email"]')
puppeteer    page.locator('#join_neu_email_field >>> [name="email"]')
selenium     driver.findElement(By.cssSelector("outer-panel")).getShadowRoot()
                   .findElement(By.cssSelector("inner-field")).getShadowRoot()
                   .findElement(By.name("coupon"))
```

## The table of what pierces is measured, not read

`tests/shadow.probe.spec.ts` asserts every row against real Playwright, real Puppeteer and a real Chrome through WebDriver, because six generators are built to it. **Three of the first draft's rows were wrong:**

- Selenium is **not** "css only" from a shadow root. `name`, `id`, `linkText`, `partialLinkText`, `css` and `className` all work; only `xpath` and `tagName` fail. So **xpath is the only thing v3 generates that cannot cross a boundary**, and the locator itself needed no change in any framework.
- One Puppeteer `>>>` spans any depth.
- A closed root **is** readable by WebDriver — it uses the internal slot, not the JS accessor. The limit is that our picker is JavaScript.

## Bugs this found that were not about shadow DOM

1. **The eye under-counted every light-DOM element on a component-heavy page.** Playwright's engines pierce, so a plain `<button>Submit</button>` beside five components that each contain their own Submit is not unique — the engine said 1, a real run resolved 6. A green tick on a locator matching six, which is the failure §7 warns about.
2. **`<title>` counted as page text**, so a heading looked ambiguous whenever the document title repeated it.
3. **The `linkText` test bridge resolved through XPath**, which cannot point into a shadow tree — the bridge was wrong, not the candidate. Now `a:text-is()`, which pierces and is exactly as case-sensitive as Selenium. `:has-text` was the obvious choice for the partial form and is case-**in**sensitive, so the ground truth would have quietly disagreed with Selenium on case.
4. **`--pm-muted` does not exist** — the token is `--pm-text-muted`, so four rules across three components were invalid and rendered at full-strength text.

## Found by hand, on Etsy

- **"2 elements match that locator"** for a locator the model called unique. Two bugs one layer apart: the eye resolved against the document rather than the element's root, and then `cssFor` called `[name="email"]` unique because a plain `querySelectorAll` finds one where Playwright finds two. Every uniqueness check pierces now, because every framework consuming the answer does.
- **The chain was invisible until the code dialog.** The table row and the Edit dialog showed only the element's own locator, so the line you read was not the line you got, and nobody overriding a locator could see the part that reached into the component. Now shown in both, and locked, exactly as a frame chain is — a host is *where the element is*, not how it is found within the component.
- **`EmailAddressRequired`** — the `*` on Etsy's labels carries an accessible "Required". One trailing `Required`/`Optional` comes off the **name**; the accessible name is untouched, because `getByLabel` needs the word to match.

## Verification

- `shadow.probe.spec.ts` — 10 assertions across three real engines, the source for §19's table
- `shadow.engine.spec.ts` — the engine against real components in a real browser
- `shadow.html` added to the fidelity gate, the Puppeteer fidelity spec, and **both run specs**, so the generated code is executed in real Selenium and real Playwright Python
- Each spec counts what it exercised, because all of them would pass just as happily on a model that quietly stopped containing shadow elements. Removing the `>>>` join fails the Puppeteer spec.
- An E2E for the closed-root report, which caught a bug nothing else could: **`customElements.get()` does not work in a content script's isolated world**, so every closed root read as an ordinary unknown tag. Recorded in CLAUDE.md.

**61 Playwright + 278 unit, green. Hand-tested on both browsers.**